### PR TITLE
Add soft fail to TPU test notification step

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -448,6 +448,7 @@ steps:
 
   - label: "TPU V1 Test Notification"
     depends_on: tpu-v1-test
+    soft_fail: true
     agents:
       queue: tpu_v6e_queue
     commands: |

--- a/buildkite/test-template-fastcheck.j2
+++ b/buildkite/test-template-fastcheck.j2
@@ -235,6 +235,7 @@ steps:
 
   - label: "TPU V0 Test Notification"
     depends_on: run-tpu-v0-test
+    soft_fail: true
     agents:
       queue: tpu_v5_queue
     commands: |
@@ -268,6 +269,7 @@ steps:
 
   - label: "TPU V1 Test Notification"
     depends_on: run-tpu-v1-test
+    soft_fail: true
     agents:
       queue: tpu_v5_queue
     commands: |


### PR DESCRIPTION
When broken (which it is at the time of writing) this causes all PRs in vLLM to have to be force merged. This should not be the case. This PR adds soft fail to these steps so they don't block CI in vLLM.