### PR TITLE
Fix quoting in a100 jobs

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -81,7 +81,7 @@ plugins:
         containers:
           - image: {{ image }}
             command:
-              - bash -c '(command nvidia-smi || true) && export VLLM_LOGGING_LEVEL=DEBUG && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe }} && {{ step.command or (step.commands | join(" && ")) | safe }}'
+              - bash -c "{{ '(command nvidia-smi || true) && export VLLM_LOGGING_LEVEL=DEBUG && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd ' ~ ((step.working_dir or default_working_dir) | safe) ~ ' && ' ~ (step.command or (step.commands | join(" && ")) | safe) }}"
             resources:
               limits:
                 nvidia.com/gpu: {{ step.num_gpus or 1 }}


### PR DESCRIPTION
Fix vllm-project/vllm#18491

We seem to assume that step commands can use single quotes but not double quotes. However, this doesn't work for the special-cased a100 jobs on Kubernetes because of quoting.

Construct the command with jinja2 ~ string concatentation.

Tested with:

```
$> $ minijinja-cli ./buildkite/test-template-ci.j2 ../vllm/.buildkite/test-pipeline.yaml -D branch="main" -D list_file_diff="$LIST_FILE_DIFF" -D run_all="$RUN_ALL" -D nightly="$NIGHTLY" -D mirror_hw="$AMD_MIRROR_HW" | grep TARGET_TEST_SUITE=A100
```

Before and after:

```
-                  - bash -c '(command nvidia-smi || true) && export VLLM_LOGGING_LEVEL=DEBUG && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd /vllm-workspace/tests && pytest -v -s distributed/test_custom_all_reduce.py && torchrun --nproc_per_node=2 distributed/test_ca_buffer_sharing.py && TARGET_TEST_SUITE=A100 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)' && pytest -v -s -x lora/test_mixtral.py'
+                  - bash -c "(command nvidia-smi || true) && export VLLM_LOGGING_LEVEL=DEBUG && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd /vllm-workspace/tests && pytest -v -s distributed/test_custom_all_reduce.py && torchrun --nproc_per_node=2 distributed/test_ca_buffer_sharing.py && TARGET_TEST_SUITE=A100 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)' && pytest -v -s -x lora/test_mixtral.py"
```