### PR TITLE
Fix the terraform to reduce unintentional diff.

### DIFF
--- a/terraform/gcp_old/modules/benchmark/main.tf
+++ b/terraform/gcp_old/modules/benchmark/main.tf
@@ -44,7 +44,7 @@ resource "google_tpu_v2_vm" "tpu_v6_benchmark" {
   }
 
   network_config {
-    network = "default"
+    network = "projects/${var.project_id}/global/networks/default"
     enable_external_ips = true
   }
 

--- a/terraform/gcp_old/modules/ci_v5/main.tf
+++ b/terraform/gcp_old/modules/ci_v5/main.tf
@@ -39,7 +39,7 @@ resource "google_tpu_v2_vm" "tpu_v5" {
   }
 
   network_config {
-    network = "default"
+    network   = "projects/${var.project_id}/global/networks/default"
     enable_external_ips = true
   }
 

--- a/terraform/gcp_old/modules/ci_v6/main.tf
+++ b/terraform/gcp_old/modules/ci_v6/main.tf
@@ -40,7 +40,7 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
   accelerator_type = "v6e-1"
 
   network_config {
-    network = "default"
+    network = "projects/${var.project_id}/global/networks/default"
     enable_external_ips = true
   }
 

--- a/terraform/gcp_old/secrete.tf
+++ b/terraform/gcp_old/secrete.tf
@@ -1,6 +1,6 @@
 resource "google_secret_manager_secret" "buildkite_agent_token_benchmark_cluster" {
   project   = var.project_id
-  secret_id = "buildkite-agent-token-benchmark-cluster"
+  secret_id = "buildkite_agent_token_benchmark_cluster"
   
   replication {
     auto {}
@@ -15,7 +15,7 @@ resource "google_secret_manager_secret" "buildkite_agent_token_benchmark_cluster
 
 resource "google_secret_manager_secret" "buildkite_agent_token_ci_cluster" {
   project   = var.project_id
-  secret_id = "buildkite-agent-token-ci-cluster"
+  secret_id = "buildkite_agent_token_ci_cluster"
   
   replication {
     auto {}
@@ -30,7 +30,7 @@ resource "google_secret_manager_secret" "buildkite_agent_token_ci_cluster" {
 
 resource "google_secret_manager_secret" "huggingface_token" {
   project   = var.project_id
-  secret_id = "huggingface-token"
+  secret_id = "huggingface_token"
   
   replication {
     auto {}


### PR DESCRIPTION
### Before the fix.

when running `tf plan`, the tf will show "force replacement" because: 

1. the network_config
2. secrete_id 

These 2 differences are not expected.

### After the fix.

`tf plan` shows only meaningful diff

1. 2 benchmark machines should be created. 
2. remove some ssh public key from meta data. 