### PR TITLE
Remove CUDA 12.1 build

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -1,11 +1,9 @@
 {% set docker_image = "public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT" %}
-{% set docker_image_cu121 = "public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT-cu121" %}
 {% set docker_image_torch_nightly = "public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT-torch-nightly" %}
 {% set docker_image_cu118 = "public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT-cu118" %}
 {% if branch == "main" %}
 {% set docker_image = "public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:$BUILDKITE_COMMIT" %}
 {% set docker_image_latest = "public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:latest" %}
-{% set docker_image_cu121 = "public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:$BUILDKITE_COMMIT-cu121" %}
 {% set docker_image_torch_nightly = "public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:$BUILDKITE_COMMIT-torch-nightly" %}
 {% set docker_image_cu118 = "public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:$BUILDKITE_COMMIT-cu118" %}
 {% endif %}
@@ -141,40 +139,6 @@ steps:
       - "docker tag {{ docker_image }} {{ docker_image_latest }}"
       - "docker push {{ docker_image_latest }}"
       {% endif %}
-    env:
-      DOCKER_BUILDKIT: "1"
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: -10  # Agent was lost
-          limit: 2
-
-  - block: Build CUDA 12.1 image
-    key: block-build-cu121
-    depends_on: ~
-
-  - label: ":docker: build image CUDA 12.1"
-    key: image-build-cu121
-    depends_on: block-build-cu121
-    agents:
-      {% if branch == "main" %}
-      queue: cpu_queue_postmerge
-      {% else %}
-      queue: cpu_queue_premerge
-      {% endif %}
-    commands:
-      - "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7"
-      - |
-        #!/bin/bash
-        if [[ -z $(docker manifest inspect {{ docker_image_cu121 }}) ]]; then
-          echo "Image not found, proceeding with build..."
-        else
-          echo "Image found"
-          exit 0
-        fi
-      - "docker build --file docker/Dockerfile --build-arg max_jobs=16 --build-arg buildkite_commit=$BUILDKITE_COMMIT --build-arg USE_SCCACHE=1 --build-arg CUDA_VERSION=12.1.0 --tag {{ docker_image_cu121 }} --target test --progress plain ."
-      - "docker push {{ docker_image_cu121 }}"
     env:
       DOCKER_BUILDKIT: "1"
     retry:


### PR DESCRIPTION
Alternative to #115 for getting the build green. This PR removes the build for 12.1, as there is no CUDA 12.1 PyTorch release.

Logs from a red build:
>Running into this problem trying to get the Docker builds green in this PR - https://github.com/vllm-project/vllm/pull/20136
https://buildkite.com/vllm/ci/builds/22761#0197ae37-4295-48c9-b5c9-fc843c84f497/124-10693

Alternatively, we could switch 12.1 to 12.6, but FlashAttention doesn't build well on 12.6 https://github.com/vllm-project/ci-infra/pull/115#issuecomment-3019814648
