### PR TITLE
[TPU][Test]Add quantized_v6e_1 test and build docker image outside.

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -513,13 +513,15 @@ steps:
     depends_on: ~
     key: run-tpu-v1-benchmark-test
     soft_fail: true
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     agents:
       queue: tpu_v6e_queue
     commands:
       - yes | docker system prune -a
       - bash .buildkite/scripts/tpu/cleanup_docker.sh
+      - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=0 --tag vllm/vllm-tpu-bm --progress plain -f docker/Dockerfile.tpu ."
       - bash .buildkite/scripts/tpu/docker_run_bm.sh .buildkite/scripts/tpu/config_v6e_1.env
+      - bash .buildkite/scripts/tpu/docker_run_bm.sh .buildkite/scripts/tpu/quantized_v6e_1.env
 
   {% if branch == "main" %}
   - label: "TPU V1 Test Notification"


### PR DESCRIPTION
### What 

1. Add a new test case covering quantized running. 

2. Build the docker image outside of the test(next, in vllm branch, remove the docker image build.) 

3. Increase the timeout to 60 minutes for safety.

### Test

https://buildkite.com/vllm/ci/builds/23289

1. test finishes in 17 minutes. 

2. artifacts(logs) successfully uploaded. 
![image](https://github.com/user-attachments/assets/62e7c995-a9ca-4b51-80ab-bca0cb333929)

3. The docker image is built successfully 3 times in a test, which proves the extra "docker build" works. 
