### PR TITLE
Update nightly CPU image build

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -203,7 +203,7 @@ steps:
           echo "Image found"
           exit 0
         fi
-      - "docker build --file docker/Dockerfile.cpu --build-arg max_jobs=16 --build-arg buildkite_commit=$BUILDKITE_COMMIT --tag {{ docker_image_cpu }} --target vllm-test --progress plain ."
+      - "docker build --file docker/Dockerfile.cpu --build-arg max_jobs=16 --build-arg buildkite_commit=$BUILDKITE_COMMIT --build-arg VLLM_CPU_AVX512BF16=true --build-arg VLLM_CPU_AVX512VNNI=true --tag {{ docker_image_cpu }} --target vllm-test --progress plain ."
       - "docker push {{ docker_image_cpu }}"
     env:
       DOCKER_BUILDKIT: "1"


### PR DESCRIPTION
Add extra build arguments to nightly CPU image build command for keeping consistent with regular release images.
https://github.com/vllm-project/vllm/blob/49e8c7ea256bd48a36391b5bc72212af39278b67/.buildkite/release-pipeline.yaml#L104