### PR TITLE
Implement Dockerfile argument for VLLM_USE_PRECOMPILED environment

### DIFF
--- a/buildkite/bootstrap.sh
+++ b/buildkite/bootstrap.sh
@@ -57,6 +57,7 @@ upload_pipeline() {
             -D run_all="$RUN_ALL" \
             -D nightly="$NIGHTLY" \
             -D mirror_hw="$AMD_MIRROR_HW" \
+            -D vllm_use_precompiled="$VLLM_USE_PRECOMPILED" \
             | sed '/^[[:space:]]*$/d' \
             > pipeline.yaml
     )
@@ -91,6 +92,7 @@ patterns=(
     "requirements/test.txt"
     "setup.py"
     "csrc/"
+    "cmake/"
 )
 
 ignore_patterns=(
@@ -124,6 +126,17 @@ for file in $file_diff; do
         fi
     fi
 done
+
+# Decide whether to use precompiled wheels
+# Relies on existing patterns array as a basis.
+if [[ $RUN_ALL -eq 1 ]]; then
+    export VLLM_USE_PRECOMPILED=0
+    echo "Detected critical changes, building wheels from source"
+else
+    export VLLM_USE_PRECOMPILED=1
+    echo "No critical changes, using precompiled wheels"
+fi
+
 
 LIST_FILE_DIFF=$(get_diff | tr ' ' '|')
 if [[ $BUILDKITE_BRANCH == "main" ]]; then

--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -155,7 +155,20 @@ steps:
           echo "Image found"
           exit 0
         fi
-      - "docker build --file docker/Dockerfile --build-arg max_jobs=16 --build-arg buildkite_commit=$BUILDKITE_COMMIT --build-arg USE_SCCACHE=1 --tag {{ docker_image }} --target test --progress plain ."
+      - > 
+        docker build --file docker/Dockerfile
+        --build-arg max_jobs=16
+        --build-arg buildkite_commit=$BUILDKITE_COMMIT
+        --build-arg USE_SCCACHE=1
+        {% if branch != "main" %}
+        --build-arg VLLM_USE_PRECOMPILED={{ vllm_use_precompiled | default("0") }}
+        --build-arg VLLM_DOCKER_BUILD_CONTEXT=1{% if vllm_use_precompiled is defined and vllm_use_precompiled == "1" %}
+        --build-arg USE_FLASHINFER_PREBUILT_WHEEL=true{% endif %}
+        {% else %}
+        {% endif %}
+        --tag {{ docker_image }}
+        --target test
+        --progress plain .
       - "docker push {{ docker_image }}"
       {% if branch == "main" %}
       - "docker tag {{ docker_image }} {{ docker_image_latest }}"
@@ -193,7 +206,21 @@ steps:
           echo "Image found"
           exit 0
         fi
-      - "docker build --file docker/Dockerfile --build-arg max_jobs=16 --build-arg buildkite_commit=$BUILDKITE_COMMIT --build-arg USE_SCCACHE=1 --build-arg CUDA_VERSION=11.8.0 --tag {{ docker_image_cu118 }} --target test --progress plain ."
+      - >
+        docker build
+        --file docker/Dockerfile
+        --build-arg max_jobs=16
+        --build-arg buildkite_commit=$BUILDKITE_COMMIT
+        --build-arg USE_SCCACHE=1
+        --build-arg CUDA_VERSION=11.8.0
+        {% if branch != "main" %}
+        --build-arg VLLM_USE_PRECOMPILED={{ vllm_use_precompiled | default("0") }}
+        --build-arg VLLM_DOCKER_BUILD_CONTEXT=1{% if vllm_use_precompiled is defined and vllm_use_precompiled == "1" %}
+        --build-arg USE_FLASHINFER_PREBUILT_WHEEL=true{% endif %}
+        {% endif %}
+        --tag {{ docker_image_cu118 }}
+        --target test
+        --progress plain .
       - "docker push {{ docker_image_cu118 }}"
     env:
       DOCKER_BUILDKIT: "1"
@@ -309,7 +336,15 @@ steps:
               echo "Image found"
               exit 0
             fi
-          - "docker build --file docker/Dockerfile.nightly_torch --build-arg max_jobs=16 --build-arg buildkite_commit=$BUILDKITE_COMMIT --build-arg USE_SCCACHE=1 --tag {{ docker_image_torch_nightly }} --target test --progress plain ."
+            - >
+              docker build
+              --file docker/Dockerfile.nightly_torch
+              --build-arg max_jobs=16
+              --build-arg buildkite_commit=$BUILDKITE_COMMIT
+              --build-arg USE_SCCACHE=1
+              --tag {{ docker_image_torch_nightly }}
+              --target test
+              --progress plain .
           - "docker push {{ docker_image_torch_nightly }}"
         env:
           DOCKER_BUILDKIT: "1"
@@ -363,7 +398,17 @@ steps:
         soft_fail: true
         commands:
           # Handle the introduction of test target in Dockerfile.rocm
-          - "docker build --build-arg max_jobs=16 --build-arg REMOTE_VLLM=1 --build-arg ARG_PYTORCH_ROCM_ARCH='gfx90a;gfx942' --build-arg VLLM_BRANCH=$BUILDKITE_COMMIT --tag {{ docker_image_amd }} -f docker/Dockerfile.rocm --target test --no-cache --progress plain ."
+            - >
+              docker build
+              --build-arg max_jobs=16
+              --build-arg REMOTE_VLLM=1
+              --build-arg ARG_PYTORCH_ROCM_ARCH='gfx90a;gfx942'
+              --build-arg VLLM_BRANCH=$BUILDKITE_COMMIT
+              --tag {{ docker_image_amd }}
+              -f docker/Dockerfile.rocm
+              --target test
+              --no-cache
+              --progress plain .
           - "docker push {{ docker_image_amd }}"
         key: "amd-build"
         env:


### PR DESCRIPTION
This PR avoids rebuilding the vLLM wheel in CI unless core files have changed.

Specifically:
- We use the logic for the RUN_ALL variable to determine if we should build the wheels.
- If no changes are to those core files are detected, we set `VLLM_USE_PRECOMPILED=1` for faster builds

Related to discussion in vLLM community sync on July 14.