### PR TITLE
buildkite: strip blank lines from pipeline.yaml

### DIFF
--- a/buildkite/bootstrap.sh
+++ b/buildkite/bootstrap.sh
@@ -48,7 +48,18 @@ upload_pipeline() {
     echo "AMD Mirror HW: $AMD_MIRROR_HW"
 
     cd .buildkite
-    minijinja-cli test-template.j2 test-pipeline.yaml -D branch="$BUILDKITE_BRANCH" -D list_file_diff="$LIST_FILE_DIFF" -D run_all="$RUN_ALL" -D nightly="$NIGHTLY" -D mirror_hw="$AMD_MIRROR_HW"> pipeline.yaml
+    (
+        set -x
+        # Output pipeline.yaml with all blank lines removed
+        minijinja-cli test-template.j2 test-pipeline.yaml \
+            -D branch="$BUILDKITE_BRANCH" \
+            -D list_file_diff="$LIST_FILE_DIFF" \
+            -D run_all="$RUN_ALL" \
+            -D nightly="$NIGHTLY" \
+            -D mirror_hw="$AMD_MIRROR_HW" \
+            | sed '/^[[:space:]]*$/d' \
+            > pipeline.yaml
+    )
     cat pipeline.yaml
     buildkite-agent artifact upload pipeline.yaml
     buildkite-agent pipeline upload pipeline.yaml


### PR DESCRIPTION
This strips all blank lines from the pipeline.yaml file. I felt as though the blank lines were unintentional and it made reading through the rendered pipeline.yaml file a bit more difficult.

> [!NOTE]
> Tested here:
https://buildkite.com/vllm/ci/builds/24445/steps/canvas?sid=0198242b-57d6-4ef5-a702-f9148a747d9c