### PR TITLE
[TPU][Test] Divide the test to 2 parts and reduce timeout.

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -520,13 +520,24 @@ steps:
   - label: "TPU V1 Test"
     depends_on: ~
     key: run-tpu-v1-test
-    timeout_in_minutes: 300
+    timeout_in_minutes: 180
     agents:
       queue: tpu_v6e_queue
     commands:
       - yes | docker system prune -a
       - bash .buildkite/scripts/tpu/cleanup_docker.sh
       - if [[ -f ".buildkite/scripts/hardware_ci/run-tpu-v1-test.sh" ]]; then bash .buildkite/scripts/hardware_ci/run-tpu-v1-test.sh; fi
+
+  - label: "TPU V1 Test Part2"
+    depends_on: ~
+    key: run-tpu-v1-test-part2
+    timeout_in_minutes: 90
+    agents:
+      queue: tpu_v6e_queue
+    commands:
+      - yes | docker system prune -a
+      - bash .buildkite/scripts/tpu/cleanup_docker.sh
+      - if [[ -f ".buildkite/scripts/hardware_ci/run-tpu-v1-test-part2.sh" ]]; then bash .buildkite/scripts/hardware_ci/run-tpu-v1-test-part2.sh; fi
 
   - label: "TPU V1 Benchmark Test"
     depends_on: ~


### PR DESCRIPTION
The existing TPU V1 Test usually takes 1 hour and 50 minutes but the timeout setting is 300 minutes(5 hours). If the test stuck, the waiting time is very long. 

I want to divide it to 2 tests and give each of them shorter timeout. 

TODO, after merging this and [the vllm branch PR](https://github.com/vllm-project/vllm/pull/21431), set the part1 timeout to 90 minutes.