### PR TITLE
[tpu][test] reduce the timeout to 180 minutes from 300 minutes

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -520,7 +520,7 @@ steps:
   - label: "TPU V1 Test"
     depends_on: ~
     key: run-tpu-v1-test
-    timeout_in_minutes: 300
+    timeout_in_minutes: 180
     agents:
       queue: tpu_v6e_queue
     commands:


### PR DESCRIPTION
I see in most cases when test passes, it takes about 2 hours but the test time out is 300 minutes. 
Set it shorter to faster fail. 

Follow up changes will be made to divide the test cases and make timeout shorter.

Note: I didn't trigger a test for this change because the v6e-queue is very long now because of huggingface download issue which is supposed to fixed in https://github.com/vllm-project/vllm/pull/21418