### PR TITLE
split b200 by letting per host docker gpus

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -83,7 +83,8 @@ plugins:
       image: {{ image }}
       always-pull: true
       propagate-environment: true
-      gpus: all
+      # gpus will be configured by BUILDKITE_PLUGIN_DOCKER_GPUS in per host environment variable.
+      # gpus: all
       command: ["bash", "-xc", "(command nvidia-smi || true) && export VLLM_LOGGING_LEVEL=DEBUG && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe }} && {{ step.command or (step.commands | join(' && ')) | safe }}"]
       environment:
         - VLLM_USAGE_SOURCE=ci-test

--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -78,7 +78,25 @@ plugins:
       volumes:
         - /dev/shm:/dev/shm
         - {{ hf_home_fsx }}:{{ hf_home_fsx }}
-  {% elif step.gpu == "h200" or step.gpu == "b200" %}
+  {% elif step.gpu == "h200" %}
+   - docker#v5.2.0:
+      image: {{ image }}
+      always-pull: true
+      propagate-environment: true
+      gpus: all
+      command: ["bash", "-xc", "(command nvidia-smi || true) && export VLLM_LOGGING_LEVEL=DEBUG && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe }} && {{ step.command or (step.commands | join(' && ')) | safe }}"]
+      environment:
+        - VLLM_USAGE_SOURCE=ci-test
+        - HF_HOME=/benchmark-hf-cache
+        - HF_TOKEN
+        {% if branch == "main" %}
+        - BUILDKITE_ANALYTICS_TOKEN
+        {% endif %}
+      volumes:
+        - /dev/shm:/dev/shm
+        - /data/benchmark-hf-cache:/benchmark-hf-cache 
+        - /data/benchmark-vllm-cache:/root/.cache/vllm
+  {% elif step.gpu == "b200" %}
    - docker#v5.2.0:
       image: {{ image }}
       always-pull: true


### PR DESCRIPTION
```
# cat environment
#!/usr/bin/env bash

# The `environment` hook will run before all other commands, and can be used
# to set up secrets, data, and so on. Anything exported in hooks will be available
# to the build script.
#
# For example:
#
# export SECRET_VAR=token

# Note that as the script is sourced not run directly, the shebang line will be ignored
# See https://buildkite.com/docs/agent/v3/hooks#creating-hook-scripts

set -e

export VLLM_USAGE_SOURCE=...
export HF_TOKEN=...

# Assume BUILDKITE_AGENT_NAME is already set
# Example: dgxb200-01-4
agent_name="$BUILDKITE_AGENT_NAME"

# Extract the last digit
last_digit="${agent_name##*-}"

# Set device string based on last digit
case "$last_digit" in
  1)
    export BUILDKITE_PLUGIN_DOCKER_GPUS='"device=0,1"'
    ;;
  2)
    export BUILDKITE_PLUGIN_DOCKER_GPUS='"device=2,3"'
    ;;
  3)
    export BUILDKITE_PLUGIN_DOCKER_GPU='"device=4,5"'
    ;;
  4)
    export BUILDKITE_PLUGIN_DOCKER_GPUS='"device=6,7"'
    ;;
  *)
    echo "Unexpected agent suffix: $last_digit"
    exit 1
    ;;
esac

# Optionally print the result
echo "BUILDKITE_AGENT_NAME is: $BUILDKITE_AGENT_NAME"
echo "BUILDKITE_PLUGIN_DOCKER_GPUS set to $BUILDKITE_PLUGIN_DOCKER_GPUS"
```