### PR TITLE
Disable soft fail on AMD tests

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -415,7 +415,7 @@ steps:
     steps:
       - label: "AMD: :docker: build image"
         depends_on: ~
-        soft_fail: true
+        soft_fail: false
         commands:
           # Handle the introduction of test target in Dockerfile.rocm
           - >
@@ -462,7 +462,7 @@ steps:
         env:
           DOCKER_BUILDKIT: "1"
         priority: 100
-        soft_fail: true
+        soft_fail: false
         {% endif %}
     {% endfor %}
     {% for step in steps %}


### PR DESCRIPTION
Proposal to disable the soft fail for AMD tests due to:
Just the build being active in the AMD CI for the past 2 weeks, and it being green except for the 2 real failures due to
https://github.com/vllm-project/vllm/pull/21961
and
https://github.com/vllm-project/vllm/pull/22211
and to prevent such failures in the future