### PR TITLE
speed: reduce the archs for test container

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -181,6 +181,8 @@ steps:
         --build-arg max_jobs=16
         --build-arg buildkite_commit=$BUILDKITE_COMMIT
         --build-arg USE_SCCACHE=1
+        --build-arg TORCH_CUDA_ARCH_LIST="8.0 8.9 9.0 10.0"
+        --build-arg FI_TORCH_CUDA_ARCH_LIST="8.0 8.9 9.0a 10.0a"
         {% if branch != "main" %}
         --build-arg VLLM_USE_PRECOMPILED={{ vllm_use_precompiled | default("0") }}
         --build-arg VLLM_DOCKER_BUILD_CONTEXT=1{% if vllm_use_precompiled is defined and vllm_use_precompiled == "1" %}


### PR DESCRIPTION
this effectively removes the need for 7.0 (V100), 7.5 (T4) and 12.0 (RTX 5080) for our CI. 