### PR TITLE
Avoid cleaning all docker images each time after test.

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -593,7 +593,6 @@ steps:
     agents:
       queue: tpu_v6e_queue
     commands:
-      - yes | docker system prune -a
       - bash .buildkite/scripts/tpu/cleanup_docker.sh
       - if [[ -f ".buildkite/scripts/hardware_ci/run-tpu-v1-test.sh" ]]; then bash .buildkite/scripts/hardware_ci/run-tpu-v1-test.sh; fi
 
@@ -605,7 +604,6 @@ steps:
     agents:
       queue: tpu_v6e_queue
     commands:
-      - yes | docker system prune -a
       - bash .buildkite/scripts/tpu/cleanup_docker.sh
       - if [[ -f ".buildkite/scripts/hardware_ci/run-tpu-v1-test-part2.sh" ]]; then bash .buildkite/scripts/hardware_ci/run-tpu-v1-test-part2.sh; fi
 
@@ -617,7 +615,6 @@ steps:
     agents:
       queue: tpu_v6e_queue
     commands:
-      - yes | docker system prune -a
       - bash .buildkite/scripts/tpu/cleanup_docker.sh
       - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=0 --tag vllm/vllm-tpu-bm --progress plain -f docker/Dockerfile.tpu ."
       - bash .buildkite/scripts/tpu/docker_run_bm.sh .buildkite/scripts/tpu/config_v6e_1.env

--- a/buildkite/test-template-fastcheck.j2
+++ b/buildkite/test-template-fastcheck.j2
@@ -272,8 +272,8 @@ steps:
     agents:
       queue: tpu_v6e_queue
     commands:
-      - if [[ -f ".buildkite/scripts/hardware_ci/run-tpu-v1-test.sh" ]]; then bash .buildkite/scripts/hardware_ci/run-tpu-v1-test.sh; fi
-      - yes | docker system prune -a
+      - bash .buildkite/scripts/tpu/cleanup_docker.sh
+      - if [[ -f ".buildkite/scripts/hardware_ci/run-tpu-v1-test.sh" ]]; then bash .buildkite/scripts/hardware_ci/run-tpu-v1-test.sh; fi      
 
   - label: "TPU V1 Test Notification"
     depends_on: run-tpu-v1-test


### PR DESCRIPTION
### Problem

Recently, TPU test often fail because of fail to pull docker image 

```
docker pull us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.12_tpuvm_20250730
```

Failed with error: 

```
failed to register layer: rename /mnt/disks/persist/image/overlay2/layerdb/tmp/write-set-4044406855 /mnt/disks/persist/image/overlay2/layerdb/sha256/4aaaa2b79c7e5e57f65f63d23191fbbf2d13e8a4c42f7aa002a7ae668c884268: file exists
```

I think the problem is the TPU test script delete image too aggresively for saving space. 

### This change
1. Remove the aggressive cleaning up so that the run can use cached imaged.
2. Delete image more aggressively when disk is not enough [PR in vllm](https://github.com/vllm-project/vllm/pull/23291)

### Test

[The ci test with this change](https://buildkite.com/vllm/ci/builds/27819#0198ca50-090f-4d16-9003-5b90e07636ef)
With the change, the test will reuse the cache instead of pulling new base image.

#### Before the change - benchmark test
<img width="1373" height="807" alt="image" src="https://github.com/user-attachments/assets/65488bf3-9060-45a4-9c0d-1c59db75e102" />

#### With this change benchmark test
<img width="1371" height="623" alt="image" src="https://github.com/user-attachments/assets/0ba0d050-4cac-40b7-b1e9-5bd7d2852ab9" />

#### Before the change unit test
<img width="1212" height="860" alt="image" src="https://github.com/user-attachments/assets/59beaae2-d3cc-4a29-a36c-44f609ab5751" />

#### With the change unit test
<img width="1239" height="455" alt="image" src="https://github.com/user-attachments/assets/e3550b14-e30c-4d7d-826f-39c68afcdb7d" />

