### PR TITLE
Add a helper script to taint machines and set benchmark machines to 0

### DIFF
--- a/terraform/gcp_old/modules/benchmark/main.tf
+++ b/terraform/gcp_old/modules/benchmark/main.tf
@@ -21,7 +21,7 @@ locals {
 
 resource "google_compute_disk" "disk_east1_d" {
   provider = google-beta.us-east1-d
-  count = 2
+  count = 0
 
   name  = "tpu-disk-east1-d${count.index + 1}"
   size  = 512
@@ -31,7 +31,7 @@ resource "google_compute_disk" "disk_east1_d" {
 
 resource "google_tpu_v2_vm" "tpu_v6_benchmark" {
   provider = google-beta.us-east1-d
-  count = 2
+  count = 0
   name = "vllm-tpu-v6-benchmark-${count.index + 1}"
   zone = "us-east1-d"
 

--- a/terraform/gcp_old/taint.sh
+++ b/terraform/gcp_old/taint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Usage: ./taint.sh "0,2,5"
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 \"index1,index2,...\""
+  exit 1
+fi
+
+# Split comma-separated indexes into array
+IFS=',' read -ra INDEXES <<< "$1"
+
+for idx in "${INDEXES[@]}"; do
+  echo "Tainting index $idx..."
+  terraform taint "module.ci_v6.google_compute_disk.disk_east5_b[$idx]"
+  terraform taint "module.ci_v6.google_tpu_v2_vm.tpu_v6_ci[$idx]"
+done


### PR DESCRIPTION
1. Add a helper script for faster recreate machine.
2. set benchmark machine number to 0 since no capacity to create them. 