### PR TITLE
[typo fix] broke the vllm nightly

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -94,7 +94,7 @@ plugins:
         {% endif %}
       volumes:
         - /dev/shm:/dev/shm
-        - /data/benchmark-hf-cache:/benchmark-hf-cache 
+        - /data/benchmark-hf-cache:/benchmark-hf-cache
         - /data/benchmark-vllm-cache:/root/.cache/vllm
   {% elif step.gpu == "b200" %}
    - docker#v5.2.0:
@@ -113,7 +113,7 @@ plugins:
         {% endif %}
       volumes:
         - /dev/shm:/dev/shm
-        - /data/benchmark-hf-cache:/benchmark-hf-cache 
+        - /data/benchmark-hf-cache:/benchmark-hf-cache
         - /data/benchmark-vllm-cache:/root/.cache/vllm
   {% else %}
   - kubernetes:
@@ -176,7 +176,7 @@ steps:
           echo "Image found"
           exit 0
         fi
-      - > 
+      - >
         docker build --file docker/Dockerfile
         --build-arg max_jobs=16
         --build-arg buildkite_commit=$BUILDKITE_COMMIT
@@ -358,15 +358,15 @@ steps:
               echo "Image found"
               exit 0
             fi
-            - >
-              docker build
-              --file docker/Dockerfile.nightly_torch
-              --build-arg max_jobs=16
-              --build-arg buildkite_commit=$BUILDKITE_COMMIT
-              --build-arg USE_SCCACHE=1
-              --tag {{ docker_image_torch_nightly }}
-              --target test
-              --progress plain .
+          - >
+            docker build
+            --file docker/Dockerfile.nightly_torch
+            --build-arg max_jobs=16
+            --build-arg buildkite_commit=$BUILDKITE_COMMIT
+            --build-arg USE_SCCACHE=1
+            --tag {{ docker_image_torch_nightly }}
+            --target test
+            --progress plain .
           - "docker push {{ docker_image_torch_nightly }}"
         env:
           DOCKER_BUILDKIT: "1"
@@ -622,7 +622,7 @@ steps:
 
   {% if branch == "main" %}
   - label: "TPU V1 Test Notification"
-    depends_on: 
+    depends_on:
       - run-tpu-v1-test
       - run-tpu-v1-test-part2
     soft_fail: true


### PR DESCRIPTION
the typo seems introduced by
https://github.com/vllm-project/ci-infra/commit/0d4d33a2b4a6c6ff6899d34af1bc658aabc4da05#diff-74489a1a1968ff88685b06763ae68ec799521c9cda72e32eb01837aaf409616c

seems extra indent is put in front of. -> for torch night
