### PR TITLE
Add default cancel_on_build_failing

### DIFF
--- a/buildkite/test-template-fastcheck.j2
+++ b/buildkite/test-template-fastcheck.j2
@@ -66,6 +66,7 @@ steps:
       queue: gpu_1_queue
       {% endif %}
     soft_fail: {{ step.soft_fail or false }}
+    cancel_on_build_failing: {{ step.cancel_on_build_failing or true }}
     {% if step.parallelism %}
     parallelism: {{ step.parallelism }}
     {% endif %}
@@ -119,6 +120,7 @@ steps:
       queue: gpu_1_queue
       {% endif %}
     soft_fail: {{ step.soft_fail or false }}
+    cancel_on_build_failing: {{ step.cancel_on_build_failing or true }}
     {% if step.parallelism %}
     parallelism: {{ step.parallelism }}
     {% endif %}
@@ -178,6 +180,7 @@ steps:
     agents:
       queue: a100_queue
     soft_fail: {{ step.soft_fail or false }}
+    cancel_on_build_failing: {{ step.cancel_on_build_failing or true }}
     {% if step.parallelism %}
     parallelism: {{ step.parallelism }}
     {% endif %}


### PR DESCRIPTION
we need to abort the CI on first failure as it will free up valuable resources (re-run would be needed regardless).

To automatically cancel any remaining jobs as soon as any job in the build fails (except jobs marked as soft_fail), I added the cancel_on_build_failing: true attribute to the command steps. When a job fails, the build enters a failing state. Any jobs still running that have cancel_on_build_failing: true are automatically canceled. Once all running jobs have been cancelled, the build is marked as failed due to the initial job failure.

Check official buildkite documentation here: https://buildkite.com/docs/pipelines/configure/step-types/command-step#fast-fail-running-jobs