### PR TITLE
Fast Fail Test Groups

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -64,11 +64,12 @@ plugins:
       {% if step.label == "Benchmarks" %}
       mount-buildkite-agent: true
       {% endif %}
-      command: ["bash", "-xc", "(command nvidia-smi || true) && export VLLM_LOGGING_LEVEL=DEBUG && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe }} && {{ step.command or (step.commands | join(' && ')) | safe }}"]
+      command: ["bash", "-xce", "(command nvidia-smi || true) && export VLLM_LOGGING_LEVEL=DEBUG && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe }} && {{ step.command or (step.commands | join(' && ')) | safe }}"]
       environment:
         - VLLM_USAGE_SOURCE=ci-test
         - HF_HOME={{ hf_home_fsx }}
         - HF_TOKEN
+        - PYTEST_ADDOPTS=-x
         {% if branch == "main" %}
         - BUILDKITE_ANALYTICS_TOKEN
         {% endif %}
@@ -84,11 +85,12 @@ plugins:
       always-pull: true
       propagate-environment: true
       gpus: all
-      command: ["bash", "-xc", "(command nvidia-smi || true) && export VLLM_LOGGING_LEVEL=DEBUG && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe }} && {{ step.command or (step.commands | join(' && ')) | safe }}"]
+      command: ["bash", "-xce", "(command nvidia-smi || true) && export VLLM_LOGGING_LEVEL=DEBUG && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe }} && {{ step.command or (step.commands | join(' && ')) | safe }}"]
       environment:
         - VLLM_USAGE_SOURCE=ci-test
         - HF_HOME=/benchmark-hf-cache
         - HF_TOKEN
+        - PYTEST_ADDOPTS=-x
         {% if branch == "main" %}
         - BUILDKITE_ANALYTICS_TOKEN
         {% endif %}
@@ -103,11 +105,12 @@ plugins:
       propagate-environment: true
       # gpus will be configured by BUILDKITE_PLUGIN_DOCKER_GPUS in per host environment variable.
       # gpus: all
-      command: ["bash", "-xc", "(command nvidia-smi || true) && export VLLM_LOGGING_LEVEL=DEBUG && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe }} && {{ step.command or (step.commands | join(' && ')) | safe }}"]
+      command: ["bash", "-xce", "(command nvidia-smi || true) && export VLLM_LOGGING_LEVEL=DEBUG && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe }} && {{ step.command or (step.commands | join(' && ')) | safe }}"]
       environment:
         - VLLM_USAGE_SOURCE=ci-test
         - HF_HOME=/benchmark-hf-cache
         - HF_TOKEN
+        - PYTEST_ADDOPTS=-x
         {% if branch == "main" %}
         - BUILDKITE_ANALYTICS_TOKEN
         {% endif %}

--- a/buildkite/test-template-fastcheck.j2
+++ b/buildkite/test-template-fastcheck.j2
@@ -86,7 +86,7 @@ steps:
           {% if step.label == "Benchmarks" %}
           mount-buildkite-agent: true
           {% endif %}
-          command: ["bash", "-xc", "(command nvidia-smi || true) && export VLLM_LOGGING_LEVEL=DEBUG && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe  }} && {{ step.command  or (step.commands | join(' && ')) | safe }}"]
+          command: ["bash", "-xce", "(command nvidia-smi || true) && export VLLM_LOGGING_LEVEL=DEBUG && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe  }} && {{ step.command  or (step.commands | join(' && ')) | safe }}"]
           environment:
             - VLLM_USAGE_SOURCE=ci-test
             - HF_HOME={{ hf_home_fsx }}
@@ -140,7 +140,7 @@ steps:
           {% if step.label == "Benchmarks" %}
           mount-buildkite-agent: true
           {% endif %}
-          command: ["bash", "-xc", "(command nvidia-smi || true) && export VLLM_LOGGING_LEVEL=DEBUG && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe  }} && {{ step.command  or (step.commands | join(' && ')) | safe }}"]
+          command: ["bash", "-xce", "(command nvidia-smi || true) && export VLLM_LOGGING_LEVEL=DEBUG && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe  }} && {{ step.command  or (step.commands | join(' && ')) | safe }}"]
           environment:
             - VLLM_USAGE_SOURCE=ci-test
             - HF_HOME={{ hf_home_fsx }}


### PR DESCRIPTION
Setting `PYTEST_ADDOPTS=-x` on the pipeline
Setting -e flag for bash to early exit

Example run with fast fail: https://buildkite.com/vllm/fastcheck/builds/39726#019914e1-5975-4b7b-9c2c-79f467ad2e1a