### PR TITLE
Fixes skip image build for eligible PRs (to improve CI run times)

### DIFF
--- a/buildkite/bootstrap.sh
+++ b/buildkite/bootstrap.sh
@@ -185,8 +185,18 @@ else
 fi
 echo "Final SKIP_IMAGE_BUILD=${SKIP_IMAGE_BUILD} (RUN_ALL=${RUN_ALL}, VLLM_USE_PRECOMPILED=${VLLM_USE_PRECOMPILED:-unset})"
 
-# TODO: This will be replaced with a method which selects image based on latest common ancestor 
-DOCKER_IMAGE_OVERRIDE="public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:latest"
+# Select Docker image based on latest common ancestor (LCA) commit between current branch and main
+LCA_COMMIT=""
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    LCA_COMMIT=$(git merge-base origin/main HEAD)
+fi
+if [[ -n "$LCA_COMMIT" ]]; then
+    DOCKER_IMAGE_OVERRIDE="public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:$LCA_COMMIT"
+    echo "Using Docker image for LCA commit: $DOCKER_IMAGE_OVERRIDE"
+else
+    DOCKER_IMAGE_OVERRIDE="public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:latest"
+    echo "Could not determine LCA commit, using latest Docker image: $DOCKER_IMAGE_OVERRIDE"
+fi
 
 ################## end WIP #####################
 

--- a/buildkite/bootstrap.sh
+++ b/buildkite/bootstrap.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 set -euo pipefail
@@ -76,6 +75,9 @@ upload_pipeline() {
             -D mirror_hw="$AMD_MIRROR_HW" \
             -D fail_fast="$FAIL_FAST" \
             -D vllm_use_precompiled="$VLLM_USE_PRECOMPILED" \
+            -D skip_image_build="$SKIP_IMAGE_BUILD" \
+            -D requirements_changed="$REQUIREMENTS_CHANGED" \
+            -D docker_image_override="$DOCKER_IMAGE_OVERRIDE" \
             | sed '/^[[:space:]]*$/d' \
             > pipeline.yaml
     )
@@ -117,6 +119,16 @@ ignore_patterns=(
     "docker/Dockerfile."
 )
 
+# Track changes to requirements/*.txt explicitly
+REQUIREMENTS_CHANGED=0
+for f in $file_diff; do
+    case "$f" in
+        requirements/common.txt|requirements/cuda.txt|requirements/build.txt|requirements/test.txt)
+            REQUIREMENTS_CHANGED=1
+            ;;
+    esac
+done
+
 for file in $file_diff; do
     # First check if file matches any pattern
     matches_pattern=0
@@ -157,6 +169,26 @@ else
     echo "No critical changes, using precompiled wheels"
 fi
 
+# Decide whether to skip building docker images (pull & mount code instead)
+# Honor manual override if provided.
+if [[ -n "${SKIP_IMAGE_BUILD:-}" ]]; then
+    echo "SKIP_IMAGE_BUILD is preset to: ${SKIP_IMAGE_BUILD}"
+else
+    # Auto decision:
+    # - No critical changes (RUN_ALL==0)
+    # - VLLM_USE_PRECOMPILED==1
+    if [[ "${VLLM_USE_PRECOMPILED:-}" == "1" && "$RUN_ALL" -eq 0 ]]; then
+        SKIP_IMAGE_BUILD=1
+    else
+        SKIP_IMAGE_BUILD=0
+    fi
+fi
+echo "Final SKIP_IMAGE_BUILD=${SKIP_IMAGE_BUILD} (RUN_ALL=${RUN_ALL}, VLLM_USE_PRECOMPILED=${VLLM_USE_PRECOMPILED:-unset})"
+
+# TODO: This will be replaced with a method which selects image based on latest common ancestor 
+DOCKER_IMAGE_OVERRIDE="public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:latest"
+
+################## end WIP #####################
 
 LIST_FILE_DIFF=$(get_diff | tr ' ' '|')
 if [[ $BUILDKITE_BRANCH == "main" ]]; then

--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -9,6 +9,14 @@
 {% set docker_image_cu118 = "public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:$BUILDKITE_COMMIT-cu118" %}
 {% set docker_image_cpu = "public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:$BUILDKITE_COMMIT-cpu" %}
 {% endif %}
+{% set skip_image_build = (skip_image_build | default("0")) %}
+{% set requirements_changed = (requirements_changed | default("0")) %}
+{% if skip_image_build == "1" and docker_image_override is defined and docker_image_override %}
+  {% set docker_image = docker_image_override %}
+  {% set docker_image_torch_nightly = docker_image_override %}
+  {% set docker_image_cu118 = docker_image_override %}
+  {% set docker_image_cpu = docker_image_override %}
+{% endif %}
 {% set docker_image_amd = "rocm/vllm-ci:$BUILDKITE_COMMIT" %}
 {% set default_working_dir = "/vllm-workspace/tests" %}
 {% set hf_home = "/root/.cache/huggingface" %}
@@ -16,6 +24,47 @@
 {% set hf_home_fsx = "/fsx/hf_cache" %}
 {% set list_file_diff = list_file_diff | split("|") %}
 
+{% macro vllm_checkoutoverlay_script(step,default_working_dir,skip_image_build,requirements_changed,fail_fast) -%}
+set {% if fail_fast == "true" %}-xeuo pipefail{% else %}-xuo{% endif %}
+echo "SKIP_IMAGE_BUILD={{ skip_image_build }} REQUIREMENTS_CHANGED={{ requirements_changed }}"
+{% if skip_image_build == "1" %}
+
+# Copy in the code from the checkout to the workspace
+rm -rf /vllm-workspace/vllm || true
+cp -a /workdir/. /vllm-workspace/
+
+# Overlay the pure-Python vllm into the install package dir
+export SITEPKG="$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
+cp -a /vllm-workspace/vllm/* "$$SITEPKG/vllm/"
+
+# Restore src/ layout, as Dockerfile does. Hides code from tests, but allows setup.
+rm -rf /vllm-workspace/src || true
+mkdir -p /vllm-workspace/src
+mv /vllm-workspace/vllm /vllm-workspace/src/vllm
+
+# If deps changed, re-install (system-wide in the container)
+{% if requirements_changed == '1' %}
+cd /vllm-workspace
+uv pip install --system -r requirements/common.txt -r requirements/build.txt -r requirements/test.txt
+{% endif %}
+{% endif %}
+
+(command -v nvidia-smi >/dev/null && nvidia-smi || true)
+export VLLM_LOGGING_LEVEL=DEBUG
+export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1
+cd {{ (step.working_dir or default_working_dir) | safe }}
+
+{# Emit commands exactly as input. #}
+{% if step.command -%}
+{{ step.command | replace(' \\', '') | trim | safe }}
+{%- elif step.commands -%}
+{%- for cmd in step.commands %}
+{{ cmd | replace(' \\', '') | trim | safe }}
+{%- endfor %}
+{%- else -%}
+echo "No command(s) defined for this step." >&2; exit 2
+{%- endif %}
+{%- endmacro %}
 
 {% macro render_cuda_config(step, image, default_working_dir, hf_home_fsx, hf_home, branch) %}
 agents:
@@ -64,10 +113,11 @@ plugins:
       {% if step.label == "Benchmarks" or step.mount_buildkite_agent %}
       mount-buildkite-agent: true
       {% endif %}
-      command: 
-        - "bash"
-        - "{% if fail_fast == "true" %}-xce{% else %}-xc{% endif %}"
-        - "(command nvidia-smi || true) && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe }} && {{ step.command or (step.commands | join(' && ')) | safe }}"
+      command:
+          - "/bin/bash"
+          - "-xce"
+          - |
+{{ vllm_checkoutoverlay_script(step,default_working_dir,skip_image_build,requirements_changed,fail_fast) | indent(12,true) }}
       environment:
         - VLLM_USAGE_SOURCE=ci-test
         - NCCL_CUMEM_HOST_ENABLE=0
@@ -91,10 +141,11 @@ plugins:
       always-pull: true
       propagate-environment: true
       gpus: all
-      command: 
-        - "bash"
-        - "{% if fail_fast == "true" %}-xce{% else %}-xc{% endif %}"
-        - "(command nvidia-smi || true) && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe }} && {{ step.command or (step.commands | join(' && ')) | safe }}"
+      command:
+          - "/bin/bash"
+          - "-xce"
+          - |
+{{ vllm_checkoutoverlay_script(step,default_working_dir,skip_image_build,requirements_changed,fail_fast) | indent(12,true) }}
       environment:
         - VLLM_USAGE_SOURCE=ci-test
         - NCCL_CUMEM_HOST_ENABLE=0
@@ -117,10 +168,11 @@ plugins:
       propagate-environment: true
       # gpus will be configured by BUILDKITE_PLUGIN_DOCKER_GPUS in per host environment variable.
       # gpus: all
-      command: 
-        - "bash"
-        - "{% if fail_fast == "true" %}-xce{% else %}-xc{% endif %}"
-        - "(command nvidia-smi || true) && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe }} && {{ step.command or (step.commands | join(' && ')) | safe }}"
+      command:
+          - "/bin/bash"
+          - "-xce"
+          - |
+{{ vllm_checkoutoverlay_script(step,default_working_dir,skip_image_build,requirements_changed,fast_fail) | indent(12,true) }}
       environment:
         - VLLM_USAGE_SOURCE=ci-test
         - NCCL_CUMEM_HOST_ENABLE=0
@@ -180,6 +232,7 @@ plugins:
 
 
 steps:
+  {% if skip_image_build != "1" %}
   - label: ":docker: build image"
     key: image-build
     depends_on: ~
@@ -305,6 +358,7 @@ steps:
           limit: 2
         - exit_status: -10  # Agent was lost
           limit: 2
+  {% endif %}
 
   {% for step in steps %}
   {% if step.fast_check_only != true %}
@@ -333,7 +387,11 @@ steps:
 
   {% if ns.blocked == 1 or (step.optional and nightly != "1") %}
   - block: "Run {{ step.label }}"
+    {% if skip_image_build != "1" %}
     depends_on: image-build
+    {% else %}
+    depends_on: ~
+    {% endif %}
     key: block-{{ step.label | replace(" ", "-") | lower | replace("(", "") | replace(")", "") | replace("%", "") | replace(",", "-") | replace("+", "-") }}
   {% endif %}
 
@@ -341,7 +399,11 @@ steps:
     {% if ns.blocked == 1 or (step.optional and nightly != "1") %}
     depends_on: block-{{ step.label | replace(" ", "-") | lower | replace("(", "") | replace(")", "") | replace("%", "") | replace(",", "-") | replace("+", "-") }}
     {% else %}
+    {% if skip_image_build != "1" %}
     depends_on: {{ "image-build-cpu" if step.no_gpu else "image-build" }}
+    {% else %}
+    depends_on: ~
+    {% endif %}
     {% endif %}
     soft_fail: {{ step.soft_fail or false }}
     {{ render_cuda_config(step, docker_image_cpu if step.no_gpu else docker_image, default_working_dir, hf_home_fsx, hf_home, branch)  | indent(4, true) }}

--- a/buildkite/test-template-fastcheck.j2
+++ b/buildkite/test-template-fastcheck.j2
@@ -1,11 +1,59 @@
 {% set docker_image = "public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT" %}
 {% set docker_image_amd = "rocm/vllm-ci:$BUILDKITE_COMMIT" %}
+{% set skip_image_build = (skip_image_build | default("0")) %}
+{% set requirements_changed = (requirements_changed | default("0")) %}
+{% if skip_image_build == "1" and docker_image_override is defined and docker_image_override %}
+  {% set docker_image = docker_image_override %}
+{% endif %}
 {% set default_working_dir = "/vllm-workspace/tests" %}
 {% set hf_home = "/root/.cache/huggingface" %}
 {% set hf_home_efs = "/mnt/efs/hf_cache" %}
 {% set hf_home_fsx = "/fsx/hf_cache" %}
 
+{% macro vllm_checkoutoverlay_script(step,default_working_dir,skip_image_build,requirements_changed,fail_fast) -%}
+set {% if fail_fast == "true" %}-xeuo pipefail{% else %}-xuo{% endif %}
+echo "SKIP_IMAGE_BUILD={{ skip_image_build }} REQUIREMENTS_CHANGED={{ requirements_changed }}"
+{% if skip_image_build == "1" %}
+
+# Copy in the code from the checkout to the workspace
+rm -rf /vllm-workspace/vllm || true
+cp -a /workdir/. /vllm-workspace/
+
+# Overlay the pure-Python vllm into the install package dir
+export SITEPKG="$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
+cp -a /vllm-workspace/vllm/* "$$SITEPKG/vllm/"
+
+# Restore src/ layout, as Dockerfile does. Hides code from tests, but allows setup.
+rm -rf /vllm-workspace/src || true
+mkdir -p /vllm-workspace/src
+mv /vllm-workspace/vllm /vllm-workspace/src/vllm
+
+# If deps changed, re-install (system-wide in the container)
+{% if requirements_changed == '1' %}
+cd /vllm-workspace
+uv pip install --system -r requirements/common.txt -r requirements/build.txt -r requirements/test.txt
+{% endif %}
+{% endif %}
+
+(command -v nvidia-smi >/dev/null && nvidia-smi || true)
+export VLLM_LOGGING_LEVEL=DEBUG
+export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1
+cd {{ (step.working_dir or default_working_dir) | safe }}
+
+{# Emit commands exactly as input. #}
+{% if step.command -%}
+{{ step.command | replace(' \\', '') | trim | safe }}
+{%- elif step.commands -%}
+{%- for cmd in step.commands %}
+{{ cmd | replace(' \\', '') | trim | safe }}
+{%- endfor %}
+{%- else -%}
+echo "No command(s) defined for this step." >&2; exit 2
+{%- endif %}
+{%- endmacro %}
+
 steps:
+  {% if skip_image_build != "1" %}
   - label: ":docker: build image"
     key: image-build
     agents:
@@ -39,6 +87,7 @@ steps:
           limit: 5
         - exit_status: -10  # Agent was lost
           limit: 5
+  {% endif %}
 
   - block: Run Neuron Test
     depends_on: ~
@@ -54,7 +103,11 @@ steps:
   {% for step in steps %}
   {% if step.gpu != "a100" and step.fast_check == true and step.num_nodes < 2 %}
   - label: "{{ step.label }}"
+    {% if skip_image_build != "1" %}
     depends_on: image-build
+    {% else %}
+    depends_on: ~
+    {% endif %}
     agents:
       {% if step.label == "Documentation Build" %}
       queue: small_cpu_queue_premerge
@@ -86,10 +139,11 @@ steps:
           {% if step.label == "Benchmarks" %}
           mount-buildkite-agent: true
           {% endif %}
-          command: 
-            - "bash"
-            - "{% if fail_fast == "true" %}-xce{% else %}-xc{% endif %}"
-            - "(command nvidia-smi || true) && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe  }} && {{ step.command  or (step.commands | join(' && ')) | safe }}"
+          command:
+            - "/bin/bash"
+            - "-xce"
+            - |
+{{ vllm_checkoutoverlay_script(step,default_working_dir,skip_image_build,requirements_changed,fail_fast) | indent(14,true) }}
           environment:
             - VLLM_USAGE_SOURCE=ci-test
             - NCCL_CUMEM_HOST_ENABLE=0
@@ -111,7 +165,11 @@ steps:
   {% if step.gpu != "a100" and step.fast_check != true and step.num_nodes < 2 %}
   - block: "Run {{ step.label }}"
     key: block-{{ step.label | replace(" ", "-") | lower | replace("(", "") | replace(")", "") | replace("%", "") | replace(",", "-") | replace("+", "-") }}
+    {% if skip_image_build != "1" %}
     depends_on: image-build
+    {% else %}
+    depends_on: ~
+    {% endif %}
 
   - label: "{{ step.label }}"
     depends_on: block-{{ step.label | replace(" ", "-") | lower | replace("(", "") | replace(")", "") | replace("%", "") | replace(",", "-") | replace("+", "-") }}
@@ -146,10 +204,11 @@ steps:
           {% if step.label == "Benchmarks" %}
           mount-buildkite-agent: true
           {% endif %}
-          command: 
-            - "bash"
-            - "{% if fail_fast == "true" %}-xce{% else %}-xc{% endif %}"
-            - "(command nvidia-smi || true) && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe  }} && {{ step.command  or (step.commands | join(' && ')) | safe }}"
+          command:
+            - "/bin/bash"
+            - "-xce"
+            - |
+{{ vllm_checkoutoverlay_script(step,default_working_dir,skip_image_build,requirements_changed,fail_fast) | indent(14,true) }}
           environment:
             - VLLM_USAGE_SOURCE=ci-test
             - NCCL_CUMEM_HOST_ENABLE=0
@@ -171,7 +230,11 @@ steps:
   {% if step.num_nodes >= 2 %}
   - block: "Run {{ step.label }}"
     key: block-{{ step.label | replace(" ", "-") | lower | replace("(", "") | replace(")", "") | replace("%", "") | replace(",", "-") | replace("+", "-") }}
+    {% if skip_image_build != "1" %}
     depends_on: image-build
+    {% else %}
+    depends_on: ~
+    {% endif %}
 
   - label: "{{ step.label }}"
     depends_on: block-{{ step.label | replace(" ", "-") | lower | replace("(", "") | replace(")", "") | replace("%", "") | replace(",", "-") | replace("+", "-") }}
@@ -183,7 +246,11 @@ steps:
   {% endfor %}
 
   - block: "Run A100 tests"
+    {% if skip_image_build != "1" %}
     depends_on: image-build
+    {% else %}
+    depends_on: ~
+    {% endif %}
 
   {% for step in steps %}
   {% if step.gpu == "a100" %}


### PR DESCRIPTION
Related to PR #149 & #158 (reverted in #159 )

Reverted due to missing quotes (due to me cleaning up code and then only checking fastcheck after, thereby, impacting the CI pipeline) in an echo, which was happening on each docker run command for eligible PRs (most of them).

This fix re-introduces the skip image build for eligible PRs and also fixes the missing quote.

New test plan: Validate both CI and Fastcheck Pipelines prior to merge

* [Example build, fastcheck pipeline](https://buildkite.com/vllm/fastcheck/builds/40832)
* [Example build, ci pipeline](https://buildkite.com/vllm/ci/builds/29982)