### PR TITLE
Fix K8s YAML for CUMEM host

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -141,7 +141,7 @@ plugins:
               - name: VLLM_USAGE_SOURCE
                 value: ci-test
               - name: NCCL_CUMEM_HOST_ENABLE
-                value: 0
+                value: "0"
               - name: HF_HOME
                 value: {{ hf_home }}
               - name: HF_TOKEN


### PR DESCRIPTION
agent-stack-k8s failed to parse the job: failed parsing Kubernetes plugin: json: cannot unmarshal number into Go struct field EnvVar.podSpec.containers.env.value of type string