### PR TITLE
Automatic test coverage generation

### DIFF
--- a/buildkite/bootstrap.sh
+++ b/buildkite/bootstrap.sh
@@ -34,6 +34,10 @@ fail_fast() {
     fi
 }
 
+if [[ -z "${COV_ENABLED:-}" ]]; then
+    COV_ENABLED=0
+fi
+
 upload_pipeline() {
     echo "Uploading pipeline..."
     # Install minijinja
@@ -76,6 +80,7 @@ upload_pipeline() {
             -D mirror_hw="$AMD_MIRROR_HW" \
             -D fail_fast="$FAIL_FAST" \
             -D vllm_use_precompiled="$VLLM_USE_PRECOMPILED" \
+            -D cov_enabled="$COV_ENABLED" \
             | sed '/^[[:space:]]*$/d' \
             > pipeline.yaml
     )

--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -1,3 +1,4 @@
+{% set cov_enabled = (cov_enabled == "1") %}
 {% set docker_image = "public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT" %}
 {% set docker_image_torch_nightly = "public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT-torch-nightly" %}
 {% set docker_image_cu118 = "public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT-cu118" %}
@@ -16,6 +17,32 @@
 {% set hf_home_fsx = "/fsx/hf_cache" %}
 {% set list_file_diff = list_file_diff | split("|") %}
 
+{% macro add_pytest_coverage(cmd, coverage_file) %}
+{% if "pytest " in cmd %}
+COVERAGE_FILE={{ coverage_file }} {{ cmd | replace("pytest ", "pytest --cov=vllm --cov-report= --cov-append --durations=0 ") }} || true
+{% else %}
+{{ cmd }}
+{% endif %}
+{% endmacro %}
+
+{% macro add_docker_pytest_coverage(step, cov_enabled) %}
+{% if cov_enabled %}
+{% set step_length = step.label | length %}
+{% set step_first = step.label | first | default("x") %}
+{% set coverage_file = ".coverage." + step_length ~ "_" ~ step_first %}
+{% set ns = namespace(has_pytest=false) %}
+{% if step.command %}
+{% if "pytest " in step.command %}{% set ns.has_pytest = true %}{% endif %}
+{{ add_pytest_coverage(step.command, coverage_file) }}
+{% else %}
+{% for cmd in step.commands %}
+{% if "pytest " in cmd %}{% set ns.has_pytest = true %}{% endif %}
+{{ add_pytest_coverage(cmd, coverage_file) }}{{ " && " if not loop.last else "" }}{% endfor %}
+{% endif %}{% if ns.has_pytest %} && buildkite-agent artifact upload {{ coverage_file }}{% endif %}
+{% else %}
+{{ step.command or (step.commands | join(' && ')) | safe }}
+{% endif %}
+{% endmacro %}
 
 {% macro render_cuda_config(step, image, default_working_dir, hf_home_fsx, hf_home, branch) %}
 agents:
@@ -61,13 +88,10 @@ plugins:
       {% if not step.no_gpu %}
       gpus: all
       {% endif %}
-      {% if step.label == "Benchmarks" or step.mount_buildkite_agent %}
+      {% if step.label == "Benchmarks" or step.mount_buildkite_agent or cov_enabled %}
       mount-buildkite-agent: true
       {% endif %}
-      command: 
-        - "bash"
-        - "{% if fail_fast == "true" %}-xce{% else %}-xc{% endif %}"
-        - "(command nvidia-smi || true) && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe }} && {{ step.command or (step.commands | join(' && ')) | safe }}"
+      command: ["bash", "{% if fail_fast == "true" %}-xce{% else %}-xc{% endif %}", "(command nvidia-smi || true) && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe }} && {{ add_docker_pytest_coverage(step, cov_enabled) }}"]
       environment:
         - VLLM_USAGE_SOURCE=ci-test
         - NCCL_CUMEM_HOST_ENABLE=0
@@ -669,4 +693,31 @@ steps:
                      - "vllm#tpu-ci-notifications"
       YAML
       fi
+  {% endif %}
+
+  {% if cov_enabled %}
+  - block: "Generate Coverage Report"
+    depends_on: ~
+    key: block-generate-coverage-report
+    prompt: "Generate HTML coverage report from all test coverage files?"
+
+  - label: "Generate Coverage Report and Upload"
+    depends_on: block-generate-coverage-report
+    soft_fail: true
+    agents:
+      queue: cpu_queue_postmerge_us_east_1
+    plugins:
+      - docker#v5.2.0:
+          image: {{ docker_image }}
+          always-pull: true
+          mount-buildkite-agent: true
+          command: ["bash", "-xce", "buildkite-agent artifact download '.coverage.*' . || echo 'No coverage files found' && if ls .coverage.* 1> /dev/null 2>&1; then echo 'Coverage files found, generating report...' && python3 -m coverage combine && python3 -m coverage html -d coverage_html_report && tar -czf coverage_report.tar.gz coverage_html_report/ && buildkite-agent artifact upload coverage_report.tar.gz && python3 -m coverage report; else echo 'No coverage files found. Skipping coverage report generation.' && echo 'This may indicate that all pytest steps failed or coverage was not enabled.'; fi"]
+          environment:
+            - BUILDKITE_AGENT_ACCESS_TOKEN
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 1
+        - exit_status: -10
+          limit: 1
   {% endif %}


### PR DESCRIPTION
Implements automatic coverage report generation.
if COV_ENABLED is set, it will modify the existing steps which use pytest to generate a report, it will then uploads the report as separate artifacts for each step.
Finally a new step is added called "Generate Coverage Report" which is triggered manually. Once triggered, it will download the coverage results from all passed tests, combines them into a single report, generate an HTML version and uploads it as a tar artifact.

If COV_ENABLED is not set this will do nothing and works as before.

Example buildkite run: 
https://buildkite.com/vllm/ci/builds/30604/steps/canvas?sid=0199406f-1a83-4743-a43f-b9ceee9e6acd
<img width="1040" height="419" alt="image" src="https://github.com/user-attachments/assets/51859ab0-903d-4a75-81f0-073e420f86b9" />

<img width="1311" height="362" alt="image" src="https://github.com/user-attachments/assets/749cea70-756f-4d0f-9acd-bfaa0e004a5d" />
