### PR TITLE
Amd blocking test collection + test dispatching to the specific agent pool (v2)

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -474,8 +474,8 @@ steps:
       - label: "{{ step.agent_pool }}: {{ step.label }}"
         depends_on: amd-build
         agents:
-          #queue: "{{ step.agent_pool }}"
-          queue: amd_mi325_1
+          queue: {{ step.agent_pool }}
+          #queue: amd_mi325_1
         command: bash .buildkite/scripts/hardware_ci/run-amd-test.sh "(command rocm-smi || true) && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" && ")) | safe }}"
         env:
           DOCKER_BUILDKIT: "1"

--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -479,11 +479,11 @@ steps:
         env:
           DOCKER_BUILDKIT: "1"
         priority: 100
-         {% if step.label and step.label=="Regression Test" or step.label=="Engine Test" %}
-           soft_fail: false
-         {% else %}
-           soft_fail: true
-         {% endif%}
+        {% if step.label and step.label=="Regression Test" or step.label=="Engine Test" %}
+        soft_fail: false
+        {% else %}
+        soft_fail: true
+        {% endif%}
     {% endif %}
     {% endfor %}
     {% for step in steps %}

--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -471,24 +471,20 @@ steps:
 
     {% for step in steps %}
     {% if step.mirror_hardwares and mirror_hw in step.mirror_hardwares %}
-      - label: "AMD MI300: {{ step.label }}"
+      - label: "{{ step.agent_pool }}: {{ step.label }}"
         depends_on: amd-build
         agents:
-         {% if step.label and step.label=="Benchmarks" or step.label=="Kernels Attention Test %N" or step.label=="LoRA Test %N" or step.label=="Kernels Quantization Test %N" %}
-           queue: amd_mi325_8
-         {% elif step.label=="Distributed Tests (4 GPUs)" or step.label=="2 Node Tests (4 GPUs in total)" or step.label=="Multi-step Tests (4 GPUs)" or step.label=="Pipeline Parallelism Test" or step.label=="LoRA TP Test (Distributed)" %}
-           queue: amd_mi325_4
-         {% elif step.label=="Distributed Comm Ops Test" or step.label=="Distributed Tests (2 GPUs)" or step.label=="Plugin Tests (2 GPUs)" or step.label=="Weight Loading Multiple GPU Test" or step.label=="Weight Loading Multiple GPU Test - Large Models" %}
-           queue: amd_mi325_2
-         {% else %}
-           queue: amd_mi325_1
-         {% endif%}
+          queue: "{{ step.agent_pool }}"
         command: bash .buildkite/scripts/hardware_ci/run-amd-test.sh "(command rocm-smi || true) && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" && ")) | safe }}"
         env:
           DOCKER_BUILDKIT: "1"
         priority: 100
-        soft_fail: false
-        {% endif %}
+         {% if step.label and step.label=="Regression Test" or step.label=="Engine Test" %}
+           soft_fail: false
+         {% else %}
+           soft_fail: true
+         {% endif%}
+    {% endif %}
     {% endfor %}
     {% for step in steps %}
         # removed because of lack of HW resources: step.label and step.label=="Benchmarks" or step.label=="Pipeline Parallelism Test" or

--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -475,7 +475,6 @@ steps:
         depends_on: amd-build
         agents:
           queue: {{ step.agent_pool }}
-          #queue: amd_mi325_1
         command: bash .buildkite/scripts/hardware_ci/run-amd-test.sh "(command rocm-smi || true) && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" && ")) | safe }}"
         env:
           DOCKER_BUILDKIT: "1"

--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -474,7 +474,8 @@ steps:
       - label: "{{ step.agent_pool }}: {{ step.label }}"
         depends_on: amd-build
         agents:
-          queue: "{{ step.agent_pool }}"
+          #queue: "{{ step.agent_pool }}"
+          queue: amd_mi325_1
         command: bash .buildkite/scripts/hardware_ci/run-amd-test.sh "(command rocm-smi || true) && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" && ")) | safe }}"
         env:
           DOCKER_BUILDKIT: "1"


### PR DESCRIPTION
Adds functionality to decide if a specific AMD test is blocking.

Implemented trough an additional "grade" property for each test definition in the test-pipeline.yaml. E.g.:

- label: Regression Test # 7min
  timeout_in_minutes: 20
  mirror_hardwares: [amdexperimental, amdproduction]
  agent_pool: amd_mi325_1
....

makes this "AMD: Regression Test" dispatched to the amd_mi325_1 agent pool.



The decision on making softfail "true" or "false" is contained in the ci-infra/buildkite/test-template-ci.j2 file.


Signed-off-by: Alexei V. Ivanov [alexei.ivanov@amd.com](mailto:alexei.ivanov@amd.com)