### PR TITLE
Skip hardware tests on docs-only changes

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -17,6 +17,12 @@
 {% set hf_home_fsx = "/fsx/hf_cache" %}
 {% set list_file_diff = list_file_diff | split("|") %}
 
+{% set docs_only = (list_file_diff | length > 0) %}
+{% for file in list_file_diff %}
+{% if file[:5] != 'docs/' %}
+{% set docs_only = false %}
+{% endif %}
+{% endfor %}
 {% macro add_pytest_coverage(cmd, coverage_file) %}
 {% if "pytest " in cmd %}
 COVERAGE_FILE={{ coverage_file }} {{ cmd | replace("pytest ", "pytest --cov=vllm --cov-report= --cov-append --durations=0 ") }} || true
@@ -529,6 +535,7 @@ steps:
         {% endif %}
     {% endfor %}
 
+{% if not docs_only %}
   - label: "Neuron Test"
     depends_on: ~
     agents:
@@ -701,6 +708,7 @@ steps:
                      - "vllm#tpu-ci-notifications"
       YAML
       fi
+{% endif %}
   {% endif %}
 
   {% if cov_enabled %}

--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -17,12 +17,14 @@
 {% set hf_home_fsx = "/fsx/hf_cache" %}
 {% set list_file_diff = list_file_diff | split("|") %}
 
-{% set docs_only = (list_file_diff | length > 0) %}
+{% set docs_check = namespace(all_docs=true, found_any=false) %}
 {% for file in list_file_diff %}
+{% set docs_check.found_any = true %}
 {% if file[:5] != 'docs/' %}
-{% set docs_only = false %}
+{% set docs_check.all_docs = false %}
 {% endif %}
 {% endfor %}
+{% set docs_only = (docs_check.all_docs and docs_check.found_any) %}
 {% macro add_pytest_coverage(cmd, coverage_file) %}
 {% if "pytest " in cmd %}
 COVERAGE_FILE={{ coverage_file }} {{ cmd | replace("pytest ", "pytest --cov=vllm --cov-report= --cov-append --durations=0 ") }} || true


### PR DESCRIPTION
This will skip hardware CI tests on docs only PRs such as https://github.com/vllm-project/vllm/pull/25819 

Testing
---
Normal run on master:
https://buildkite.com/vllm/ci/builds/32829/steps/canvas

PR with just docs files modified:
https://buildkite.com/vllm/ci/builds/32831/steps/canvas