### PR TITLE
skip pipeline if all changed files are under docs/

### DIFF
--- a/buildkite/bootstrap.sh
+++ b/buildkite/bootstrap.sh
@@ -19,6 +19,10 @@ if [[ -z "${AMD_MIRROR_HW:-}" ]]; then
     AMD_MIRROR_HW="amdproduction"
 fi
 
+if [[ -z "${DOCS_ONLY_DISABLE:-}" ]]; then
+    DOCS_ONLY_DISABLE=0
+fi
+
 fail_fast() {
     DISABLE_LABEL="ci-no-fail-fast"
     # If BUILDKITE_PULL_REQUEST != "false", then we check the PR labels using curl and jq
@@ -104,6 +108,40 @@ file_diff=$(get_diff)
 if [[ $BUILDKITE_BRANCH == "main" ]]; then
     file_diff=$(get_diff_main)
 fi
+
+# ----------------------------------------------------------------------
+# Early exit start: skip pipeline if conditions are met
+# ----------------------------------------------------------------------
+
+# skip pipeline if all changed files are under docs/
+if [[ "${DOCS_ONLY_DISABLE}" != "1" ]]; then
+  if [[ -n "${file_diff:-}" ]]; then
+    docs_only=1
+    # Robust iteration over newline-separated file_diff
+    while IFS= read -r f; do
+      [[ -z "$f" ]] && continue
+      # **Policy:** only skip if *every* path starts with docs/
+      if [[ "$f" != docs/* ]]; then
+        docs_only=0
+        break
+      fi
+    done <<< "$file_diff"
+
+    if [[ "$docs_only" -eq 1 ]]; then
+      buildkite-agent annotate ":memo: CI skipped — docs/** only changes detected
+
+\`\`\`
+${file_diff}
+\`\`\`" --style "info" || true
+      echo "[docs-only] All changes are under docs/. Exiting before pipeline upload."
+      exit 0
+    fi
+  fi
+fi
+
+# ----------------------------------------------------------------------
+# Early exit end
+# ----------------------------------------------------------------------
 
 patterns=(
     "docker/Dockerfile"

--- a/buildkite/bootstrap.sh
+++ b/buildkite/bootstrap.sh
@@ -19,8 +19,8 @@ if [[ -z "${AMD_MIRROR_HW:-}" ]]; then
     AMD_MIRROR_HW="amdproduction"
 fi
 
-if [[ -z "${DOCS_ONLY_DISABLE:-}" ]]; then
-    DOCS_ONLY_DISABLE=0
+if [[ -z "${DOCS_ONLY:-}" ]]; then
+    DOCS_ONLY=0
 fi
 
 fail_fast() {
@@ -114,7 +114,7 @@ fi
 # ----------------------------------------------------------------------
 
 # skip pipeline if all changed files are under docs/
-if [[ "${DOCS_ONLY_DISABLE}" != "1" ]]; then
+if [[ "${DOCS_ONLY}" != "1" ]]; then
   if [[ -n "${file_diff:-}" ]]; then
     docs_only=1
     # Robust iteration over newline-separated file_diff

--- a/buildkite/bootstrap.sh
+++ b/buildkite/bootstrap.sh
@@ -19,8 +19,8 @@ if [[ -z "${AMD_MIRROR_HW:-}" ]]; then
     AMD_MIRROR_HW="amdproduction"
 fi
 
-if [[ -z "${DOCS_ONLY:-}" ]]; then
-    DOCS_ONLY=0
+if [[ -z "${DOCS_ONLY_DISABLE:-}" ]]; then
+    DOCS_ONLY_DISABLE=0
 fi
 
 fail_fast() {
@@ -114,7 +114,7 @@ fi
 # ----------------------------------------------------------------------
 
 # skip pipeline if all changed files are under docs/
-if [[ "${DOCS_ONLY}" != "1" ]]; then
+if [[ "${DOCS_ONLY_DISABLE}" != "1" ]]; then
   if [[ -n "${file_diff:-}" ]]; then
     docs_only=1
     # Robust iteration over newline-separated file_diff


### PR DESCRIPTION
# Summary

Same as https://github.com/vllm-project/ci-infra/pull/178 , but directly creating a new branch under vllm-project/ci-infra for easy testing

# Test

## doc-only case
Use https://github.com/vllm-project/vllm/pull/25819 , and launch a new buildkite https://buildkite.com/vllm/ci/builds/32894/steps/canvas?sid=019998f0-f555-4fe8-ada0-9c91c83cce01

relevant output
```
[2025-09-30T04:46:36Z] [docs-only] All changes are under docs/. Exiting before pipeline upload.
```

## general case

Use https://github.com/vllm-project/vllm/commit/07be34b65336a7d07beb6e8705a16d117e28935b , and launch a new buildkite  https://buildkite.com/vllm/ci/builds/32915/steps/canvas