### PR TITLE
Intelligent test filtering if only test files are modified

### DIFF
--- a/buildkite/test-template-ci.j2
+++ b/buildkite/test-template-ci.j2
@@ -17,6 +17,19 @@
 {% set hf_home_fsx = "/fsx/hf_cache" %}
 {% set list_file_diff = list_file_diff | split("|") %}
 
+{# Intelligent test targeting: Detect when only test files changed and collect them #}
+{%- set tests_acc = namespace(only_tests=true, any=false, changed=[]) %}
+{%- for file in list_file_diff %}
+{%- if file[:6] == 'tests/' and '/test_' in file and file[-3:] == '.py' %}
+{%- set tests_acc.any = true %}
+{%- set tests_acc.changed = tests_acc.changed + [file[6:]] %}
+{%- else %}
+{%- set tests_acc.only_tests = false %}
+{%- endif %}
+{%- endfor %}
+{%- set tests_only = (tests_acc.only_tests and tests_acc.any) %}
+{%- set changed_tests = tests_acc.changed %}
+
 {% macro add_pytest_coverage(cmd, coverage_file) %}
 {% if "pytest " in cmd %}
 COVERAGE_FILE={{ coverage_file }} {{ cmd | replace("pytest ", "pytest --cov=vllm --cov-report=xml --cov-append --durations=0 ") }} || true
@@ -26,10 +39,46 @@ COVERAGE_FILE={{ coverage_file }} {{ cmd | replace("pytest ", "pytest --cov=vllm
 {% endmacro %}
 
 {% macro add_docker_pytest_coverage(step, cov_enabled) %}
-{% if cov_enabled %}
+{# Compute coverage file id #}
 {% set step_length = step.label | length %}
 {% set step_first = step.label | first | default("x") %}
 {% set coverage_file = ".coverage." + step_length ~ "_" ~ step_first %}
+
+{# Intelligent test targeting: Build matched test targets for this step when only tests changed #}
+{%- set match_ns = namespace(targets=[]) %}
+{%- if tests_only and step.source_file_dependencies %}
+{%- for dep in step.source_file_dependencies %}
+{%- if dep[:6] == 'tests/' %}
+{%- set dep_rel = dep[6:] %}
+{# Handle deps that already end with '/' (e.g., tests/benchmarks/) #}
+{%- if dep_rel[-1:] == '/' %}
+{%- set dep_dir_prefix = dep_rel %}
+{%- set dep_file_name = dep_rel[:-1] ~ '.py' %}
+{%- else %}
+{%- set dep_dir_prefix = dep_rel ~ '/' %}
+{%- set dep_file_name = dep_rel ~ '.py' %}
+{%- endif %}
+{%- for t in changed_tests %}
+{# Check if t starts with dep_dir_prefix (for directories) or equals dep_file_name (for files) #}
+{%- set prefix_len = dep_dir_prefix | length %}
+{%- set t_prefix = t[:prefix_len] %}
+{%- set cond1 = (t | length >= prefix_len and t_prefix == dep_dir_prefix) %}
+{%- set cond2 = (t == dep_file_name) %}
+{%- if cond1 or cond2 %}
+{%- set match_ns.targets = match_ns.targets + [t] %}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- set matched_targets = match_ns.targets %}
+
+{# If we have matched targets, run only those specific tests #}
+{% if matched_targets | length > 0 %}
+pytest -v -s {{ matched_targets | join(' ') }}
+{% else %}
+{# Default behavior: preserve original commands with optional coverage injection #}
+{% if cov_enabled %}
 {% set ns = namespace(has_pytest=false) %}
 {% if step.command %}
 {% if "pytest " in step.command %}{% set ns.has_pytest = true %}{% endif %}
@@ -41,6 +90,7 @@ COVERAGE_FILE={{ coverage_file }} {{ cmd | replace("pytest ", "pytest --cov=vllm
 {% endif %}{% if ns.has_pytest %} && curl -sSL https://raw.githubusercontent.com/vllm-project/ci-infra/{{ vllm_ci_branch | default('main') }}/buildkite/scripts/upload_codecov.sh | bash -s -- \"{{ step.label }}\"{% endif %}
 {% else %}
 {{ step.command or (step.commands | join(' && ')) | safe }}
+{% endif %}
 {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
This will make it so that if only some tests are modified, we will only run those tests in the CI.

Because jinja is hard to read, this is the python translation to make understanding it easier:
```
def intelligent_test_targeting(
    list_file_diff: str,  # Pipe-separated: "tests/engine/test_llm.py|vllm/config.py"
    step_dependencies: List[str],  # e.g., ["vllm/", "tests/engine", "tests/test_sequence"]
    step_commands: List[str],  # e.g., ["pytest -v -s engine test_sequence.py ..."]
    cov_enabled: bool = False
) -> str:
    """
    Generate optimized or default test command based on changed files.
    
    Returns:
        Command string to execute (optimized if possible, default otherwise)
    """
    
    # =========================================================================
    # STEP 1: Detect if ONLY test files changed (Lines 21-31)
    # =========================================================================
    files = [f for f in list_file_diff.split('|') if f]
    
    only_tests = True
    any_test = False
    changed_tests = []  # Relative to tests/ directory
    
    for file in files:
        # Check if file is a test: starts with "tests/", contains "/test_", ends with ".py"
        if file[:6] == 'tests/' and '/test_' in file and file[-3:] == '.py':
            any_test = True
            changed_tests.append(file[6:])  # Strip "tests/" prefix
        else:
            only_tests = False  # Found a non-test file
    
    tests_only = only_tests and any_test
    
    # If not tests_only, use default commands
    if not tests_only or not step_dependencies:
        return ' && '.join(step_commands)  # DEFAULT
    
    # =========================================================================
    # STEP 2: Match changed tests to step's test dependencies (Lines 48-74)
    # =========================================================================
    matched_targets = []
    
    for dep in step_dependencies:
        # Only process test dependencies
        if dep[:6] != 'tests/':
            continue
        
        dep_rel = dep[6:]  # Remove "tests/" prefix
        
        # Handle trailing slashes (e.g., "benchmarks/" vs "engine")
        if dep_rel[-1:] == '/':
            dep_dir_prefix = dep_rel  # Keep slash: "benchmarks/"
            dep_file_name = dep_rel[:-1] + '.py'  # "benchmarks.py"
        else:
            dep_dir_prefix = dep_rel + '/'  # Add slash: "engine/"
            dep_file_name = dep_rel + '.py'  # "test_sequence.py"
        
        # Check each changed test
        for t in changed_tests:
            prefix_len = len(dep_dir_prefix)
            
            # Directory match: "engine/test_llm.py" starts with "engine/"
            is_dir_match = (len(t) >= prefix_len and t[:prefix_len] == dep_dir_prefix)
            
            # File match: "test_sequence.py" == "test_sequence.py"
            is_file_match = (t == dep_file_name)
            
            if is_dir_match or is_file_match:
                matched_targets.append(t)
    
    # =========================================================================
    # STEP 3: Generate command (Lines 77-92)
    # =========================================================================
    if matched_targets:
        # OPTIMIZED: Run only matched tests
        if cov_enabled:
            return f"COVERAGE_FILE=.coverage pytest --cov=vllm {' '.join(matched_targets)}"
        else:
            return f"pytest -v -s {' '.join(matched_targets)}"
    else:
        # DEFAULT: Run original commands
        return ' && '.join(step_commands)
```

Testing
---
Test : Only  engine test file modified -> Only running the new test
https://github.com/vllm-project/vllm/pull/26036/commits/db06bd0c6c56b8e68b2fa094da4be6863f6ce17e
Build: https://buildkite.com/vllm/ci/builds/33083/steps/canvas?sid=0199a0cb-d268-42e4-b644-967f4e59a267



Test: Some test files and non-test files modified --> Behaving as before
https://github.com/vllm-project/vllm/pull/26036/files
Build: https://buildkite.com/vllm/ci/builds/33100/steps/canvas?sid=0199a13c-d6da-4781-8ea2-f968e48c1826
