### PR TITLE
fix_doc_only_skip

### DIFF
--- a/buildkite/bootstrap.sh
+++ b/buildkite/bootstrap.sh
@@ -126,7 +126,7 @@ if [[ "${DOCS_ONLY_DISABLE}" != "1" ]]; then
         docs_only=0
         break
       fi
-    done <<< "$file_diff"
+    done < <(printf '%s\n' "$file_diff" | tr ' ' '\n' | tr -d '\r')
 
     if [[ "$docs_only" -eq 1 ]]; then
       buildkite-agent annotate ":memo: CI skipped — docs/** only changes detected


### PR DESCRIPTION
# Summary

My PR https://github.com/vllm-project/ci-infra/pull/180 testing is wrong - i used a commit which is already in main to test (which uses get_diff_main instead of get_diff)

# Test 
## Test on PR with changes on both docs and others
https://github.com/vllm-project/vllm/pull/25741
=>
https://buildkite.com/vllm/ci/builds/33142/steps/canvas

## Test on PR with changes on docs only
https://github.com/vllm-project/vllm/pull/26024
=>
https://buildkite.com/vllm/ci/builds/33144/steps/canvas

## Test on PR with no changes on docs
https://github.com/vllm-project/vllm/pull/26053
=>
https://buildkite.com/vllm/ci/builds/33149/steps/canvas

## Test on merge PR with changes on both docs and others
https://github.com/vllm-project/vllm/commit/2f652e6cdf09da407e78a60327832f913b32e26e
=>
https://buildkite.com/vllm/ci/builds/33148/steps/canvas

## Test on merged PR with changes on docs only
https://github.com/vllm-project/vllm/commit/57b46d769eb7c6bfe03756da3071aa99779b1b99
=>
https://buildkite.com/vllm/ci/builds/33147/steps/canvas

## Test on merged PR with no changes on docs
https://github.com/vllm-project/vllm/commit/c36f0aa3005115699abeb7d66f14ba16bde62cf4
=>
https://buildkite.com/vllm/ci/builds/33150/steps/canvas
