### PR TITLE
[AMD] Add BuildKite parallelism, automatic retries

### DIFF
--- a/buildkite/test-template-amd.j2
+++ b/buildkite/test-template-amd.j2
@@ -356,7 +356,11 @@ plugins:
           {% else %}
           queue: amd_mi325_1
           {% endif %}
+        {% if step.num_nodes and step.num_nodes >= 2 %}
+        command: (command rocm-smi || true) && ./.buildkite/scripts/run-multi-node-test.sh {{ (step.working_dir or default_working_dir) | safe }} {{ step.num_nodes }} {{ step.num_gpus or 1 }} {{ docker_image_amd }} {% for command in step.commands %} "{{ (command | join(' && ')) | safe }}" {% endfor %}
+        {% else %}
         command: bash .buildkite/scripts/hardware_ci/run-amd-test.sh "(command rocm-smi || true) && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" && ")) | safe }}"
+        {% endif %}
         env:
           DOCKER_BUILDKIT: "1"
         priority: 100
@@ -364,6 +368,9 @@ plugins:
         soft_fail: false
         {% else %}
         soft_fail: true
-        {% endif%}
+        {% endif %}
+        {% if step.parallelism %}
+        parallelism: {{ step.parallelism }}
+        {% endif %}
     {% endif %}
     {% endfor %}

--- a/buildkite/test-template-amd.j2
+++ b/buildkite/test-template-amd.j2
@@ -309,9 +309,11 @@ plugins:
         retry:
           automatic:
             - exit_status: -1  # Agent was lost
-              limit: 1
+              limit: 2
             - exit_status: -10  # Agent was lost
-              limit: 1
+              limit: 2
+            - exit_status: 128  # Git connectivity issues
+              limit: 2
             - exit_status: 1  # Machine occasionally fail
               limit: 1
         agents:
@@ -372,5 +374,13 @@ plugins:
         {% if step.parallelism %}
         parallelism: {{ step.parallelism }}
         {% endif %}
+        retry:
+          automatic:
+            - exit_status: -1  # Agent was lost
+              limit: 2
+            - exit_status: -10  # Agent was lost
+              limit: 2
+            - exit_status: 128  # Git connectivity issues
+              limit: 2
     {% endif %}
     {% endfor %}


### PR DESCRIPTION
AMD CI currently uses [complicated logic](https://github.com/vllm-project/vllm/blob/a28d9f4470550835a8b36b9e558d4d47b30c7127/.buildkite/scripts/hardware_ci/run-amd-test.sh#L168-L226) to emulate BuildKite's step parallelism.

This small PR, combined with https://github.com/vllm-project/vllm/pull/32745, simplifies said parallelism logic and aligns it with best practice on Nvidia CI. It has the added benefit of reducing effective CI load because sharded tests can now correctly use a 1-GPU machine per shard, rather than occupying an entire 8-GPU machine for all shards even when the number of shards is less than 8.

This PR also adds automatic retries for some failure patterns (e.g. agent loss, temporary network connectivity issues).

This branch has been tested and is working on the following builds:

1. First **all-green** AMD nightly CI [here](https://buildkite.com/vllm/amd-ci/builds/3472)!
2. Regular vLLM PR CI builds: [here](https://buildkite.com/vllm/amd-ci/builds/3495) and [here](https://buildkite.com/vllm/amd-ci/builds/3497).
