### PR TITLE
Rewrite README with comprehensive documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,220 @@
-# vLLM Continuous Integration (CI) Infrastructure
+# vLLM CI Infrastructure
 
-## Overview
-This repository contains the infrastructure and bootstrap code for the vLLM continuous integration pipeline using Buildkite.
+Infrastructure-as-Code and bootstrap scripts for vLLM's continuous integration pipeline, built on [Buildkite](https://buildkite.com/) with autoscaling compute across AWS and GCP.
 
-Current CI Infrastructure Setup:
+## Repository Structure
 
-- AWS Buildkite Elastic CI Stack: Infrastructure code in `terraform/aws`
-- TPU v5/v6e Nodes on GCP: Infrastructure code in `terraform/gcp_old`
-- GKE Cluster on GCP (currently not in use): Infrastructure code in `terraform/gcp`
+```
+ci-infra/
+├── .buildkite/            # Scheduled Buildkite pipelines (e.g. daily AMI rebuild)
+├── buildkite/             # Bootstrap scripts, Jinja2 pipeline templates, and build scripts
+│   ├── bootstrap.sh       # Main CI entry point (CUDA/CPU)
+│   ├── bootstrap-amd.sh   # AMD/ROCm CI entry point
+│   ├── test-template-ci.j2       # Full CI pipeline template
+│   ├── test-template-fastcheck.j2 # Lightweight fast-check template
+│   ├── test-template-amd.j2      # AMD/ROCm pipeline template
+│   ├── pipeline_generator/        # Python-based pipeline generator (WIP)
+│   └── scripts/           # Helper scripts (Docker bake, Codecov upload)
+├── docker/                # Docker buildx bake configuration (ci.hcl)
+├── terraform/
+│   ├── aws/               # AWS infrastructure (primary, active)
+│   ├── gcp/               # GCP GKE cluster setup
+│   └── gcp_old/           # GCP TPU v5/v6e infrastructure (legacy)
+├── packer/
+│   ├── cpu/               # CPU build AMI with warm Docker cache
+│   └── gpu/               # GPU AMI with NVIDIA drivers
+├── infra-k8s/             # Kubernetes-based Buildkite agent deployment
+├── github/                # GitHub Actions runner groups (Neural Magic, IBM)
+└── usage-stats/           # Usage telemetry collection (Vector)
+```
 
-Buildkite bootstrap scripts & pipeline template files are located in the `buildkite/` directory.
+## How CI Works
 
-## How vLLM Uses Buildkite for CI
-vLLM leverages Buildkite for CI workflow. Whenever a commit is pushed to the vLLM GitHub repository, a Buildkite webhook triggers an event that initiates a new build in the Buildkite pipeline with relevant details like Github branch and commit.
+When a commit is pushed to the [vLLM repository](https://github.com/vllm-project/vllm), a Buildkite webhook triggers a new build. The pipeline is dynamically generated based on the changes in the commit.
 
-Build Process Overview:
+### Build Flow
 
-- Bootstrap Step:
-    - Executed via `buildkite/bootstrap.sh`.
-    - Utilizes a CI Jinja2 template (`buildkite/test-template-ci.j2`) along with the [list of tests from vLLM](https://github.com/vllm-project/vllm/blob/main/.buildkite/test-pipeline.yaml) to render a Buildkite YAML configuration that defines all build/test steps and their configurations.
-    - Uploads the rendered YAML to Buildkite to initiate the build.
-    - Note: We are transitioning to a custom Buildkite pipeline generator to replace the Jinja2 template rendering soon.
+```
+GitHub push/PR
+    │
+    ▼
+Buildkite webhook triggers build
+    │
+    ▼
+Bootstrap step (buildkite/bootstrap.sh)
+    ├── Detects changed files
+    ├── Determines test scope (subset vs. run-all)
+    ├── Resolves Docker cache layers (ECR)
+    ├── Renders Jinja2 template with vLLM's test list
+    └── Uploads generated pipeline YAML to Buildkite
+    │
+    ▼
+Steps dispatched to agent queues
+    ├── CPU queues ─── Docker image build, compilation, CPU tests
+    ├── GPU queues ─── Single/multi-GPU tests (L4, A100, H100, H200, B200)
+    ├── TPU queues ─── TPU-specific tests
+    └── AMD queues ─── ROCm tests (MI250, MI325, MI355)
+    │
+    ▼
+Results reported back (test results, coverage via Codecov)
+```
 
-- Job Queueing and Execution:
-    - Each Buildkite step is associated with an agent queue.
-    - After uploaded, steps are pushed into the queue, waiting to be picked up by a Buildkite agent.
-    
-## Buildkite Agent Cluster Setup
-We use the [Buildkite Elastic CI Stack](https://github.com/buildkite/elastic-ci-stack-for-aws) to set up our autoscaling Buildkite agent cluster on AWS.
+### Smart Test Selection
 
-Components of the stack for each Agent Queue:
+The bootstrap script analyzes the diff to decide what to run:
 
-- AWS CloudFormation Stack:
-    - Contains an EC2 Auto Scaling Group and an AWS Lambda function.
+- **Docs-only changes** (`docs/`, `*.md`, `mkdocs.yaml`): CI is skipped entirely.
+- **Critical file changes** (`Dockerfile`, `CMakeLists.txt`, `csrc/`, `setup.py`, `requirements/*.txt`): All tests run and wheels are built from source.
+- **Other changes**: Only affected tests run, using precompiled wheels from the merge-base commit when available (fetched from `wheels.vllm.ai`).
+- **PR labels**: `ready-run-all-tests` forces all tests including optional/nightly ones. `ci-no-fail-fast` disables fail-fast mode.
 
-- EC2 Auto Scaling Group:
-    - Automatically scales number of EC2 instances based on the workload from the Buildkite queue.
-    - Each EC2 instance comes with a Buildkite agent that executes jobs.
+### Pipeline Templates
 
-- AWS Lambda Function:
-    - Periodically polls Buildkite to assess capacity needs for the queue and adjusts the size of the Auto Scaling Group accordingly.
+Three Jinja2 templates generate Buildkite YAML from vLLM's [`test-pipeline.yaml`](https://github.com/vllm-project/vllm/blob/main/.buildkite/test-pipeline.yaml):
 
-## How to test changes in this repo
-1. Create a feature branch on this repo, say named `my-feature-branch`. If you can't create a feature branch, ping @khluu to add you into the repo.
-2. Once the branch is created, you can start making changes and commit to the branch.
-3. After the changes are pushed to the branch, wait a few minutes, then create a new build on Buildkite with this environment variable `VLLM_CI_BRANCH=my-feature-branch` to test your changes against vLLM codebase.
+| Template | Pipeline | Purpose |
+|----------|----------|---------|
+| `test-template-ci.j2` | `ci` | Full CI pipeline with all hardware targets |
+| `test-template-fastcheck.j2` | `fastcheck` | Lightweight subset for quick validation |
+| `test-template-amd.j2` | `ci-amd` | AMD/ROCm GPU pipeline |
 
-Please note that when creating a new build on Buildkite:
-- Please do it on your own feature branch/fork branch on vLLM, preferrably a branch that is up to date with `main`.
-- If it's a fork branch, `HEAD` cannot be used as commit when creating a build. You have to put in the hash of the latest commit on your branch. Also, format the branch name to include your fork prefix as `<fork/username>:<branch name on fork>`.
+Templates are rendered using [minijinja-cli](https://github.com/mitsuhiko/minijinja) and support per-step configuration for GPU count, hardware type, working directory, parallelism, and multi-node execution.
 
-## How to onboard runners onto CI cluster on Buildkite
-The machines communicate with Buildkite server via an agent being installed on the machine. There are multiple ways agents can be installed, depending on how the machines are set up:
-1. [Buildkite Elastic CI stack](https://buildkite.com/docs/agent/v3/elastic-ci-aws/elastic-ci-stack-overview) if you want the compute to be autoscaling EC2 instances.
-2. [Buildkite K8s agent stack](https://github.com/buildkite/agent-stack-k8s) if you want machines to be managed/orchestrated in a Kubernetes cluster.
-3. [Buildkite agent](https://buildkite.com/docs/agent/v3) if you already have existing standalone machines.
+## Infrastructure
 
-For all of these approaches, you would need the following info to set up (please contact @khluu on #sig-ci channel - vllm-dev.slack.com to get them):
-- Buildkite agent token
-- Buildkite queue name
-- (optional) Buildkite cluster UUID
+### AWS (Primary)
 
-If you go with option 1 or 2, these info would need to be provided when you setup the stack. 
-For option 3, it doesn't require it when installing agent. After installation, you would need to manually:
-- Add these info in the agent config (usually located in `/etc/buildkite-agent/buildkite-agent.cfg`)
-- Restart the agent (usually `systemctl stop buildkite-agent` then `systemctl start buildkite-agent` works)
+Managed via Terraform in `terraform/aws/`. Uses the [Buildkite Elastic CI Stack for AWS](https://github.com/buildkite/elastic-ci-stack-for-aws) (v6.21.0) to deploy autoscaling agent clusters as CloudFormation stacks.
+
+**Regions**: us-west-2 (GPU + CPU queues), us-east-1 (CPU build queues with warm-cache AMI)
+
+#### Agent Queues
+
+| Queue | Instance Type | Max | Purpose |
+|-------|--------------|-----|---------|
+| `small_cpu_queue_premerge` | r6in.large | 40 | Bootstrap, docs, lightweight tasks |
+| `medium_cpu_queue_premerge` | r6in.4xlarge | 40 | Medium CPU workloads |
+| `cpu_queue_premerge` | r6in.16xlarge (512GB) | 10 | CUDA kernel compilation |
+| `cpu_queue_premerge_us_east_1` | r6in.16xlarge (512GB) | 20 | CPU builds (warm-cache AMI) |
+| `arm64_cpu_queue_premerge` | r7g.16xlarge | 10 | ARM64 builds |
+| `gpu_1_queue` | g6.4xlarge (1x L4) | 208 | Single-GPU tests |
+| `gpu_4_queue` | g6.12xlarge (4x L4) | 64 | Multi-GPU tests |
+
+Equivalent postmerge and release queues exist with write access to ECR for pushing images. Specialized hardware (H100, H200, B200, A100) is managed via Kubernetes or dedicated pools.
+
+**Each queue consists of:**
+- An EC2 Auto Scaling Group that scales instances based on workload
+- A Lambda function that polls Buildkite to assess capacity needs
+- Buildkite agents running on each instance, executing jobs in Docker containers
+
+#### AWS Resources
+
+- **VPC**: Isolated networks in us-west-2 and us-east-1 (10.0.0.0/16, 4 public subnets each)
+- **ECR**: `vllm-ci-test-cache` (PR builds) and `vllm-ci-postmerge-cache` (main branch) with 14-day lifecycle
+- **S3**: `vllm-build-sccache` for C++ compiler cache, `vllm-wheels` / `vllm-wheels-dev` for wheel binaries
+- **Secrets Manager**: HuggingFace token, Buildkite analytics token
+- **SSM Parameter Store**: Agent tokens, AMI IDs
+
+### GCP
+
+- **GKE** (`terraform/gcp/`): Kubernetes clusters with L4 GPU node pools (g2-standard machines) for containerized agent workloads. Artifact registry with 7-day cleanup.
+- **TPU** (`terraform/gcp_old/`): TPU v5 and v6e nodes for TPU CI and benchmarks, with Buildkite agents installed directly on instances.
+
+### Kubernetes
+
+The `infra-k8s/` directory provides Helm-based deployment of the [Buildkite Agent Stack for Kubernetes](https://github.com/buildkite/agent-stack-k8s). Used primarily for specialized hardware (A100, H100, H200, B200) where pipeline templates generate Kubernetes pod specs with GPU resource requests and shared storage mounts (EFS/FSx for model weights).
+
+## Caching Strategy
+
+Build performance relies on a multi-layer caching approach:
+
+### Docker Layer Cache (BuildKit + ECR)
+
+The bootstrap script resolves cache sources with a fallback chain:
+
+1. **PR-specific cache**: `vllm-ci-test-cache:pr-{number}`
+2. **Base branch cache**: Cache from the PR's target branch
+3. **Main branch cache**: `vllm-ci-postmerge-cache:latest`
+
+Cache is stored as registry refs in private ECR repositories with 14-day expiration.
+
+### Warm-Cache AMI
+
+A daily Buildkite pipeline (`.buildkite/pipelines/rebuild-cpu-ami.yml`, scheduled at 3 AM PST) builds custom EC2 AMIs with pre-warmed Docker layer caches:
+
+1. **Build AMI**: Packer creates an AMI from the Buildkite Elastic Stack base, pre-pulls the latest postmerge Docker image layers into a persistent BuildKit daemon (not docker-container driver), maximizing cache locality.
+2. **Update SSM**: Stores the new AMI ID in AWS SSM Parameter Store.
+3. **Update Launch Templates**: Creates new EC2 Launch Template versions and updates Auto Scaling Groups. Existing instances cycle out naturally (`TerminateInstanceAfterJob=true`).
+4. **Cleanup**: Retains the 3 most recent old AMIs for rollback, deletes older ones.
+
+The warm-cache AMI is used by the `cpu_queue_premerge_us_east_1` and `cpu_queue_postmerge_us_east_1` queues.
+
+### sccache
+
+C++ compilation outputs are cached in S3 (`vllm-build-sccache` in us-west-2), configured via `docker/ci.hcl`.
+
+### Precompiled Wheels
+
+When no critical source files have changed, the CI uses precompiled wheels from the merge-base commit (hosted at `wheels.vllm.ai`) instead of building from source.
+
+## GitHub Runner Groups
+
+The `github/` directory contains Terraform configurations for GitHub Actions runner groups used by partner organizations:
+
+- **Neural Magic** (`group-neural-magic/`): Dedicated runner group for Neural Magic workloads.
+- **IBM** (`group-ibm/`): Dedicated runner group for IBM workloads.
+
+These are deployed with `terraform apply` and require a GitHub PAT with organizational admin permissions.
+
+## Development
+
+### Testing Changes
+
+1. Create a feature branch on this repo (contact @khluu for access if needed).
+2. Push your changes to the branch.
+3. Create a new build on Buildkite with the environment variable:
+   ```
+   VLLM_CI_BRANCH=my-feature-branch
+   ```
+   This tells the bootstrap script to fetch templates from your branch instead of `main`.
+
+**Notes:**
+- Run builds on your own vLLM feature branch/fork, preferably up-to-date with `main`.
+- For fork branches, use the full commit hash (not `HEAD`) and format the branch name as `<fork/username>:<branch>`.
+
+### Key Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `VLLM_CI_BRANCH` | ci-infra branch to use for templates (default: `main`) |
+| `RUN_ALL` | Force all tests to run |
+| `NIGHTLY` | Include optional nightly tests |
+| `VLLM_USE_PRECOMPILED` | Use precompiled wheels (`1`) or build from source (`0`) |
+| `COV_ENABLED` | Enable pytest coverage collection and Codecov upload |
+| `DOCS_ONLY_DISABLE` | Skip docs-only detection (always run CI) |
+| `AMD_MIRROR_HW` | AMD hardware mirror target (default: `amdproduction`) |
+
+### Pre-commit Hooks
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Enforces YAML validation, Python formatting (ruff), spell checking (typos), and GitHub Actions linting (actionlint).
+
+## Onboarding New Runners
+
+Machines communicate with Buildkite via an agent. Three deployment options:
+
+1. **[Elastic CI Stack](https://buildkite.com/docs/agent/v3/elastic-ci-aws/elastic-ci-stack-overview)**: Autoscaling EC2 instances (used by AWS queues).
+2. **[K8s Agent Stack](https://github.com/buildkite/agent-stack-k8s)**: Kubernetes-orchestrated agents (used for specialized GPU hardware).
+3. **[Standalone Agent](https://buildkite.com/docs/agent/v3)**: Direct installation on existing machines.
+
+All options require a Buildkite agent token and queue name. Contact @khluu on `#sig-ci` ([vllm-dev.slack.com](https://vllm-dev.slack.com)) to obtain credentials.
+
+For standalone agents, add the token and queue to the agent config (typically `/etc/buildkite-agent/buildkite-agent.cfg`) and restart the service.
+
+## License
+
+Apache License 2.0


### PR DESCRIPTION
## Summary

- Rewrites the outdated README with full documentation of the CI infrastructure
- Adds repository structure overview, build flow diagram, and smart test selection logic
- Documents AWS infrastructure (agent queues with instance types/limits), GCP (GKE + TPU), and Kubernetes setup
- Covers the multi-layer caching strategy: BuildKit/ECR cache chain, daily warm-cache AMI pipeline, sccache, and precompiled wheels
- Adds environment variable reference table, pipeline template descriptions, and GitHub runner groups section

## Test plan

- [ ] Verify rendered markdown looks correct on GitHub
- [ ] Cross-check queue names and instance types against current Terraform config
- [ ] Confirm all linked URLs are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)