### PR TITLE
Force stop the buildkite-agent and start at the end of startup process

### DIFF
--- a/terraform/gcp_old/tpu-inference/modules/ci_cpu/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cpu/main.tf
@@ -64,6 +64,10 @@ resource "google_compute_instance" "buildkite-agent-instance" {
       echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
       apt-get update
       apt-get install -y bk buildkite-agent
+           
+      # Force stop the buildkite-agent and start at the end to avoid race condition
+      sudo systemctl stop buildkite-agent
+
 
       sudo usermod -a -G docker buildkite-agent
       sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet

--- a/terraform/gcp_old/tpu-inference/modules/ci_cpu_64_core/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cpu_64_core/main.tf
@@ -59,6 +59,9 @@ resource "google_compute_instance" "buildkite-agent-instance" {
       echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
       apt-get update
       apt-get install -y bk buildkite-agent
+           
+      # Force stop the buildkite-agent and start at the end to avoid race condition
+      sudo systemctl stop buildkite-agent
 
       sudo usermod -a -G docker buildkite-agent
       sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet

--- a/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
@@ -58,6 +58,9 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
       apt-get update
       apt-get install -y buildkite-agent
+     
+      # Force stop the buildkite-agent and start at the end to avoid race condition
+      sudo systemctl stop buildkite-agent
 
       sudo usermod -a -G docker buildkite-agent
       sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet

--- a/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
@@ -58,6 +58,9 @@ resource "google_tpu_v2_vm" "tpu_v7x_ci" {
       echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
       apt-get update
       apt-get install -y buildkite-agent
+      
+      # Force stop the buildkite-agent and start at the end to avoid race condition
+      sudo systemctl stop buildkite-agent
 
       sudo usermod -a -G docker buildkite-agent
       sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet


### PR DESCRIPTION
Force stop the bk agent after the installation and start a the end of the startup process to avoid some rare race condition. 

Applying this change to cpus, v6e and v7x since its a safe practice.

### Test
This is tested on tpu7x-2-ci-6-cicd-us-central1-c by pausing the agent and then executed the following commands:

```
yiweiw_google_com@t1v-n-f20d5aa2-w-0:~/ci-infra/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd$ terraform apply \
  -replace='module.ci_v7x_2.google_tpu_v2_vm.tpu_v7x_ci[6]' \
  -target='module.ci_v7x_2.google_tpu_v2_vm.tpu_v7x_ci[6]'
```

The agent successfully recreated with no issue and connected to the Buildkite which proves that this should be a relatively safe change and won't cause issue to the production.

### TF Apply

I will run `terraform apply` after the PR is merged. We don't need to recreate the instances this time, as the new startup scripts will be used automatically when the next restart happens to each machine.