### PR TITLE
[CI] Support custom Buildkite agent tags in pipeline generator

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -115,6 +115,15 @@ def get_agent_queue(step: Step):
         return AgentQueue.GPU_1
 
 
+def _get_step_agents(step: Step) -> Dict[str, str]:
+    # Queue is mandatory for routing in current infra; allow step-level
+    # overrides/additional constraints (e.g. device, mem) via `agents`.
+    agents = {"queue": str(get_agent_queue(step))}
+    if step.agents:
+        agents.update(step.agents)
+    return agents
+
+
 def _get_variables_to_inject() -> Dict[str, str]:
     global_config = get_global_config()
     if global_config["name"] != "vllm_ci":
@@ -229,7 +238,7 @@ def convert_group_step_to_buildkite_step(
                 commands=step_commands,
                 depends_on=step.depends_on,
                 soft_fail=step.soft_fail,
-                agents={"queue": get_agent_queue(step)},
+                agents=_get_step_agents(step),
                 priority=1000 if os.getenv("PRIORITY", "") == "HIGH" else 0
             )
 

--- a/buildkite/pipeline_generator/step.py
+++ b/buildkite/pipeline_generator/step.py
@@ -27,6 +27,7 @@ class Step(BaseModel):
     optional: Optional[bool] = False
     no_plugin: Optional[bool] = False
     mirror: Optional[Dict[str, Dict[str, Any]]] = None
+    agents: Optional[Dict[str, str]] = None
 
     @model_validator(mode="after")
     def validate_multi_node(self) -> Self:


### PR DESCRIPTION
This PR adds support for custom tags in the pipeline generator.

Previously, generated steps only set agents.queue from device-based mapping. ```agents={"queue": get_agent_queue(step)}```
With this change, a step can define additional agent constraints and they will be merged into the generated agents map.