### PR TITLE
Revert continue-on-failure changes

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -152,8 +152,7 @@ def _prepare_commands(step: Step, variables_to_inject: Dict[str, str]) -> List[s
     continue_on_failure = os.getenv("CONTINUE_ON_FAILURE") == "1"
 
     if continue_on_failure:
-        commands.append("__CI_OVERALL_STATUS=0")
-        commands.append("__CI_RESULTS=''")
+        commands.append("CI_OVERALL_STATUS=0")
 
     if step.commands:
         for i, cmd in enumerate(step.commands):
@@ -161,24 +160,12 @@ def _prepare_commands(step: Step, variables_to_inject: Dict[str, str]) -> List[s
             preview = cmd[:80].replace("'", "").replace('"', '').replace('$', '')
             commands.append(f"echo '+++ :test_tube: Command ({i+1}/{len(step.commands)}): {preview}'")
             if continue_on_failure:
-                safe_preview = preview.replace('\\', '').replace('`', '')
-                tag = f"({i+1}/{len(step.commands)}) {safe_preview}"
-                commands.append(
-                    f"({cmd}); __CI_CMD_EXIT=$?; "
-                    f"if [ $__CI_CMD_EXIT -ne 0 ]; then "
-                    f"__CI_OVERALL_STATUS=1; "
-                    f'__CI_RESULTS="$__CI_RESULTS\\n:x: {tag}"; '
-                    f"else "
-                    f'__CI_RESULTS="$__CI_RESULTS\\n:white_check_mark: {tag}"; '
-                    f"fi"
-                )
+                commands.append(f"({cmd}) || CI_OVERALL_STATUS=1")
             else:
                 commands.append(cmd)
 
     if continue_on_failure:
-        commands.append("echo '+++ :bar_chart: Command Summary'")
-        commands.append('echo -e "$__CI_RESULTS"')
-        commands.append("exit $__CI_OVERALL_STATUS")
+        commands.append("exit $$CI_OVERALL_STATUS")
 
     final_commands = []
     for command in commands:

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -153,8 +153,8 @@ def _prepare_commands(step: Step, variables_to_inject: Dict[str, str]) -> List[s
 
     if continue_on_failure:
         commands.append("set +eo pipefail")
-        commands.append("CI_OVERALL_STATUS=0")
-        commands.append("CI_RESULTS=''")
+        commands.append("__CI_OVERALL_STATUS=0")
+        commands.append("__CI_RESULTS=''")
 
     if step.commands:
         for i, cmd in enumerate(step.commands):
@@ -164,17 +164,16 @@ def _prepare_commands(step: Step, variables_to_inject: Dict[str, str]) -> List[s
             if continue_on_failure:
                 safe_preview = preview.replace('\\', '').replace('`', '')
                 tag = f"({i+1}/{len(step.commands)}) {safe_preview}"
-                log_file = f"/tmp/ci_cmd_{i+1}.log"
-                # Use $$ to escape $ from Buildkite pipeline interpolation
+                log_file = f"/tmp/__ci_cmd_{i+1}.log"
                 commands.append(
-                    f"({cmd}) 2>&1 | tee {log_file}; CI_CMD_EXIT=$${{PIPESTATUS[0]}}; "
-                    f"if [ $$CI_CMD_EXIT -ne 0 ]; then "
-                    f"CI_OVERALL_STATUS=1; "
-                    f'CI_RESULTS="$$CI_RESULTS\\n:x: {tag}"; '
-                    f'echo "\\n:x: {tag}\\n" >> /tmp/ci_failures.log; '
-                    f"tail -200 {log_file} >> /tmp/ci_failures.log; "
+                    f"({cmd}) 2>&1 | tee {log_file}; __CI_CMD_EXIT=${{PIPESTATUS[0]}}; "
+                    f"if [ $__CI_CMD_EXIT -ne 0 ]; then "
+                    f"__CI_OVERALL_STATUS=1; "
+                    f'__CI_RESULTS="$__CI_RESULTS\\n:x: {tag}"; '
+                    f'echo "\\n:x: {tag}\\n" >> /tmp/__ci_failures.log; '
+                    f"tail -200 {log_file} >> /tmp/__ci_failures.log; "
                     f"else "
-                    f'CI_RESULTS="$$CI_RESULTS\\n:white_check_mark: {tag}"; '
+                    f'__CI_RESULTS="$__CI_RESULTS\\n:white_check_mark: {tag}"; '
                     f"fi"
                 )
             else:
@@ -182,9 +181,9 @@ def _prepare_commands(step: Step, variables_to_inject: Dict[str, str]) -> List[s
 
     if continue_on_failure:
         commands.append("echo '+++ :bar_chart: Command Summary'")
-        commands.append('echo -e "$$CI_RESULTS"')
-        commands.append('if [ -f /tmp/ci_failures.log ]; then echo ""; echo "--- Failure Details ---"; cat /tmp/ci_failures.log; fi')
-        commands.append("exit $$CI_OVERALL_STATUS")
+        commands.append('echo -e "$__CI_RESULTS"')
+        commands.append('if [ -f /tmp/__ci_failures.log ]; then echo ""; echo "--- Failure Details ---"; cat /tmp/__ci_failures.log; fi')
+        commands.append("exit $__CI_OVERALL_STATUS")
 
     final_commands = []
     for command in commands:

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -152,6 +152,7 @@ def _prepare_commands(step: Step, variables_to_inject: Dict[str, str]) -> List[s
     continue_on_failure = os.getenv("CONTINUE_ON_FAILURE") == "1"
 
     if continue_on_failure:
+        commands.append("set +eo pipefail")
         commands.append("CI_OVERALL_STATUS=0")
         commands.append("CI_RESULTS=''")
 
@@ -164,12 +165,9 @@ def _prepare_commands(step: Step, variables_to_inject: Dict[str, str]) -> List[s
                 safe_preview = preview.replace('\\', '').replace('`', '')
                 tag = f"({i+1}/{len(step.commands)}) {safe_preview}"
                 log_file = f"/tmp/ci_cmd_{i+1}.log"
-                # Use $$ to escape $ from Buildkite pipeline interpolation.
-                # Capture output to file (for failure details), then cat it so it
-                # still appears in the live log. This avoids tee/PIPESTATUS which
-                # require bash, but Buildkite steps may run under /bin/sh.
+                # Use $$ to escape $ from Buildkite pipeline interpolation
                 commands.append(
-                    f"({cmd}) > {log_file} 2>&1; CI_CMD_EXIT=$$?; cat {log_file}; "
+                    f"({cmd}) 2>&1 | tee {log_file}; CI_CMD_EXIT=$${{PIPESTATUS[0]}}; "
                     f"if [ $$CI_CMD_EXIT -ne 0 ]; then "
                     f"CI_OVERALL_STATUS=1; "
                     f'CI_RESULTS="$$CI_RESULTS\\n:x: {tag}"; '

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -152,7 +152,6 @@ def _prepare_commands(step: Step, variables_to_inject: Dict[str, str]) -> List[s
     continue_on_failure = os.getenv("CONTINUE_ON_FAILURE") == "1"
 
     if continue_on_failure:
-        commands.append("set +eo pipefail")
         commands.append("__CI_OVERALL_STATUS=0")
         commands.append("__CI_RESULTS=''")
 
@@ -164,14 +163,11 @@ def _prepare_commands(step: Step, variables_to_inject: Dict[str, str]) -> List[s
             if continue_on_failure:
                 safe_preview = preview.replace('\\', '').replace('`', '')
                 tag = f"({i+1}/{len(step.commands)}) {safe_preview}"
-                log_file = f"/tmp/__ci_cmd_{i+1}.log"
                 commands.append(
-                    f"({cmd}) 2>&1 | tee {log_file}; __CI_CMD_EXIT=${{PIPESTATUS[0]}}; "
+                    f"({cmd}); __CI_CMD_EXIT=$?; "
                     f"if [ $__CI_CMD_EXIT -ne 0 ]; then "
                     f"__CI_OVERALL_STATUS=1; "
                     f'__CI_RESULTS="$__CI_RESULTS\\n:x: {tag}"; '
-                    f'echo "\\n:x: {tag}\\n" >> /tmp/__ci_failures.log; '
-                    f"tail -200 {log_file} >> /tmp/__ci_failures.log; "
                     f"else "
                     f'__CI_RESULTS="$__CI_RESULTS\\n:white_check_mark: {tag}"; '
                     f"fi"
@@ -182,7 +178,6 @@ def _prepare_commands(step: Step, variables_to_inject: Dict[str, str]) -> List[s
     if continue_on_failure:
         commands.append("echo '+++ :bar_chart: Command Summary'")
         commands.append('echo -e "$__CI_RESULTS"')
-        commands.append('if [ -f /tmp/__ci_failures.log ]; then echo ""; echo "--- Failure Details ---"; cat /tmp/__ci_failures.log; fi')
         commands.append("exit $__CI_OVERALL_STATUS")
 
     final_commands = []


### PR DESCRIPTION
## Summary
- Reverts 4 commits added on top of 69b6569 (`feat: add monitoring dashboard and webhook receiver (#336)`)
- Reverted commits:
  - `86547ef` fix: use POSIX-compatible shell for continue-on-failure mode
  - `e93bfde` fix: escape shell variables with $$ for Buildkite pipeline interpolation
  - `9593e16` summary on continue on failure mode
  - `aca0587` summary on continue on failure mode

## Test plan
- [ ] Verify `buildkite_step.py` matches the state at commit 69b6569

🤖 Generated with [Claude Code](https://claude.com/claude-code)