### PR TITLE
adding AMD zen5

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -115,6 +115,8 @@ def get_agent_queue(step: Step):
         return AgentQueue.DGX_SPARK
     elif step.num_devices == 2 or step.num_devices == 4:
         return AgentQueue.GPU_4
+    elif step.device == DeviceType.ZEN5:
+        return AgentQueue.ZEN5
     else:
         return AgentQueue.GPU_1
 

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -290,6 +290,8 @@ def get_agent_queue(step: Step):
         return AgentQueue.DGX_SPARK
     elif step.num_devices == 2 or step.num_devices == 4:
         return AgentQueue.GPU_4
+    elif step.device == DeviceType.ZEN5:
+        return AgentQueue.ZEN5
     else:
         return AgentQueue.GPU_1
 

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -290,8 +290,8 @@ def get_agent_queue(step: Step):
         return AgentQueue.DGX_SPARK
     elif step.num_devices == 2 or step.num_devices == 4:
         return AgentQueue.GPU_4
-    elif step.device == DeviceType.ZEN5:
-        return AgentQueue.ZEN5
+    elif step.device == DeviceType.AMD_ZEN5_CPU:
+        return AgentQueue.AMD_ZEN5_CPU
     else:
         return AgentQueue.GPU_1
 

--- a/buildkite/pipeline_generator/constants.py
+++ b/buildkite/pipeline_generator/constants.py
@@ -30,6 +30,7 @@ class DeviceType(str, Enum):
     AMD_MI355_4 = "mi355_4"
     AMD_MI355_8 = "mi355_8"
     DGX_SPARK = "dgx-spark"
+    ZEN5 = "zen5"
 
 
 class AgentQueue(str, Enum):
@@ -69,3 +70,4 @@ class AgentQueue(str, Enum):
     AMD_MI355_8 = "amd_mi355_8"
     DGX_SPARK = "dgx-spark"
     REDHAT_H100_FRANKFURT = "RedHat-H100-Frankfurt"
+    ZEN5 = "amd-zen5-cpu"

--- a/buildkite/pipeline_generator/constants.py
+++ b/buildkite/pipeline_generator/constants.py
@@ -36,7 +36,7 @@ class DeviceType(str, Enum):
     AMD_MI355_4 = "mi355_4"
     AMD_MI355_8 = "mi355_8"
     DGX_SPARK = "dgx-spark"
-    ZEN5 = "zen5"
+    AMD_ZEN5_CPU = "zen5"
 
 
 class AgentQueue(str, Enum):
@@ -82,4 +82,4 @@ class AgentQueue(str, Enum):
     AMD_MI355_8 = "amd_mi355_8"
     DGX_SPARK = "dgx-spark"
     REDHAT_H100_FRANKFURT = "RedHat-H100-Frankfurt"
-    ZEN5 = "amd-zen5-cpu"
+    AMD_ZEN5_CPU = "amd-zen5-cpu"

--- a/buildkite/pipeline_generator/constants.py
+++ b/buildkite/pipeline_generator/constants.py
@@ -36,6 +36,7 @@ class DeviceType(str, Enum):
     AMD_MI355_4 = "mi355_4"
     AMD_MI355_8 = "mi355_8"
     DGX_SPARK = "dgx-spark"
+    ZEN5 = "zen5"
 
 
 class AgentQueue(str, Enum):
@@ -81,3 +82,4 @@ class AgentQueue(str, Enum):
     AMD_MI355_8 = "amd_mi355_8"
     DGX_SPARK = "dgx-spark"
     REDHAT_H100_FRANKFURT = "RedHat-H100-Frankfurt"
+    ZEN5 = "amd-zen5-cpu"

--- a/buildkite/pipeline_generator/plugin/docker_plugin.py
+++ b/buildkite/pipeline_generator/plugin/docker_plugin.py
@@ -80,6 +80,23 @@ b200_plugin_template = {
     ],
 }
 
+zen5_plugin_template = {
+    "image": "",
+    "always-pull": True,
+    "propagate-environment": True,
+    "environment": [
+        "VLLM_USAGE_SOURCE=ci-test",
+        "NCCL_CUMEM_HOST_ENABLE=0",
+        "HF_HOME",
+        "HF_TOKEN",
+        "CODECOV_TOKEN",
+        "BUILDKITE_ANALYTICS_TOKEN",
+    ],
+    "volumes": [
+        "/dev/shm:/dev/shm",
+        "/mnt/ci-cache:/mnt/ci-cache",
+    ],
+}
 
 def get_docker_plugin(step: Step, image: str):
     plugin = None
@@ -89,6 +106,8 @@ def get_docker_plugin(step: Step, image: str):
         plugin = copy.deepcopy(h200_plugin_template)
     elif step.device == DeviceType.B200:
         plugin = copy.deepcopy(b200_plugin_template)
+    elif step.device == DeviceType.ZEN5:
+        plugin = copy.deepcopy(zen5_plugin_template)
     else:
         plugin = copy.deepcopy(docker_plugin_template)
     plugin["image"] = image

--- a/buildkite/pipeline_generator/plugin/docker_plugin.py
+++ b/buildkite/pipeline_generator/plugin/docker_plugin.py
@@ -104,7 +104,7 @@ b200_plugin_template = {
     ],
 }
 
-zen5_plugin_template = {
+amd_zen5_plugin_template = {
     "image": "",
     "always-pull": True,
     "propagate-environment": True,
@@ -132,8 +132,8 @@ def get_docker_plugin(step: Step, image: str):
         plugin = copy.deepcopy(h200_plugin_template)
     elif step.device == DeviceType.B200:
         plugin = copy.deepcopy(b200_plugin_template)
-    elif step.device == DeviceType.ZEN5:
-        plugin = copy.deepcopy(zen5_plugin_template)
+    elif step.device == DeviceType.AMD_ZEN5_CPU:
+        plugin = copy.deepcopy(amd_zen5_plugin_template)
     else:
         plugin = copy.deepcopy(docker_plugin_template)
     plugin["image"] = image

--- a/buildkite/pipeline_generator/plugin/docker_plugin.py
+++ b/buildkite/pipeline_generator/plugin/docker_plugin.py
@@ -104,6 +104,23 @@ b200_plugin_template = {
     ],
 }
 
+zen5_plugin_template = {
+    "image": "",
+    "always-pull": True,
+    "propagate-environment": True,
+    "environment": [
+        "VLLM_USAGE_SOURCE=ci-test",
+        "NCCL_CUMEM_HOST_ENABLE=0",
+        "HF_HOME",
+        "HF_TOKEN",
+        "CODECOV_TOKEN",
+        "BUILDKITE_ANALYTICS_TOKEN",
+    ],
+    "volumes": [
+        "/dev/shm:/dev/shm",
+        "/mnt/ci-cache:/mnt/ci-cache",
+    ],
+}
 
 def get_docker_plugin(step: Step, image: str):
     plugin = None
@@ -115,6 +132,8 @@ def get_docker_plugin(step: Step, image: str):
         plugin = copy.deepcopy(h200_plugin_template)
     elif step.device == DeviceType.B200:
         plugin = copy.deepcopy(b200_plugin_template)
+    elif step.device == DeviceType.ZEN5:
+        plugin = copy.deepcopy(zen5_plugin_template)
     else:
         plugin = copy.deepcopy(docker_plugin_template)
     plugin["image"] = image


### PR DESCRIPTION
SUMMARY:
- add routing to AMD Zen5 queue

VALIDATION:
- adding `zen5` device didn't break anything, https://buildkite.com/vllm/ci/builds/64501

latest run as of 2026-07-08
https://buildkite.com/vllm/ci/builds/77192
