### PR TITLE
[CI] Gate torch-nightly group on NIGHTLY=1 only, not on branch == main

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -398,7 +398,7 @@ def _create_torch_nightly_group(
     """Create the 'vLLM Against PyTorch Nightly' group with image build + test steps."""
     global_config = get_global_config()
     branch = global_config["branch"]
-    auto_run = global_config["nightly"] == "1" or branch == "main"
+    auto_run = global_config["nightly"] == "1"
 
     nightly_image = get_torch_nightly_image()
     group_steps_list = []


### PR DESCRIPTION
  Post-merge webhook builds on main were auto-running the entire
  "vLLM Against PyTorch Nightly" group because _create_torch_nightly_group
  set auto_run whenever branch == "main", regardless of the NIGHTLY env var.

  Scheduled nightly builds and manual NIGHTLY=1 RUN_ALL=1 triggers already
  set NIGHTLY=1, so gating on that alone is sufficient. PR-side builds are
  unaffected (they still use the existing block-step / file-dependency
  flow). Only post-merge main webhooks change: they now block the nightly
  group instead of auto-running it.


cc @khluu 