### PR TITLE
Add HOST_NAME In TPU V6/V7's env vars

### DIFF
--- a/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
@@ -66,11 +66,12 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 
       sudo sed -i "s/xxx/${var.buildkite_token_value}/g" /etc/buildkite-agent/buildkite-agent.cfg
+      
       HOST_NAME_VAL="${var.accelerator_type}-ci-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}"
-      # Set the system-wide environment variable
+      # Set the system-wide environment variable and make it take effect
       echo "HOST_NAME=$HOST_NAME_VAL" | sudo tee -a /etc/environment
-      # Use the same local variable for the sed command
-      sudo sed -i "s/name=\"%hostname-%spawn\"/name=\"$HOST_NAME_VAL\"/" /etc/buildkite-agent/buildkite-agent.cfg
+      set -a; source /etc/environment; set +a
+      sudo sed -i "s/name=\"%hostname-%spawn\"/name=\"$HOST_NAME\"/" /etc/buildkite-agent/buildkite-agent.cfg
 
       echo 'tags="queue=${var.buildkite_queue_name}"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
       echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment

--- a/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
@@ -68,7 +68,7 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       sudo sed -i "s/xxx/${var.buildkite_token_value}/g" /etc/buildkite-agent/buildkite-agent.cfg
       
       HOST_NAME_VAL="${var.accelerator_type}-ci-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}"
-      # Set the system-wide environment variable and make it take effect, avoid using the default HOSTNAME because it's too vague to be useful. For example, t1v-n-01667781-w-0
+      # Set the system-wide environment variable, avoid using the default HOSTNAME because it's too vague to be useful. For example, t1v-n-01667781-w-0
       echo "HOST_NAME=$HOST_NAME_VAL" | sudo tee -a /etc/environment
       sudo sed -i "s/name=\"%hostname-%spawn\"/name=\"$HOST_NAME_VAL\"/" /etc/buildkite-agent/buildkite-agent.cfg
       echo 'tags="queue=${var.buildkite_queue_name}"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg

--- a/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
@@ -68,11 +68,9 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       sudo sed -i "s/xxx/${var.buildkite_token_value}/g" /etc/buildkite-agent/buildkite-agent.cfg
       
       HOST_NAME_VAL="${var.accelerator_type}-ci-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}"
-      # Set the system-wide environment variable and make it take effect
+      # Set the system-wide environment variable and make it take effect, avoid using the default HOSTNAME because it's too vague to be useful. For example, t1v-n-01667781-w-0
       echo "HOST_NAME=$HOST_NAME_VAL" | sudo tee -a /etc/environment
-      set -a; source /etc/environment; set +a
-      sudo sed -i "s/name=\"%hostname-%spawn\"/name=\"$HOST_NAME\"/" /etc/buildkite-agent/buildkite-agent.cfg
-
+      sudo sed -i "s/name=\"%hostname-%spawn\"/name=\"$HOST_NAME_VAL\"/" /etc/buildkite-agent/buildkite-agent.cfg
       echo 'tags="queue=${var.buildkite_queue_name}"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
       echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment
       echo 'BUILDKITE_ANALYTICS_TOKEN=${var.buildkite_analytics_token_value}' | sudo tee -a /etc/environment

--- a/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
@@ -66,7 +66,12 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 
       sudo sed -i "s/xxx/${var.buildkite_token_value}/g" /etc/buildkite-agent/buildkite-agent.cfg
-      sudo sed -i 's/name="%hostname-%spawn"/name="${var.accelerator_type}-ci-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}"/' /etc/buildkite-agent/buildkite-agent.cfg
+      HOST_NAME_VAL="${var.accelerator_type}-ci-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}"
+      # Set the system-wide environment variable
+      echo "HOST_NAME=$HOST_NAME_VAL" | sudo tee -a /etc/environment
+      # Use the same local variable for the sed command
+      sudo sed -i "s/name=\"%hostname-%spawn\"/name=\"$HOST_NAME_VAL\"/" /etc/buildkite-agent/buildkite-agent.cfg
+
       echo 'tags="queue=${var.buildkite_queue_name}"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
       echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment
       echo 'BUILDKITE_ANALYTICS_TOKEN=${var.buildkite_analytics_token_value}' | sudo tee -a /etc/environment

--- a/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
@@ -68,11 +68,9 @@ resource "google_tpu_v2_vm" "tpu_v7x_ci" {
       sudo sed -i "s/xxx/${var.buildkite_token_value}/g" /etc/buildkite-agent/buildkite-agent.cfg
       
       HOST_NAME_VAL="${var.accelerator_type}-ci-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}"
-      # Set the system-wide environment variable and make it take effect
+      # Set the system-wide environment variable and make it take effect, avoid using the default HOSTNAME because it's too vague to be useful. For example, t1v-n-01667781-w-0
       echo "HOST_NAME=$HOST_NAME_VAL" | sudo tee -a /etc/environment
-      set -a; source /etc/environment; set +a
-      sudo sed -i "s/name=\"%hostname-%spawn\"/name=\"$HOST_NAME\"/" /etc/buildkite-agent/buildkite-agent.cfg
-
+      sudo sed -i "s/name=\"%hostname-%spawn\"/name=\"$HOST_NAME_VAL\"/" /etc/buildkite-agent/buildkite-agent.cfg
       echo 'tags="queue=${var.buildkite_queue_name}"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
       echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment
       echo 'BUILDKITE_ANALYTICS_TOKEN=${var.buildkite_analytics_token_value}' | sudo tee -a /etc/environment

--- a/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
@@ -66,7 +66,13 @@ resource "google_tpu_v2_vm" "tpu_v7x_ci" {
       sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 
       sudo sed -i "s/xxx/${var.buildkite_token_value}/g" /etc/buildkite-agent/buildkite-agent.cfg
-      sudo sed -i 's/name="%hostname-%spawn"/name="${var.accelerator_type}-ci-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}"/' /etc/buildkite-agent/buildkite-agent.cfg
+      
+      HOST_NAME_VAL="${var.accelerator_type}-ci-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}"
+      # Set the system-wide environment variable
+      echo "HOST_NAME=$HOST_NAME_VAL" | sudo tee -a /etc/environment
+      # Use the same local variable for the sed command
+      sudo sed -i "s/name=\"%hostname-%spawn\"/name=\"$HOST_NAME_VAL\"/" /etc/buildkite-agent/buildkite-agent.cfg
+
       echo 'tags="queue=${var.buildkite_queue_name}"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
       echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment
       echo 'BUILDKITE_ANALYTICS_TOKEN=${var.buildkite_analytics_token_value}' | sudo tee -a /etc/environment

--- a/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
@@ -68,10 +68,10 @@ resource "google_tpu_v2_vm" "tpu_v7x_ci" {
       sudo sed -i "s/xxx/${var.buildkite_token_value}/g" /etc/buildkite-agent/buildkite-agent.cfg
       
       HOST_NAME_VAL="${var.accelerator_type}-ci-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}"
-      # Set the system-wide environment variable
+      # Set the system-wide environment variable and make it take effect
       echo "HOST_NAME=$HOST_NAME_VAL" | sudo tee -a /etc/environment
-      # Use the same local variable for the sed command
-      sudo sed -i "s/name=\"%hostname-%spawn\"/name=\"$HOST_NAME_VAL\"/" /etc/buildkite-agent/buildkite-agent.cfg
+      set -a; source /etc/environment; set +a
+      sudo sed -i "s/name=\"%hostname-%spawn\"/name=\"$HOST_NAME\"/" /etc/buildkite-agent/buildkite-agent.cfg
 
       echo 'tags="queue=${var.buildkite_queue_name}"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
       echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment

--- a/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
@@ -68,7 +68,7 @@ resource "google_tpu_v2_vm" "tpu_v7x_ci" {
       sudo sed -i "s/xxx/${var.buildkite_token_value}/g" /etc/buildkite-agent/buildkite-agent.cfg
       
       HOST_NAME_VAL="${var.accelerator_type}-ci-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}"
-      # Set the system-wide environment variable and make it take effect, avoid using the default HOSTNAME because it's too vague to be useful. For example, t1v-n-01667781-w-0
+      # Set the system-wide environment variable, avoid using the default HOSTNAME because it's too vague to be useful. For example, t1v-n-01667781-w-0
       echo "HOST_NAME=$HOST_NAME_VAL" | sudo tee -a /etc/environment
       sudo sed -i "s/name=\"%hostname-%spawn\"/name=\"$HOST_NAME_VAL\"/" /etc/buildkite-agent/buildkite-agent.cfg
       echo 'tags="queue=${var.buildkite_queue_name}"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg

--- a/test.txt
+++ b/test.txt
@@ -1,2 +1,0 @@
-# The name of the agent
-name="asjkld=sdf-sdfjdk-"

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,2 @@
+# The name of the agent
+name="asjkld=sdf-sdfjdk-"


### PR DESCRIPTION
Add HOST_NAME env var and make them effective immediately. The HOST_NAME is the same one we used to replace in the buildkite-agent/buildkite-agent.cfg. At this moment, the HOST_NAME will be used to identify the host when running kernel tuning jobs. It's propagated into the docker container.

I locally run the commands and these command behave as expected.