### PR TITLE
Skip AMD block step when AMD mirror step should auto-run

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -274,12 +274,13 @@ def convert_group_step_to_buildkite_step(
             # Create AMD mirror step and its block step if specified/applicable
             if step.mirror and step.mirror.get("amd"):
                 amd_block_step = None
-                amd_block_step = BuildkiteBlockStep(
-                    block=f"Run AMD: {step.label}",
-                    depends_on=["image-build-amd"],
-                    key=f"block-amd-{_generate_step_key(step.label)}",
-                )
-                amd_mirror_steps.append(amd_block_step)
+                if not _step_should_run(step, list_file_diff):
+                    amd_block_step = BuildkiteBlockStep(
+                        block=f"Run AMD: {step.label}",
+                        depends_on=["image-build-amd"],
+                        key=f"block-amd-{_generate_step_key(step.label)}",
+                    )
+                    amd_mirror_steps.append(amd_block_step)
                 amd_step = _create_amd_mirror_step(step, step_commands, step.mirror["amd"])
                 if amd_block_step:
                     amd_step.depends_on.extend([amd_block_step.key])


### PR DESCRIPTION
## Summary
- AMD mirror steps previously always got a manual block step gating them, even when the underlying step's source file dependencies matched (or `run_all`/nightly was set).
- Mirror the regular-step gating in `convert_group_step_to_buildkite_step`: only emit `block-amd-<key>` when `_step_should_run` returns False. The AMD command step already depends on `image-build-amd`, so the dependency chain stays correct.

## Test plan
- [ ] Generate a pipeline for a PR that touches a source file dep covered by an AMD-mirrored step → AMD step runs without a block.
- [ ] Generate a pipeline for an unrelated PR → AMD step is still gated behind `block-amd-<key>`.
- [ ] Verify `run_all` and nightly modes auto-run AMD mirror steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)