### PR TITLE
Disable expandable_segments for h200_18gb MIG docker plugin

### DIFF
--- a/buildkite/pipeline_generator/plugin/docker_plugin.py
+++ b/buildkite/pipeline_generator/plugin/docker_plugin.py
@@ -29,6 +29,7 @@ h200_18gb_plugin_template = {
     "environment": [
         "VLLM_USAGE_SOURCE=ci-test",
         "NCCL_CUMEM_HOST_ENABLE=0",
+        "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False",
         "HF_TOKEN",
         "HF_HOME",
         "CODECOV_TOKEN",

--- a/buildkite/pipeline_generator/plugin/docker_plugin.py
+++ b/buildkite/pipeline_generator/plugin/docker_plugin.py
@@ -29,7 +29,7 @@ h200_18gb_plugin_template = {
     "environment": [
         "VLLM_USAGE_SOURCE=ci-test",
         "NCCL_CUMEM_HOST_ENABLE=0",
-        "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False",
+        "PYTORCH_CUDA_ALLOC_CONF=backend:cudaMallocAsync",
         "HF_TOKEN",
         "HF_HOME",
         "CODECOV_TOKEN",

--- a/buildkite/pipeline_generator/plugin/docker_plugin.py
+++ b/buildkite/pipeline_generator/plugin/docker_plugin.py
@@ -29,7 +29,7 @@ h200_18gb_plugin_template = {
     "environment": [
         "VLLM_USAGE_SOURCE=ci-test",
         "NCCL_CUMEM_HOST_ENABLE=0",
-        "PYTORCH_CUDA_ALLOC_CONF=backend:cudaMallocAsync",
+        "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False",
         "HF_TOKEN",
         "HF_HOME",
         "CODECOV_TOKEN",


### PR DESCRIPTION
## Summary
- Add `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False` to the h200_18gb docker plugin environment
- This fixes a PyTorch NVML assertion failure that prevents most vLLM tests from running on H200 18GB MIG partitions

## Problem
When running vLLM CI jobs on H200 18GB MIG partitions, PyTorch's `CUDACachingAllocator` crashes with:
```
RuntimeError: NVML_SUCCESS == r INTERNAL ASSERT FAILED at
"/pytorch/c10/cuda/CUDACachingAllocator.cpp":1165
```

The expandable segments feature (default in PyTorch 2.11) uses NVML to query device memory info. On MIG partitions, these NVML calls to the parent GPU fail with permission errors, causing the assertion.

## Fix
Setting `expandable_segments:False` forces PyTorch to use traditional `cudaMalloc` instead of the virtual memory + NVML path. This is safe for single-GPU MIG workloads.

## Validation
Tested in Buildkite build [#65789](https://buildkite.com/vllm/ci/builds/65789) — this was the root cause for 45+ out of 53 job failures when migrating `gpu_1_queue` jobs to h200_18gb MIG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)