### PR TITLE
Setup the GCS bucket to store the centralized jax compilation cache

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -130,3 +130,10 @@ module "ci_monitoring" {
   org_slug              = "tpu-commons"
   buildkite_token_value = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
 }
+
+module "ci_cache_storage" {
+  source = "../modules/ci_cache_storage"
+
+  project_id  = var.project_id
+  bucket_name = "ullm-ci-cache"
+}

--- a/terraform/gcp_old/tpu-inference/modules/ci_cache_storage/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cache_storage/main.tf
@@ -1,0 +1,25 @@
+resource "google_storage_bucket" "jax_cache_bucket" {
+  name                        = var.bucket_name
+  project                     = var.project_id
+  location                    = var.location
+  force_destroy               = false
+  uniform_bucket_level_access = true
+  storage_class               = "STANDARD"
+
+  # Auto garbage collection(guarantee the rsync performance)
+  lifecycle_rule {
+    condition {
+      age = var.lifecycle_age_days
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  # Import the existing bucket without destroy it
+  lifecycle {
+    ignore_changes = [
+      project
+    ]
+  }
+}

--- a/terraform/gcp_old/tpu-inference/modules/ci_cache_storage/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cache_storage/variables.tf
@@ -1,0 +1,21 @@
+variable "project_id" {
+  type        = string
+  description = "The GCP Project ID where the JAX cache bucket will be hosted."
+}
+
+variable "bucket_name" {
+  type        = string
+  description = "Custom name for the JAX compilation cache GCS bucket."
+}
+
+variable "location" {
+  type        = string
+  default     = "us-central1"
+  description = "GCP region for the storage bucket. Should match TPU region for minimal latency."
+}
+
+variable "lifecycle_age_days" {
+  type        = number
+  default     = 30
+  description = "Number of days before stale cache folders/files are automatically deleted by GCS GC."
+}


### PR DESCRIPTION
setup the bucket to store the later centralized jax compilation cache from the CI test and benchmark.