### PR TITLE
Prevent TPU VM root disk exhaustion via aggressive logrotate

### DIFF
--- a/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
@@ -105,6 +105,13 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
       sudo bash add-google-cloud-ops-agent-repo.sh --also-install
 
+      # Inject ultra-strict limit policy for syslog and kern.log (50M, 1 backup)
+      echo "Configuring strict logrotate for syslog and kern.log..."
+      sudo sed -i '1i/var/log/syslog\n/var/log/kern.log\n{\n  size 50M\n  rotate 1\n  missingok\n  notifempty\n  compress\n  delaycompress\n  postrotate\n    /usr/lib/rsyslog/rsyslog-rotate\n  endscript\n}\n' /etc/logrotate.d/rsyslog
+      
+      # Force rotate once
+      sudo logrotate -f /etc/logrotate.conf
+
       systemctl enable buildkite-agent
       systemctl start buildkite-agent
     EOF

--- a/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
@@ -105,6 +105,13 @@ resource "google_tpu_v2_vm" "tpu_v7x_ci" {
       curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
       sudo bash add-google-cloud-ops-agent-repo.sh --also-install
 
+      # Inject ultra-strict limit policy for syslog and kern.log (50M, 1 backup)
+      echo "Configuring strict logrotate for syslog and kern.log..."
+      sudo sed -i '1i/var/log/syslog\n/var/log/kern.log\n{\n  size 50M\n  rotate 1\n  missingok\n  notifempty\n  compress\n  delaycompress\n  postrotate\n    /usr/lib/rsyslog/rsyslog-rotate\n  endscript\n}\n' /etc/logrotate.d/rsyslog
+      
+      # Force rotate once
+      sudo logrotate -f /etc/logrotate.conf
+
       systemctl enable buildkite-agent
       systemctl start buildkite-agent
     EOF


### PR DESCRIPTION
Updates the Terraform startup-script for the TPU CI nodes to inject a strict, aggressive logrotate policy specifically for /var/log/syslog and /var/log/kern.log.

Example of a current disk full VM:
```
70G	/var
62G	/var/log
30G	/var/log/syslog
30G	/var/log/kern.log
```

New limits: Max size of 50MB per file, retaining only 1 backup (rotate 1).

### Why this will NOT affect Buildkite logs:
This change is safe for our CI log visibility.

Log Isolation: The Buildkite Agent captures the stdout and stderr streams directly from the executed pipeline processes in memory and streams them over HTTPS to Buildkite's.

Zero Intersection: CI test outputs are never written to the OS-level /var/log/syslog or kern.log. Truncating these system logs will only discard underlying Ubuntu OS/hardware events, leaving the Buildkite console output completely unaffected.