### PR TITLE
fix(packer): add docker logout to prevent ECR tokens baking into AMI

### DIFF
--- a/packer/cpu/scripts/warm-cache.sh
+++ b/packer/cpu/scripts/warm-cache.sh
@@ -92,4 +92,8 @@ echo "BuildKit storage:"
 du -sh /var/lib/buildkit 2>/dev/null || echo "Cannot access /var/lib/buildkit without sudo"
 
 echo ""
+echo "Logging out from ECR to ensure credentials are not baked into the AMI..."
+docker logout "$ECR_REGISTRY"
+
+echo ""
 echo "=== Cache warming complete ==="


### PR DESCRIPTION
Ensure ~/.docker/config.json is purged of AWS ECR authentication tokens before VM snapshot creation.

BUG=b/510376817
TAG=agy
CONV=6bcb63c6-cb7f-4d40-944e-bda1812826ed