### PR TITLE
Support soft_fail in AMD mirror blocks

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -397,7 +397,7 @@ def _create_amd_mirror_step(step: Step, original_commands: List[str], amd: Dict[
         agents={"queue": amd_queue},
         env={"DOCKER_BUILDKIT": "1", "VLLM_TEST_COMMANDS": amd_commands_str},
         priority=200,
-        soft_fail=False,
+        soft_fail=amd.get("soft_fail", step.soft_fail or False),
         retry=None,
         parallelism=step.parallelism,
     )


### PR DESCRIPTION
## Summary
- The pipeline generator hardcoded `soft_fail=False` for all AMD mirror steps in `_create_amd_mirror_step()`
- Now reads `soft_fail` from the `mirror.amd` config dict, falling back to the parent step's `soft_fail` value, then `False`
- This allows vllm test YAML to set `soft_fail: true` per AMD mirror block without needing a separate step definition

## Test plan
- [ ] Verify pipeline generator still produces correct YAML for steps without `soft_fail` in mirror block (default `False`)
- [ ] Verify steps with `soft_fail: true` in mirror.amd block produce Buildkite steps with `soft_fail: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)