### PR TITLE
Reduce the lifecycle of the persistent jax cache

### DIFF
--- a/terraform/gcp_old/tpu-inference/modules/ci_cache_storage/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cache_storage/main.tf
@@ -22,4 +22,8 @@ resource "google_storage_bucket" "jax_cache_bucket" {
       project
     ]
   }
+
+  soft_delete_policy {
+    retention_duration_seconds = var.retention_seconds
+  }
 }

--- a/terraform/gcp_old/tpu-inference/modules/ci_cache_storage/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cache_storage/variables.tf
@@ -16,6 +16,13 @@ variable "location" {
 
 variable "lifecycle_age_days" {
   type        = number
-  default     = 30
+  default     = 7
   description = "Number of days before stale cache folders/files are automatically deleted by GCS GC."
 }
+
+variable "retention_seconds" {
+  type        = number
+  default     = 0
+  description = "Number of seconds for the objects to be kept within GCS after the deletion."
+}
+


### PR DESCRIPTION
The Jax cache files growing really fast and taking lots of space on the CI machines. We need to reduce the lifecycle of the cache files. The rsync latency will be distributed to each runs.

```
  # module.ci_cache_storage.google_storage_bucket.jax_cache_bucket will be updated in-place
  ~ resource "google_storage_bucket" "jax_cache_bucket" {
        id                          = "ullm-ci-cache"
        name                        = "ullm-ci-cache"
        # (17 unchanged attributes hidden)

      ~ lifecycle_rule {
          - condition {
              - age                                     = 30 -> null
              - days_since_custom_time                  = 0 -> null
              - days_since_noncurrent_time              = 0 -> null
              - matches_prefix                          = [] -> null
              - matches_storage_class                   = [] -> null
              - matches_suffix                          = [] -> null
              - num_newer_versions                      = 0 -> null
              - send_age_if_zero                        = false -> null
              - send_days_since_custom_time_if_zero     = false -> null
              - send_days_since_noncurrent_time_if_zero = false -> null
              - send_num_newer_versions_if_zero         = false -> null
              - with_state                              = "ANY" -> null
                # (3 unchanged attributes hidden)
            }
          + condition {
              + age                    = 7
              + matches_prefix         = []
              + matches_storage_class  = []
              + matches_suffix         = []
              + with_state             = (known after apply)
                # (3 unchanged attributes hidden)
            }

            # (1 unchanged block hidden)
        }

      ~ soft_delete_policy {
          ~ retention_duration_seconds = 604800 -> 0
            # (1 unchanged attribute hidden)
        }

        # (1 unchanged block hidden)
    }

```