### PR TITLE
fix(buildkite): remove evaluation of untrusted local python scripts

### DIFF
--- a/buildkite/bootstrap-amd.sh
+++ b/buildkite/bootstrap-amd.sh
@@ -156,13 +156,6 @@ upload_pipeline() {
         "https://raw.githubusercontent.com/vllm-project/ci-infra/$VLLM_CI_BRANCH/buildkite/test-template-amd.j2?$(date +%s)"
 
 
-    # (WIP) Use pipeline generator instead of jinja template
-    if [ -e ".buildkite/pipeline_generator/pipeline_generator.py" ]; then
-        python -m pip install click pydantic
-        python .buildkite/pipeline_generator/pipeline_generator.py --run_all=$RUN_ALL --list_file_diff="$LIST_FILE_DIFF" --nightly="$NIGHTLY" --torch_nightly="$TORCH_NIGHTLY" --mirror_hw="$AMD_MIRROR_HW"
-        buildkite-agent pipeline upload .buildkite/pipeline.yaml
-        exit 0
-    fi
     echo "List file diff: $LIST_FILE_DIFF"
     echo "Run all: $RUN_ALL"
     echo "Nightly: $NIGHTLY"


### PR DESCRIPTION
Remove the WIP feature in bootstrap-amd.sh that unconditionally executes .buildkite/pipeline_generator/pipeline_generator.py from the untrusted pull request checkout workspace, preventing arbitrary code execution on CI runner instances.

All standard vLLM pull requests and nightly workflows use the established Jinja templating engine (test-template-amd.j2), so this code block is completely unused by standard jobs.

Signed-off-by: Jincheng Chen <chenjincheng@google.com>

BUG=b/510375628
TAG=agy
CONV=b0c467aa-15c4-4a1c-90eb-dd47e74ade75