### PR TITLE
Scale up multihost VM machines disk

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-tpu-inference-test/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-tpu-inference-test/main.tf
@@ -49,6 +49,7 @@ module "ci_v6e_8" {
   accelerator_type                 = "v6e-8"
   reserved                         = true
   instance_count                   = 9
+  disk_size                        = 4096
   buildkite_queue_name             = "tpu_v6e_8_queue"
   project_id                       = var.project_id
   project_short_name               = var.project_short_name


### PR DESCRIPTION
v6e-8 VMs are used to run multihost tests and benchmarks. Current disk size is 2T but only `Qwen3-Coder-480B` and `Qwen3.5-397B-A17B` will take near 1T disk.

Scale the v6e-8 up to 4T just like the current disk size for v7x-8 which runs similar test/bm suite. 

```
yiweiw_google_com@t1v-n-2d23b80a-w-0:/mnt/disks/persist/models/hub$ sudo du -sh /mnt/disks/persist/models/hub/* | sort -hr
450G	/mnt/disks/persist/models/hub/models--Qwen--Qwen3-Coder-480B-A35B-Instruct-FP8
379G	/mnt/disks/persist/models/hub/models--Qwen--Qwen3.5-397B-A17B-FP8
203G	/mnt/disks/persist/models/hub/models--meta-llama--Llama-4-Scout-17B-16E-Instruct
...
```