### PR TITLE
[ROCm] Bugfix to enable amd ci if pipeline is generated

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -319,14 +319,6 @@ def _step_should_run(step: Step, list_file_diff: List[str]) -> bool:
         return False
     global_config = get_global_config()
     if step.key and step.key.startswith("image-build"):
-        # The shared AMD image build stays on-demand for non-main branches,
-        # except on scheduled nightlies where it should run automatically.
-        if (
-            step.key == "image-build-amd"
-            and global_config["branch"] != "main"
-            and global_config["nightly"] != "1"
-        ):
-            return False
         return True
     if global_config["nightly"] == "1":
         return True

--- a/buildkite/test-template-amd.j2
+++ b/buildkite/test-template-amd.j2
@@ -36,18 +36,8 @@
         agents:
           queue: amd-cpu
 
-      {% if branch != "main" and nightly != "1" %}
-      - block: "Run AMD ROCm image build"
-        depends_on: "amd-ci-base-ready"
-        key: "block-amd-build"
-      {% endif %}
-
       - label: "AMD: :docker: build image"
-        {% if branch == "main" or nightly == "1" %}
         depends_on: "amd-ci-base-ready"
-        {% else %}
-        depends_on: "block-amd-build"
-        {% endif %}
         soft_fail: false
         commands:
           - |


### PR DESCRIPTION
After this change, the AMD ROCm image build will run automatically whenever the AMD CI pipeline is generated. There were some cases where the reviewer needed to manually enable `Run AMD ROCm image build`.