### PR TITLE
Add intel GPU agent tags support

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -10,6 +10,15 @@ from plugin.docker_plugin import get_docker_plugin
 from constants import DeviceType, AgentQueue
 
 
+def _get_step_agents(step: Step) -> Dict[str, str]:
+    agents = {"queue": get_agent_queue(step)}
+    if step.device == DeviceType.INTEL_GPU and step.agent_tags:
+        agents.update(
+            {key: value for key, value in step.agent_tags.items() if key != "queue"}
+        )
+    return agents
+
+
 class BuildkiteCommandStep(BaseModel):
     label: str
     group: Optional[str] = None
@@ -245,7 +254,7 @@ def convert_group_step_to_buildkite_step(
                 commands=step_commands,
                 depends_on=step.depends_on,
                 soft_fail=step.soft_fail,
-                agents={"queue": get_agent_queue(step)},
+                agents=_get_step_agents(step),
                 priority=1000 if os.getenv("PRIORITY", "") == "HIGH" else 0
             )
 
@@ -517,7 +526,7 @@ def _create_torch_nightly_group(
             commands=step_commands,
             depends_on=[block_key] if blocked else ["image-build-torch-nightly"],
             soft_fail=True,
-            agents={"queue": get_agent_queue(step)},
+            agents=_get_step_agents(step),
             parallelism=step.parallelism,
             retry={
                 "automatic": [

--- a/buildkite/pipeline_generator/step.py
+++ b/buildkite/pipeline_generator/step.py
@@ -16,6 +16,7 @@ class Step(BaseModel):
     depends_on: Optional[List[str]] = None
     commands: Optional[List[str]] = None
     device: Optional[str] = None
+    agent_tags: Optional[Dict[str, str]] = None
     num_devices: Optional[int] = None
     num_nodes: Optional[int] = None
     source_file_dependencies: Optional[List[str]] = None


### PR DESCRIPTION
This pull request adds optional `agent_tags` support for Intel GPU CI steps in the Buildkite pipeline generator.

At the moment, Intel GPU jobs are routed through the same `intel-gpu` queue. In practice, however, the Intel CI fleet is heterogeneous and includes multiple device types such as B50, B60, and B70. Allowing additional agent tags makes it possible to target these device types more precisely while preserving the existing queue-based scheduling model.

## Motivation

The Intel GPU CI fleet consists of multiple hardware variants, and different jobs may be better suited to different Intel GPU device types. Without additional agent tag selection, scheduling flexibility is limited and can place unnecessary pressure on a subset of available machines.

By introducing optional agent tags for Intel GPU jobs, we can make more effective use of the available B50, B60, and B70 capacity and improve scheduling flexibility without changing the current queue model.

## Changes Introduced

This change adds an optional `agent_tags` field for pipeline steps.

For steps configured with `device: intel_gpu`:

- the queue continues to be determined by the existing `device -> queue` mapping logic
- additional Buildkite agent tags may be specified through `agent_tags`
- `agent_tags` cannot be used to override the queue selection

## Scope and Compatibility

This change is intentionally limited in scope:

- it applies only to steps using the Intel GPU queue
- the existing queue selection logic remains unchanged
- existing pipeline structure and YAML configurations continue to work as before
- no behavior is changed for non-Intel-GPU steps

## Rationale

This approach is intended to be the smallest and safest change that enables more flexible Intel GPU scheduling, without altering the existing queue model or unnecessarily expanding the pipeline schema.