### PR TITLE
Soft-fail Intel CPU queue and CPU-* jobs

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -129,6 +129,21 @@ def get_agent_queue(step: Step):
         return AgentQueue.GPU_1
 
 
+def _should_soft_fail(step: Step) -> bool:
+    """Whether the step should be soft-failed.
+
+    Soft-fail any job that runs on the Intel CPU queue or whose label starts
+    with "CPU-", in addition to steps that already opt into soft_fail.
+    """
+    if step.soft_fail:
+        return True
+    if get_agent_queue(step) == AgentQueue.INTEL_CPU:
+        return True
+    if step.label.startswith("CPU-"):
+        return True
+    return False
+
+
 def _get_variables_to_inject() -> Dict[str, str]:
     global_config = get_global_config()
     if global_config["name"] != "vllm_ci":
@@ -244,7 +259,7 @@ def convert_group_step_to_buildkite_step(
                 label=step.label,
                 commands=step_commands,
                 depends_on=step.depends_on,
-                soft_fail=step.soft_fail,
+                soft_fail=_should_soft_fail(step),
                 agents={"queue": get_agent_queue(step)},
                 priority=1000 if os.getenv("PRIORITY", "") == "HIGH" else 0
             )


### PR DESCRIPTION
## What

Force `soft_fail: true` on every generated Buildkite step that either:

- runs on the **`intel-cpu`** agent queue (`AgentQueue.INTEL_CPU`), or
- has a **label starting with `CPU-`**.

Steps that already opt into `soft_fail` keep it.

## Why

Failures in these jobs should not block the pipeline.

## How

Added a `_should_soft_fail(step)` helper in [`buildkite/pipeline_generator/buildkite_step.py`](buildkite/pipeline_generator/buildkite_step.py) and use it when constructing each `BuildkiteCommandStep` instead of passing `step.soft_fail` directly. The queue check reuses `get_agent_queue(step)`, so it tracks however a step gets routed to `intel-cpu`.

## Verification

Sanity-checked the matcher against representative steps:

| label | resolved queue | soft_fail |
|---|---|---|
| `Some Intel test` (device `intel_cpu`) | `intel-cpu` | ✅ true |
| `CPU-1-test` (device `cpu`) | `cpu_queue_premerge_us_east_1` | ✅ true |
| `CPU-2-no-device` | `gpu_1_queue` | ✅ true |
| `GPU test` | `gpu_1_queue` | false |
| `whatever` (`soft_fail=True`) | `gpu_1_queue` | ✅ true (preserved) |
| `cpu lowercase test` (device `cpu`) | `cpu_queue_premerge_us_east_1` | false |

The `CPU-` match is case-sensitive and prefix-only, so it targets exactly the `CPU-*` named jobs without catching unrelated lowercase `cpu` steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)