### PR TITLE
Export TPU_VERSION and setup GCS Fuse on host VMs

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -1,5 +1,5 @@
 data "google_secret_manager_secret_version" "buildkite_agent_token_ci_cluster" {
-  secret = "projects/${var.secret_project_id}/secrets/tpu_commons_buildkite_agent_token"
+  secret  = "projects/${var.secret_project_id}/secrets/tpu_commons_buildkite_agent_token"
   version = "latest"
 }
 
@@ -14,126 +14,128 @@ data "google_secret_manager_secret_version" "huggingface_token" {
 }
 
 module "ci_v6e_1" {
-  source    = "../modules/ci_v6e"
+  source = "../modules/ci_v6e"
   providers = {
     google-beta = google-beta.us-central1-b
   }
 
-  accelerator_type                 = "v6e-1"
-  reserved                         = true
-  instance_count                   = 30
-  disk_size                        = 1024
-  buildkite_queue_name             = "tpu_v6e_queue"
-  project_id                       = var.project_id
-  project_short_name               = var.project_short_name
-  buildkite_token_value            = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
-  buildkite_analytics_token_value  = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
-  huggingface_token_value          = data.google_secret_manager_secret_version.huggingface_token.secret_data
+  accelerator_type                = "v6e-1"
+  reserved                        = true
+  instance_count                  = 30
+  disk_size                       = 1024
+  buildkite_queue_name            = "tpu_v6e_queue"
+  project_id                      = var.project_id
+  project_short_name              = var.project_short_name
+  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
+  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
+  huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
 }
 
 module "ci_v6e_8" {
-  source    = "../modules/ci_v6e"
+  source = "../modules/ci_v6e"
   providers = {
     google-beta = google-beta.us-central1-b
   }
 
-  accelerator_type                 = "v6e-8"
-  reserved                         = true
-  instance_count                   = 0
-  buildkite_queue_name             = "tpu_v6e_8_queue"
-  project_id                       = var.project_id
-  project_short_name               = var.project_short_name
-  buildkite_token_value            = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
-  buildkite_analytics_token_value  = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
-  huggingface_token_value          = data.google_secret_manager_secret_version.huggingface_token.secret_data
+  accelerator_type                = "v6e-8"
+  reserved                        = true
+  instance_count                  = 0
+  buildkite_queue_name            = "tpu_v6e_8_queue"
+  project_id                      = var.project_id
+  project_short_name              = var.project_short_name
+  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
+  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
+  huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
 }
 
 
 module "ci_v7x_2" {
-  source    = "../modules/ci_v7x"
+  source = "../modules/ci_v7x"
   providers = {
     google-beta = google-beta.us-central1-c
   }
 
-  accelerator_type                 = "tpu7x-2"
-  reserved                         = true
-  instance_count                   = 16
-  buildkite_queue_name             = "tpu_v7x_2_queue"
-  disk_size                        = 2048
-  project_id                       = var.project_id
-  project_short_name               = var.project_short_name
-  buildkite_token_value            = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
-  buildkite_analytics_token_value  = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
-  huggingface_token_value          = data.google_secret_manager_secret_version.huggingface_token.secret_data
+  accelerator_type                = "tpu7x-2"
+  reserved                        = true
+  instance_count                  = 16
+  buildkite_queue_name            = "tpu_v7x_2_queue"
+  disk_size                       = 2048
+  project_id                      = var.project_id
+  project_short_name              = var.project_short_name
+  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
+  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
+  huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
 }
 
 module "ci_v7x_8" {
-  source    = "../modules/ci_v7x"
+  source = "../modules/ci_v7x"
   providers = {
     google-beta = google-beta.us-central1-c
   }
 
-  accelerator_type                 = "tpu7x-8"
-  reserved                         = true
-  instance_count                   = 13
-  buildkite_queue_name             = "tpu_v7x_8_queue"
-  disk_size                        = 4096
-  project_id                       = var.project_id
-  project_short_name               = var.project_short_name
-  buildkite_token_value            = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
-  buildkite_analytics_token_value  = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
-  huggingface_token_value          = data.google_secret_manager_secret_version.huggingface_token.secret_data
+  accelerator_type                = "tpu7x-8"
+  reserved                        = true
+  instance_count                  = 13
+  buildkite_queue_name            = "tpu_v7x_8_queue"
+  disk_size                       = 4096
+  project_id                      = var.project_id
+  project_short_name              = var.project_short_name
+  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
+  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
+  huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
 }
 
 module "ci_cpu_64_core" {
-  source    = "../modules/ci_cpu_64_core"
+  source = "../modules/ci_cpu_64_core"
   providers = {
     google-beta = google-beta.us-central1-b
   }
 
-  project_id              = var.project_id
-  instance_count          = 4
-  machine_type            = "n2-standard-64"
-  disk_size               = 250
-  disk_type               = "pd-balanced"
-  buildkite_queue_name    = "cpu_64_core"
+  project_id           = var.project_id
+  instance_count       = 4
+  machine_type         = "n2-standard-64"
+  disk_size            = 250
+  disk_type            = "pd-balanced"
+  buildkite_queue_name = "cpu_64_core"
 
   buildkite_token_value   = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
   huggingface_token_value = data.google_secret_manager_secret_version.huggingface_token.secret_data
 }
 
 module "ci_cpu_64_core_zone_c" {
-  source    = "../modules/ci_cpu_64_core"
+  source = "../modules/ci_cpu_64_core"
   providers = {
     google-beta = google-beta.us-central1-c
   }
-  resource_suffix = "-zone-c"
-  project_id              = var.project_id
-  instance_count          = 4
-  machine_type            = "n2-standard-64"
-  disk_size               = 250
-  disk_type               = "pd-balanced"
-  buildkite_queue_name    = "cpu_64_core"
+  resource_suffix      = "-zone-c"
+  project_id           = var.project_id
+  instance_count       = 4
+  machine_type         = "n2-standard-64"
+  disk_size            = 250
+  disk_type            = "pd-balanced"
+  buildkite_queue_name = "cpu_64_core"
 
   buildkite_token_value   = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
   huggingface_token_value = data.google_secret_manager_secret_version.huggingface_token.secret_data
 }
 
 module "ci_monitoring" {
-  source    = "../modules/ci_monitoring"
+  source = "../modules/ci_monitoring"
   providers = {
     google-beta = google-beta.us-central1-b
   }
 
-  project_id            = var.project_id
-  pipeline_slug         = "tpu-inference-ci"
-  org_slug              = "tpu-commons"
+  project_id                = var.project_id
+  pipeline_slug             = "tpu-inference-ci"
+  org_slug                  = "tpu-commons"
   buildkite_token_secret_id = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret
 }
 
 module "ci_cache_storage" {
   source = "../modules/ci_cache_storage"
 
-  project_id  = var.project_id
-  bucket_name = "ullm-ci-cache"
+  project_id         = var.project_id
+  bucket_name        = "ullm-ci-cache"
+  cache_zones        = ["us-central1-b", "us-central1-c"]
+  lifecycle_age_days = 4
 }

--- a/terraform/gcp_old/tpu-inference/modules/ci_cache_storage/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cache_storage/main.tf
@@ -27,3 +27,12 @@ resource "google_storage_bucket" "jax_cache_bucket" {
     retention_duration_seconds = var.retention_seconds
   }
 }
+
+resource "google_storage_anywhere_cache" "jax_cache" {
+  provider = google-beta
+  for_each = toset(var.cache_zones)
+
+  bucket = google_storage_bucket.jax_cache_bucket.name
+  zone   = each.value
+  ttl    = "86400s"
+}

--- a/terraform/gcp_old/tpu-inference/modules/ci_cache_storage/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cache_storage/variables.tf
@@ -26,3 +26,9 @@ variable "retention_seconds" {
   description = "Number of seconds for the objects to be kept within GCS after the deletion."
 }
 
+variable "cache_zones" {
+  type        = list(string)
+  default     = []
+  description = "The zones where Rapid Cache (Anywhere Cache) should be enabled for the bucket."
+}
+

--- a/terraform/gcp_old/tpu-inference/modules/ci_v5/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v5/main.tf
@@ -69,6 +69,7 @@ resource "google_tpu_v2_vm" "tpu_v5" {
       sudo sed -i 's/name="%hostname-%spawn"/name="vllm-tpu-${count.index}"/' /etc/buildkite-agent/buildkite-agent.cfg
       echo 'tags="queue=tpu_v5_queue"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
       echo 'HF_TOKEN=${local.huggingface_token_value}' | sudo tee -a /etc/environment
+      echo 'TPU_VERSION=tpu5' | sudo tee -a /etc/environment
 
       sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/sdb
       sudo mkdir -p /mnt/disks/persist
@@ -78,6 +79,52 @@ resource "google_tpu_v2_vm" "tpu_v5" {
       systemctl stop docker
       systemctl daemon-reload
       systemctl start docker
+
+      # ==========================================
+      # 1. JAX Cache Setup via GCS FUSE
+      # ==========================================
+      echo "Installing gcsfuse..."
+      export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s`
+      curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo tee /usr/share/keyrings/google-cloud.asc > /dev/null
+      echo "deb [signed-by=/usr/share/keyrings/google-cloud.asc] https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
+
+      sudo apt-get update
+      sudo apt-get install -y gcsfuse
+
+      # Configure FUSE to allow other users (CI Agent / Docker Containers)
+      sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
+
+      # Create local buffer cache directory on the local disk
+      sudo mkdir -p /var/cache/gcsfuse
+      sudo chmod 777 /var/cache/gcsfuse
+
+      # Create target mount point and apply Safety Lock (immutable attribute)
+      # This prevents any writes from falling back to the persistent disk if FUSE drops.
+      sudo mkdir -p /mnt/disks/persist/tpu_jax_cache
+      sudo chmod 777 /mnt/disks/persist/tpu_jax_cache
+      sudo chattr +i /mnt/disks/persist/tpu_jax_cache
+
+      # Setting up backward compatibility symlink for legacy CI jobs
+      sudo rm -rf /tmp/tpu_jax_cache
+      sudo ln -s /mnt/disks/persist/tpu_jax_cache /tmp/tpu_jax_cache
+
+      echo "Mounting GCS bucket: ullm-ci-cache..."
+      if sudo gcsfuse \
+          --implicit-dirs \
+          --file-cache-max-size-mb=10240 \
+          --cache-dir=/var/cache/gcsfuse \
+          --dir-mode=777 \
+          --file-mode=777 \
+          -o allow_other \
+          ullm-ci-cache \
+          /mnt/disks/persist/tpu_jax_cache; then
+        
+        echo "GCS FUSE mount successful."
+        echo 'CI_CACHE_FUSE_MOUNTED=1' | sudo tee -a /etc/environment
+      else
+        echo "ERROR: Failed to mount GCS FUSE bucket."
+        exit 1
+      fi
 
       systemctl enable buildkite-agent
       systemctl start buildkite-agent

--- a/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
@@ -74,6 +74,7 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       echo 'tags="queue=${var.buildkite_queue_name}"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
       echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment
       echo 'BUILDKITE_ANALYTICS_TOKEN=${var.buildkite_analytics_token_value}' | sudo tee -a /etc/environment
+      echo 'TPU_VERSION=tpu6e' | sudo tee -a /etc/environment
 
       sudo mkdir -p /mnt/disks/persist
 
@@ -106,16 +107,50 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       sudo bash add-google-cloud-ops-agent-repo.sh --also-install
 
       # ==========================================
-      # 1. Backward Compatibility & JAX Cache Setup
+      # 1. JAX Cache Setup via GCS FUSE
       # ==========================================
-      echo "Setting up backward compatibility symlink for JAX cache..."
-      # Create the persistent directory first
+      echo "Installing gcsfuse..."
+      export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s`
+      curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo tee /usr/share/keyrings/google-cloud.asc > /dev/null
+      echo "deb [signed-by=/usr/share/keyrings/google-cloud.asc] https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
+
+      sudo apt-get update
+      sudo apt-get install -y gcsfuse
+
+      # Configure FUSE to allow other users (CI Agent / Docker Containers)
+      sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
+
+      # Create local buffer cache directory on the local disk
+      sudo mkdir -p /var/cache/gcsfuse
+      sudo chmod 777 /var/cache/gcsfuse
+
+      # Create target mount point and apply Safety Lock (immutable attribute)
+      # This prevents any writes from falling back to the persistent disk if FUSE drops.
       sudo mkdir -p /mnt/disks/persist/tpu_jax_cache
       sudo chmod 777 /mnt/disks/persist/tpu_jax_cache
-      
-      # Forcefully intercept old CI jobs writing to /tmp and redirect them to the persistent disk
+      sudo chattr +i /mnt/disks/persist/tpu_jax_cache
+
+      # Setting up backward compatibility symlink for legacy CI jobs
       sudo rm -rf /tmp/tpu_jax_cache
       sudo ln -s /mnt/disks/persist/tpu_jax_cache /tmp/tpu_jax_cache
+
+      echo "Mounting GCS bucket: ullm-ci-cache..."
+      if sudo gcsfuse \
+          --implicit-dirs \
+          --file-cache-max-size-mb=10240 \
+          --cache-dir=/var/cache/gcsfuse \
+          --dir-mode=777 \
+          --file-mode=777 \
+          -o allow_other \
+          ullm-ci-cache \
+          /mnt/disks/persist/tpu_jax_cache; then
+        
+        echo "GCS FUSE mount successful."
+        echo 'CI_CACHE_FUSE_MOUNTED=1' | sudo tee -a /etc/environment
+      else
+        echo "ERROR: Failed to mount GCS FUSE bucket."
+        exit 1
+      fi
 
       # ==========================================
       # 2. Automated Disk Garbage Collection (Cron)

--- a/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
@@ -74,6 +74,7 @@ resource "google_tpu_v2_vm" "tpu_v7x_ci" {
       echo 'tags="queue=${var.buildkite_queue_name}"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
       echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment
       echo 'BUILDKITE_ANALYTICS_TOKEN=${var.buildkite_analytics_token_value}' | sudo tee -a /etc/environment
+      echo 'TPU_VERSION=tpu7x' | sudo tee -a /etc/environment
 
       sudo mkdir -p /mnt/disks/persist
 
@@ -106,16 +107,50 @@ resource "google_tpu_v2_vm" "tpu_v7x_ci" {
       sudo bash add-google-cloud-ops-agent-repo.sh --also-install
 
       # ==========================================
-      # 1. Backward Compatibility & JAX Cache Setup
+      # 1. JAX Cache Setup via GCS FUSE
       # ==========================================
-      echo "Setting up backward compatibility symlink for JAX cache..."
-      # Create the persistent directory first
+      echo "Installing gcsfuse..."
+      export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s`
+      curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo tee /usr/share/keyrings/google-cloud.asc > /dev/null
+      echo "deb [signed-by=/usr/share/keyrings/google-cloud.asc] https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
+
+      sudo apt-get update
+      sudo apt-get install -y gcsfuse
+
+      # Configure FUSE to allow other users (CI Agent / Docker Containers)
+      sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
+
+      # Create local buffer cache directory on the local disk
+      sudo mkdir -p /var/cache/gcsfuse
+      sudo chmod 777 /var/cache/gcsfuse
+
+      # Create target mount point and apply Safety Lock (immutable attribute)
+      # This prevents any writes from falling back to the persistent disk if FUSE drops.
       sudo mkdir -p /mnt/disks/persist/tpu_jax_cache
       sudo chmod 777 /mnt/disks/persist/tpu_jax_cache
-      
-      # Forcefully intercept old CI jobs writing to /tmp and redirect them to the persistent disk
+      sudo chattr +i /mnt/disks/persist/tpu_jax_cache
+
+      # Setting up backward compatibility symlink for legacy CI jobs
       sudo rm -rf /tmp/tpu_jax_cache
       sudo ln -s /mnt/disks/persist/tpu_jax_cache /tmp/tpu_jax_cache
+
+      echo "Mounting GCS bucket: ullm-ci-cache..."
+      if sudo gcsfuse \
+          --implicit-dirs \
+          --file-cache-max-size-mb=10240 \
+          --cache-dir=/var/cache/gcsfuse \
+          --dir-mode=777 \
+          --file-mode=777 \
+          -o allow_other \
+          ullm-ci-cache \
+          /mnt/disks/persist/tpu_jax_cache; then
+        
+        echo "GCS FUSE mount successful."
+        echo 'CI_CACHE_FUSE_MOUNTED=1' | sudo tee -a /etc/environment
+      else
+        echo "ERROR: Failed to mount GCS FUSE bucket."
+        exit 1
+      fi
 
       # ==========================================
       # 2. Automated Disk Garbage Collection (Cron)


### PR DESCRIPTION
The benchmark script relies on TPU_VERSION to figure out the correct jax cache to download https://github.com/vllm-project/tpu-inference/blob/main/.buildkite/scripts/run_in_docker.sh#L125
We don't always set this from benchmark case (and we should not) and it results in downloading incorrect cache. Seeing v6e cache on v7 machine and all it does is occupies additional storages.

I'm also planning to enable a change to do the jax cache clean up after the docker run to save space on tpu, hopefully to reduce the times we need to do maintenance. As a result, we always download the cache from gcs and enabling  rapid cache  could greatly reduce the time. 

<img width="937" height="725" alt="Screenshot 2026-06-11 at 11 20 26 PM" src="https://github.com/user-attachments/assets/28e86c8c-6ace-4e2e-93f7-bb8e7455b9f4" />
