### PR TITLE
Tune JAX Cache GCS Fuse Config

### DIFF
--- a/terraform/gcp_old/tpu-inference/modules/ci_v5/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v5/main.tf
@@ -110,11 +110,15 @@ resource "google_tpu_v2_vm" "tpu_v5" {
 
       echo "Mounting GCS bucket: ullm-ci-cache..."
       if sudo gcsfuse \
-          --implicit-dirs \
           --file-cache-max-size-mb=10240 \
           --cache-dir=/var/cache/gcsfuse \
           --dir-mode=777 \
           --file-mode=777 \
+          --metadata-cache-ttl-secs=-1 \
+          --kernel-list-cache-ttl-secs=-1 \
+          --metadata-cache-negative-ttl-secs=0 \
+          --stat-cache-max-size-mb=-1 \
+          --type-cache-max-size-mb=-1 \
           -o allow_other \
           ullm-ci-cache \
           /mnt/disks/persist/tpu_jax_cache; then

--- a/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
@@ -136,11 +136,15 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
 
       echo "Mounting GCS bucket: ullm-ci-cache..."
       if sudo gcsfuse \
-          --implicit-dirs \
           --file-cache-max-size-mb=10240 \
           --cache-dir=/var/cache/gcsfuse \
           --dir-mode=777 \
           --file-mode=777 \
+          --metadata-cache-ttl-secs=-1 \
+          --kernel-list-cache-ttl-secs=-1 \
+          --metadata-cache-negative-ttl-secs=0 \
+          --stat-cache-max-size-mb=-1 \
+          --type-cache-max-size-mb=-1 \
           -o allow_other \
           ullm-ci-cache \
           /mnt/disks/persist/tpu_jax_cache; then

--- a/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
@@ -136,11 +136,15 @@ resource "google_tpu_v2_vm" "tpu_v7x_ci" {
 
       echo "Mounting GCS bucket: ullm-ci-cache..."
       if sudo gcsfuse \
-          --implicit-dirs \
           --file-cache-max-size-mb=10240 \
           --cache-dir=/var/cache/gcsfuse \
           --dir-mode=777 \
           --file-mode=777 \
+          --metadata-cache-ttl-secs=-1 \
+          --kernel-list-cache-ttl-secs=-1 \
+          --metadata-cache-negative-ttl-secs=0 \
+          --stat-cache-max-size-mb=-1 \
+          --type-cache-max-size-mb=-1 \
           -o allow_other \
           ullm-ci-cache \
           /mnt/disks/persist/tpu_jax_cache; then


### PR DESCRIPTION
This PR tunes the GCS FUSE mount configuration in the TPU CI startup scripts to optimize metadata caching performance for the JAX compilation cache.
### Changes
* **Infinite Attribute Caching** (`--metadata-cache-ttl-secs=-1` & `--kernel-list-cache-ttl-secs=-1`): Caches file attributes and directory listings infinitely. Since JAX cache objects are immutable and uniquely named by content hash, they never change in place. Infinitely caching their metadata eliminates redundant GCS metadata API calls.
* **Instant Shared File Visibility** (`--metadata-cache-negative-ttl-secs=0`): Disables negative caching (caching of "file not found" results). This prevents race conditions in shared cache environments, ensuring that as soon as one worker node writes a cache file, other worker nodes can immediately see it.
* **Maximized Cache Retention** (`--stat-cache-max-size-mb=-1` & `--type-cache-max-size-mb=-1`): Removes limits on the stat and type caches. This prevents cache eviction when checking large pools of compilation files.
* **Removed `--implicit-dirs`**: Cleaned up the mount command by removing `--implicit-dirs`, as the cache bucket uses explicitly defined directory structures.
### Why this helps
These adjustments significantly reduce metadata lookup latencies and eliminate potential GCS API rate limits/throttling when parallel CI jobs inspect or fetch compiled artifacts.
3:30 PM
