### PR TITLE
Depend on arm64 image build for DGX Spark steps

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -361,6 +361,13 @@ def convert_group_step_to_buildkite_step(
                 buildkite_step.depends_on = [block_step.key]
                 if step.depends_on:
                     buildkite_step.depends_on.extend(step.depends_on)
+            # DGX Spark runs the arm64 image, so depend on the arm64 image
+            # build rather than the default x86 image-build.
+            if step.device == DeviceType.DGX_SPARK and buildkite_step.depends_on:
+                buildkite_step.depends_on = [
+                    "arm64-image-build" if dep == "image-build" else dep
+                    for dep in buildkite_step.depends_on
+                ]
             if step.env:
                 buildkite_step.env = step.env
             if step.retry:


### PR DESCRIPTION
## Summary

DGX Spark test steps run the **arm64** CI image — the generator maps `device: dgx-spark` to `queue=dgx-spark` and `get_image(arm64=True)` (the `<commit>-arm64` tag). But they inherit `depends_on: [image-build]` (the **x86** build) from their test group, and nothing makes them wait for or trigger `arm64-image-build`. So the step pulls a `<commit>-arm64` image that was never built:

```
manifest for ...vllm-ci-test-repo:<commit>-arm64 not found: manifest unknown
```

## Change

For dgx-spark steps, rewrite the inherited `image-build` dependency to `arm64-image-build` — one guarded list comprehension in `convert_group_step_to_buildkite_step`. Non-spark steps are unchanged.

In nightly, `arm64-image-build` already auto-runs (`_step_should_run` returns `True` when `nightly == 1`), so the test now correctly waits for its own image. No `image_build.yaml` change is needed.

## Testing

Exercised the real generator against a test config: a `device: dgx-spark` step's `depends_on` becomes `["arm64-image-build"]`, while an `h200_35gb` step stays `["image-build"]`.

## Notes

- Pairs with vllm-project/vllm#39541, which fixes the arm64 image's `torch_cuda_arch_list` (sm_90 → adds 12.0 / sm_121 for GB10) so the pulled image actually runs on the Spark.
- AI assistance (Claude) was used; reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
