### PR TITLE
[BugFix] Ensure `CONTINUE_ON_FAILURE` doesn't clobber exports

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -283,7 +283,9 @@ def _prepare_commands(step: Step, variables_to_inject: Dict[str, str]) -> List[s
             preview = cmd[:80].replace("'", "").replace('"', '').replace('$', '')
             commands.append(f"echo '+++ :test_tube: Command ({i+1}/{len(step.commands)}): {preview}'")
             if continue_on_failure:
-                commands.append(f"({cmd}) || CI_OVERALL_STATUS=1")
+                # Note: We don't use a subshell here to preserve environment changes between commands
+                # (export, cd, etc).
+                commands.append(f"{{ {cmd}\n}} || __CI_OVERALL_STATUS=1")
             else:
                 commands.append(cmd)
 


### PR DESCRIPTION
Thanks to @tlrmchlsmth for tracking this down!

`CONTINUE_ON_FAILURE` is set on nightly builds, but it was running each command in a subshell, including those meant to set up the environment for subsequent commands in the same group, like
```
  - set -x
  - export VLLM_USE_V2_MODEL_RUNNER=1
  - pytest -v -s v1/engine/test_llm_engine.py -k "not test_engine_metrics"
```

so many of the tests were not running with their intended configuration.