### PR TITLE
[ROCm] Fix retry matching and gate debug agent

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -18,22 +18,34 @@ PRECOMMIT_WAIT_INTERVAL = 60
 AMD_TEST_COMMAND = "bash .buildkite/scripts/hardware_ci/run-amd-test.sh"
 AMD_RETRY = {
     "automatic": [
-        {
-            "exit_status": [-1, 1, 128],
-            "signal_reason": ["none", "agent_stop", "agent_refused"],
-            "limit": 1,
-        },
+        {"exit_status": -1, "limit": 1},
+        {"exit_status": 1, "limit": 1},
+        {"exit_status": 128, "limit": 1},
+        {"signal_reason": "agent_stop", "limit": 1},
+        {"signal_reason": "agent_refused", "limit": 1},
     ],
 }
+ROCM_DEBUG_AGENT_ENV_VAR = "VLLM_CI_ENABLE_ROCM_DEBUG_AGENT"
 ROCM_DEBUG_AGENT_LIB = "/opt/rocm/lib/librocm-debug-agent.so.2"
-ROCM_DEBUG_AGENT_SETUP_COMMAND = (
-    f"if test -f {ROCM_DEBUG_AGENT_LIB}; then "
-    f"export HSA_TOOLS_LIB={ROCM_DEBUG_AGENT_LIB} && export HSA_ENABLE_DEBUG=1 "
-    f"&& echo ROCm debug agent enabled: {ROCM_DEBUG_AGENT_LIB}; "
-    f"else echo 'WARNING: ROCm debug agent not found at {ROCM_DEBUG_AGENT_LIB}; "
-    "skipping coredump setup'; "
-    "fi"
-)
+
+
+def _get_rocm_debug_agent_setup_command() -> str:
+    if os.getenv(ROCM_DEBUG_AGENT_ENV_VAR, "0") != "1":
+        return (
+            "echo 'ROCm debug agent disabled; set "
+            f"{ROCM_DEBUG_AGENT_ENV_VAR}=1 at pipeline generation time "
+            "to enable coredump setup'"
+        )
+
+    return (
+        f"if test -f {ROCM_DEBUG_AGENT_LIB}; then "
+        f"export HSA_TOOLS_LIB={ROCM_DEBUG_AGENT_LIB} && export HSA_ENABLE_DEBUG=1 "
+        f"&& echo ROCm debug agent enabled: {ROCM_DEBUG_AGENT_LIB}; "
+        f"else echo 'WARNING: ROCm debug agent not found at {ROCM_DEBUG_AGENT_LIB}; "
+        "skipping coredump setup'; "
+        "fi"
+    )
+
 
 # Self-contained poll of the pre-commit GitHub Actions check run. Baked with the
 # commit/repo at generation time and run on a CI agent as its own step, so it
@@ -381,7 +393,7 @@ def _get_setup_commands(step: Step, setup_profile: SetupProfile) -> List[str]:
             "echo '--- :amd: GPU Info'",
             "(command amd-smi || true)",
             "echo '--- :gear: ROCm Debug Agent Setup'",
-            ROCM_DEBUG_AGENT_SETUP_COMMAND,
+            _get_rocm_debug_agent_setup_command(),
         ]
 
     raise ValueError(f"Unsupported setup profile: {setup_profile}")

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -128,24 +128,49 @@ def test_direct_amd_gpu_steps_use_amd_ci_path(device, queue):
     ]
     assert command_step.plugins is None
     assert command_step.retry == buildkite_step.AMD_RETRY
-    assert len(command_step.retry["automatic"]) == 1
+    assert len(command_step.retry["automatic"]) == 5
 
     test_commands = command_step.env["VLLM_TEST_COMMANDS"]
     assert test_commands.startswith(f"export VLLM_TEST_GROUP_NAME={step.key}")
     assert "(command amd-smi || true)" in test_commands
-    assert "if test -f /opt/rocm/lib/librocm-debug-agent.so.2" in test_commands
+    assert "ROCm debug agent disabled" in test_commands
+    assert buildkite_step.ROCM_DEBUG_AGENT_ENV_VAR in test_commands
+    assert "if test -f /opt/rocm/lib/librocm-debug-agent.so.2" not in test_commands
     assert "[ -f /opt/rocm/lib/librocm-debug-agent.so.2" not in test_commands
-    assert "/opt/rocm/lib/librocm-debug-agent.so.2" in test_commands
+    assert "export HSA_TOOLS_LIB=" not in test_commands
+    assert "HSA_ENABLE_DEBUG=1" not in test_commands
+    assert "WARNING: ROCm debug agent not found at" not in test_commands
+    assert "cd /vllm-workspace/tests" in test_commands
+    assert "pytest tests/foo.py" in test_commands
+    assert "nvidia-smi" not in test_commands
+    assert "CUDA_ENABLE_COREDUMP_ON_EXCEPTION" not in test_commands
+
+
+def test_rocm_debug_agent_setup_is_opt_in(monkeypatch):
+    monkeypatch.setenv(buildkite_step.ROCM_DEBUG_AGENT_ENV_VAR, "1")
+    step = Step(
+        label="AMD debug test",
+        group="Direct AMD",
+        key="amd-debug",
+        depends_on=["image-build"],
+        device="mi300_4",
+        optional=True,
+        working_dir="/vllm-workspace/tests",
+        commands=["pytest tests/debug.py"],
+    )
+
+    group_step = _render_single_step(step)
+    _, command_step = group_step.steps
+
+    test_commands = command_step.env["VLLM_TEST_COMMANDS"]
+    assert "if test -f /opt/rocm/lib/librocm-debug-agent.so.2" in test_commands
     assert (
         "export HSA_TOOLS_LIB=/opt/rocm/lib/librocm-debug-agent.so.2"
         in test_commands
     )
     assert "HSA_ENABLE_DEBUG=1" in test_commands
+    assert "ROCm debug agent enabled" in test_commands
     assert "WARNING: ROCm debug agent not found at" in test_commands
-    assert "cd /vllm-workspace/tests" in test_commands
-    assert "pytest tests/foo.py" in test_commands
-    assert "nvidia-smi" not in test_commands
-    assert "CUDA_ENABLE_COREDUMP_ON_EXCEPTION" not in test_commands
 
 
 def test_amd_mirror_uses_shared_gating_with_amd_dependency_fallback(
@@ -189,7 +214,7 @@ def test_amd_mirror_uses_shared_gating_with_amd_dependency_fallback(
     assert len(amd_group.steps) == 1
     assert amd_command_step.depends_on == ["image-build-amd"]
     assert amd_command_step.agents == {"queue": AgentQueue.AMD_MI325_1}
-    assert "export HSA_TOOLS_LIB=/opt/rocm/lib/librocm-debug-agent.so.2" in (
+    assert "ROCm debug agent disabled" in (
         amd_command_step.env["VLLM_TEST_COMMANDS"]
     )
 


### PR DESCRIPTION
This fixes AMD CI automatic retries by splitting the retry policy into separate Buildkite rules, so normal `exit_status: 1` failures are no longer blocked by a missing `signal_reason`. It also makes the ROCm debug agent opt-in via `VLLM_CI_ENABLE_ROCM_DEBUG_AGENT=1`, since recent logs show it can crash inside `amd_dbgapi_event_processed` and mask the actual test behavior. By default, AMD steps now print that the debug agent is disabled instead of exporting `HSA_TOOLS_LIB` and `HSA_ENABLE_DEBUG`. Updated pipeline generator tests cover the new retry shape and both debug-agent disabled/enabled paths.