### PR TITLE
fix(buildkite): validate github_repo_name to prevent path traversal

### DIFF
--- a/buildkite/pipeline_generator/global_config.py
+++ b/buildkite/pipeline_generator/global_config.py
@@ -89,6 +89,12 @@ def _validate_pipeline_config(pipeline_config: Dict):
         raise ValueError("Registries are required")
     if not pipeline_config["repositories"]:
         raise ValueError("Repositories are required")
+    if "github_repo_name" in pipeline_config:
+        repo_name = pipeline_config["github_repo_name"]
+        if not re.match(r"^vllm-project/[a-zA-Z0-9._-]+$", repo_name):
+            raise ValueError(
+                f"Invalid github_repo_name: {repo_name}. Must be in format vllm-project/repo_name"
+            )
     for job_dir in pipeline_config["job_dirs"]:
         if not os.path.exists(job_dir):
             raise ValueError(f"Job directory not found: {job_dir}")

--- a/buildkite/tests/pipeline_generator/test_global_config.py
+++ b/buildkite/tests/pipeline_generator/test_global_config.py
@@ -1,0 +1,42 @@
+import pytest
+from unittest.mock import patch
+from buildkite.pipeline_generator.global_config import _validate_pipeline_config
+
+
+def test_validate_pipeline_config_valid_repo():
+    config = {
+        "name": "test",
+        "job_dirs": ["/tmp"],
+        "registries": "registry",
+        "repositories": {"main": "repo"},
+        "github_repo_name": "vllm-project/vllm",
+    }
+    with patch("os.path.exists", return_value=True):
+        # Should not raise ValueError
+        _validate_pipeline_config(config)
+
+
+def test_validate_pipeline_config_invalid_repo_org():
+    config = {
+        "name": "test",
+        "job_dirs": ["/tmp"],
+        "registries": "registry",
+        "repositories": {"main": "repo"},
+        "github_repo_name": "attacker/vllm",
+    }
+    with patch("os.path.exists", return_value=True):
+        with pytest.raises(ValueError, match="Invalid github_repo_name"):
+            _validate_pipeline_config(config)
+
+
+def test_validate_pipeline_config_invalid_repo_traversal():
+    config = {
+        "name": "test",
+        "job_dirs": ["/tmp"],
+        "registries": "registry",
+        "repositories": {"main": "repo"},
+        "github_repo_name": "vllm-project/../../attacker/repo",
+    }
+    with patch("os.path.exists", return_value=True):
+        with pytest.raises(ValueError, match="Invalid github_repo_name"):
+            _validate_pipeline_config(config)


### PR DESCRIPTION
Validate github_repo_name read from pipeline config to ensure it belongs to vllm-project organization and does not contain path traversal characters.


BUG=b/510375092
TAG=agy
CONV=f5118c4a-3577-4dc6-a4b6-1f2abb990935