### PR TITLE
[CI] Fetch latest main before computing merge-base to fix stale origin/main on workspaces

### DIFF
--- a/buildkite/pipeline_generator/utils_lib/git_utils.py
+++ b/buildkite/pipeline_generator/utils_lib/git_utils.py
@@ -9,6 +9,12 @@ def get_merge_base_commit() -> Optional[str]:
     merge_base = os.getenv("MERGE_BASE_COMMIT")
     if merge_base:
         return merge_base
+    # Fetch latest main to ensure origin/main is up-to-date on agent workspaces
+    subprocess.run(
+        ["git", "fetch", "origin", "main", "--no-tags"],
+        capture_output=True,
+        check=False,
+    )
     # Compute merge base if not provided
     try:
         result = subprocess.run(


### PR DESCRIPTION
## Problem
On Buildkite agents with workspace reuse, `origin/main` can become stale if the local git state 
is not updated between builds. This causes `git merge-base origin/main HEAD` to compute an 
incorrect merge base, leading to:
- Incorrect file diff calculations for PR CI
- Pipeline step selection based on wrong change set

## Solution
Fetch latest main before computing merge-base, ensuring accurate diff and test selection