### PR TITLE
Superseded: release image BuildKit cache support

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,18 @@ The bootstrap script resolves cache sources with a fallback chain:
 
 Cache is stored as registry refs in private ECR repositories with 14-day expiration.
 
+CUDA release image builds export BuildKit registry cache to a separate private
+ECR cache repository:
+
+- **Release image cache**:
+  `936637512419.dkr.ecr.us-east-1.amazonaws.com/vllm-release-cache:{variant}`
+
+Use a stable architecture/CUDA/Ubuntu variant key, for example
+`x86_64-cu130-ubuntu2204`. Release jobs can import the ordinary CI cache
+fallback chain with additional `--cache-from` flags, but should write
+release-specific layers only to `vllm-release-cache` so they do not churn the CI
+test or postmerge cache repositories.
+
 ### Warm-Cache AMI
 
 A daily Buildkite pipeline (`.buildkite/pipelines/rebuild-cpu-ami.yml`, scheduled at 3 AM PST) builds custom EC2 AMIs with pre-warmed Docker layer caches:

--- a/docker/ci.hcl
+++ b/docker/ci.hcl
@@ -84,8 +84,14 @@ variable "CACHE_FROM" {
   default = ""
 }
 
+# Compatibility alias for older callers. Prefer CACHE_FROM_BASE_BRANCH, which
+# matches the value resolved by vLLM's image build wrapper.
 variable "CACHE_FROM_BASE" {
   default = ""
+}
+
+variable "CACHE_FROM_BASE_BRANCH" {
+  default = CACHE_FROM_BASE
 }
 
 variable "CACHE_FROM_MAIN" {
@@ -105,7 +111,7 @@ function "get_cache_from" {
     PARENT_COMMIT != "" ? "type=registry,ref=${REGISTRY}/vllm-ci-test-cache:${PARENT_COMMIT},mode=max" : "",
     VLLM_MERGE_BASE_COMMIT != "" ? "type=registry,ref=${REGISTRY}/vllm-ci-test-cache:${VLLM_MERGE_BASE_COMMIT},mode=max" : "",
     CACHE_FROM != "" ? "type=registry,ref=${CACHE_FROM},mode=max" : "",
-    CACHE_FROM_BASE != "" ? "type=registry,ref=${CACHE_FROM_BASE},mode=max" : "",
+    CACHE_FROM_BASE_BRANCH != "" ? "type=registry,ref=${CACHE_FROM_BASE_BRANCH},mode=max" : "",
     CACHE_FROM_MAIN != "" ? "type=registry,ref=${CACHE_FROM_MAIN},mode=max" : "",
   ])
 }

--- a/terraform/aws/ecr.tf
+++ b/terraform/aws/ecr.tf
@@ -26,6 +26,11 @@ resource "aws_ecr_repository" "vllm_ci_postmerge_cache" {
   provider = aws.us_east_1
 }
 
+resource "aws_ecr_repository" "vllm_release_cache" {
+  name     = "vllm-release-cache"
+  provider = aws.us_east_1
+}
+
 # Lifecycle policies for cache repositories
 resource "aws_ecr_lifecycle_policy" "vllm_ci_test_cache" {
   repository = aws_ecr_repository.vllm_ci_test_cache.name
@@ -35,6 +40,12 @@ resource "aws_ecr_lifecycle_policy" "vllm_ci_test_cache" {
 
 resource "aws_ecr_lifecycle_policy" "vllm_ci_postmerge_cache" {
   repository = aws_ecr_repository.vllm_ci_postmerge_cache.name
+  provider   = aws.us_east_1
+  policy     = local.ecr_cache_lifecycle_policy
+}
+
+resource "aws_ecr_lifecycle_policy" "vllm_release_cache" {
+  repository = aws_ecr_repository.vllm_release_cache.name
   provider   = aws.us_east_1
   policy     = local.ecr_cache_lifecycle_policy
 }

--- a/terraform/aws/iam.tf
+++ b/terraform/aws/iam.tf
@@ -197,6 +197,42 @@ resource "aws_iam_policy" "postmerge_ecr_cache_read_write_access_policy" {
   })
 }
 
+resource "aws_iam_policy" "release_ecr_cache_read_write_access_policy" {
+  name        = "release_ecr_cache_read_write_access_policy"
+  description = "Policy to read and write cache to release cache repo"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:CompleteLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:InitiateLayerUpload",
+          "ecr:PutImage",
+          "ecr:GetAuthorizationToken",
+          "sts:GetServiceBearerToken"
+        ]
+        Resource = [
+          "arn:aws:ecr:us-east-1:936637512419:repository/vllm-release-cache"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken",
+          "sts:GetServiceBearerToken"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
 resource "aws_iam_policy" "release_ecr_public_read_write_access_policy" {
   name        = "release-ecr-public-read-write-access-policy"
   description = "Policy to push and pull images from release ECR"
@@ -427,6 +463,16 @@ resource "aws_iam_role_policy_attachment" "postmerge_ecr_cache_read_write_access
   )
   role       = each.value.outputs.InstanceRoleName
   policy_arn = aws_iam_policy.postmerge_ecr_cache_read_write_access_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "release_ecr_cache_read_write_access" {
+  for_each = merge(
+    aws_cloudformation_stack.bk_queue_postmerge,
+    aws_cloudformation_stack.bk_queue_postmerge_us_east_1,
+    aws_cloudformation_stack.bk_queue_release,
+  )
+  role       = each.value.outputs.InstanceRoleName
+  policy_arn = aws_iam_policy.release_ecr_cache_read_write_access_policy.arn
 }
 
 resource "aws_iam_role_policy_attachment" "release_ecr_public_read_write_access" {


### PR DESCRIPTION
## Summary

Adds infra-side support for cached CUDA release image builds while keeping the vLLM release pipeline change small.

Changes:
- Accept `CACHE_FROM_BASE_BRANCH` in `docker/ci.hcl`, keeping `CACHE_FROM_BASE` as a compatibility alias.
- Add a private ECR `vllm-release-cache` repository with the existing 14-day cache lifecycle.
- Add IAM read/write access for release/postmerge queues that already build and push release images.
- Document the CI cache lane vs release cache lane in the README.

## Why

The CUDA release image jobs currently build with raw `docker build` commands and do not import/export the registry BuildKit cache used by CI image builds. This gives release builds cold-cache behavior even though they share expensive layers with CI builds.

This PR intentionally only creates the infra target for a release cache. The vLLM-side release pipeline can then add direct BuildKit registry cache flags to the existing `docker build` commands without converting the release matrix to Bake.

The release cache is separate from `vllm-ci-test-cache` and `vllm-ci-postmerge-cache` so release-specific variants do not churn CI cache refs.

## Consumer Contract

CUDA release image jobs should use refs like:

```text
936637512419.dkr.ecr.us-east-1.amazonaws.com/vllm-release-cache:<arch>-cu<cuda>-ubuntu<ubuntu>
```

Suggested initial variant tags:

```text
x86_64-cu130-ubuntu2204
aarch64-cu130-ubuntu2204
x86_64-cu129-ubuntu2204
aarch64-cu129-ubuntu2204
x86_64-cu130-ubuntu2404
aarch64-cu130-ubuntu2404
x86_64-cu129-ubuntu2404
aarch64-cu129-ubuntu2404
```

Use direct BuildKit flags on the existing `docker build` release commands, for example:

```bash
--cache-from type=registry,ref=936637512419.dkr.ecr.us-east-1.amazonaws.com/vllm-release-cache:x86_64-cu130-ubuntu2204,mode=max \
--cache-to type=registry,ref=936637512419.dkr.ecr.us-east-1.amazonaws.com/vllm-release-cache:x86_64-cu130-ubuntu2204,mode=max,compression=zstd
```

The vLLM-side change can also add extra `--cache-from` flags for the existing CI fallback refs if desired, but release jobs should only write release-specific layers to `vllm-release-cache`.

## Validation

- `git diff --check origin/main...HEAD`

Not run locally because this devbox does not have `terraform`, `docker`, `tofu`, or `hclfmt` installed:
- `terraform fmt -check terraform/aws/ecr.tf terraform/aws/iam.tf`
- `docker buildx bake --print test-ci`