### PR TITLE
Fix Intel CI merge-base diff calculation

### DIFF
--- a/buildkite/bootstrap-intel.sh
+++ b/buildkite/bootstrap-intel.sh
@@ -14,16 +14,16 @@ if [[ -z "${VLLM_CI_BRANCH:-}" ]]; then
     VLLM_CI_BRANCH="main"
 fi
 
+if [[ -z "${VLLM_CI_REPO:-}" ]]; then
+    VLLM_CI_REPO="vllm-project/ci-infra"
+fi
+
 if [[ -z "${AMD_MIRROR_HW:-}" ]]; then
     AMD_MIRROR_HW="amdproduction"
 fi
 
 if [[ -z "${DOCS_ONLY_DISABLE:-}" ]]; then
     DOCS_ONLY_DISABLE=0
-fi
-
-if [[ -z "${MERGE_BASE_COMMIT:-}" ]]; then
-    MERGE_BASE_COMMIT=$(git merge-base origin/main HEAD)
 fi
 
 if [[ -z "${COV_ENABLED:-}" ]]; then
@@ -71,6 +71,31 @@ clean_docker_tag() {
     local input="$1"
     echo "$input" | sed 's/[^a-zA-Z0-9._-]/_/g' | cut -c1-128
 }
+
+fetch_origin_ref() {
+    local ref="$1"
+    git fetch --no-tags --depth=50 origin "${ref}:refs/remotes/origin/${ref}" >/dev/null 2>&1 || \
+        git fetch --no-tags origin "${ref}:refs/remotes/origin/${ref}" >/dev/null 2>&1
+}
+
+git config --global --add safe.directory "$(pwd)" 2>/dev/null || true
+
+BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-main}"
+if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false" ]]; then
+    BASE_BRANCH="main"
+fi
+
+fetch_origin_ref "$BASE_BRANCH" || true
+
+if [[ -z "${MERGE_BASE_COMMIT:-}" ]]; then
+    MERGE_BASE_COMMIT=$(git merge-base "origin/${BASE_BRANCH}" HEAD 2>/dev/null || echo "")
+    if [[ -z "$MERGE_BASE_COMMIT" ]]; then
+        echo "WARNING: Could not compute merge base, falling back to run_all=1"
+        RUN_ALL=1
+        MERGE_BASE_COMMIT="HEAD"
+    fi
+fi
+export MERGE_BASE_COMMIT
 
 resolve_ecr_cache_vars() {
     # Resolve ECR cache-from, cache-to using buildkite environment variables:
@@ -169,13 +194,11 @@ upload_pipeline() {
 }
 
 get_diff() {
-    $(git add .)
-    echo $(git diff --name-only --diff-filter=ACMDR $(git merge-base origin/main HEAD))
+    git diff --name-only --diff-filter=ACMDR "$MERGE_BASE_COMMIT" HEAD 2>/dev/null || echo ""
 }
 
 get_diff_main() {
-    $(git add .)
-    echo $(git diff --name-only --diff-filter=ACMDR HEAD~1)
+    git diff --name-only --diff-filter=ACMDR HEAD~1 HEAD 2>/dev/null || echo ""
 }
 
 file_diff=$(get_diff)
@@ -302,9 +325,10 @@ else
     fi
 fi
 
-LIST_FILE_DIFF=$(get_diff | tr ' ' '|')
-if [[ $BUILDKITE_BRANCH == "main" ]]; then
-    LIST_FILE_DIFF=$(get_diff_main | tr ' ' '|')
+if [[ $RUN_ALL -eq 1 ]]; then
+    LIST_FILE_DIFF="run_all"
+else
+    LIST_FILE_DIFF=$(printf '%s\n' "$file_diff" | tr -d '\r' | paste -sd'|' -)
 fi
 
 upload_pipeline


### PR DESCRIPTION
## Summary

Fix Intel CI diff calculation to avoid using a stale `origin/main` from reused Buildkite workspaces.

The Intel bootstrap step previously computed `MERGE_BASE_COMMIT` directly from the local `origin/main` and recalculated diff with `git merge-base origin/main HEAD`. In PR builds where the checkout only fetched the PR head, `origin/main` could be stale, producing an oversized diff and unexpectedly setting `RUN_ALL=1`.

## Changes

- Fetch the PR base branch into `refs/remotes/origin/<base>` before computing `MERGE_BASE_COMMIT`.
- Compute `MERGE_BASE_COMMIT` once and export it for downstream pipeline generation.
- Use commit-to-commit diff: `MERGE_BASE_COMMIT..HEAD`.
- Remove `git add .` from diff calculation so workspace/index state does not affect changed-file detection.
- Use `LIST_FILE_DIFF=run_all` when all tests are already enabled, avoiding very large diff strings.

## Validation

- `bash -n buildkite/bootstrap-intel.sh`