### PR TITLE
[Bugfix] continue-on-failure exit status

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -420,7 +420,7 @@ def _prepare_commands(
             if continue_on_failure:
                 # Note: We don't use a subshell here to preserve environment changes between commands
                 # (export, cd, etc).
-                commands.append(f"{{ {cmd}\n}} || __CI_OVERALL_STATUS=1")
+                commands.append(f"{{ {cmd}\n}} || CI_OVERALL_STATUS=1")
             else:
                 commands.append(cmd)
 

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 from pathlib import Path
 
@@ -171,6 +172,38 @@ def test_rocm_debug_agent_setup_is_opt_in(monkeypatch):
     assert "HSA_ENABLE_DEBUG=1" in test_commands
     assert "ROCm debug agent enabled" in test_commands
     assert "WARNING: ROCm debug agent not found at" in test_commands
+
+
+def test_continue_on_failure_exits_nonzero_after_command_failure(monkeypatch):
+    monkeypatch.setenv("CONTINUE_ON_FAILURE", "1")
+    step = Step(
+        label="Continue on failure",
+        group="Failure handling",
+        commands=[
+            "echo before",
+            "false",
+            "echo after",
+        ],
+    )
+
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="none",
+    )
+    script = " && ".join(commands).replace("$$CI_OVERALL_STATUS", "$CI_OVERALL_STATUS")
+
+    result = subprocess.run(
+        ["bash", "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "__CI_OVERALL_STATUS" not in script
+    assert "CI_OVERALL_STATUS=1" in script
+    assert "after" in result.stdout
+    assert result.returncode == 1
 
 
 def test_amd_mirror_uses_shared_gating_with_amd_dependency_fallback(


### PR DESCRIPTION
This fixes a regression in the Buildkite pipeline generator where failed commands were recorded in `__CI_OVERALL_STATUS`, but the generated script exited using `CI_OVERALL_STATUS`. Because those variables did not match, nightly steps could print failed test output while still returning exit code 0 to Buildkite. The change keeps the brace-based command wrapper from #381, so exports and other shell state still carry forward between commands. It only restores failure tracking to the same variable that the final `exit` uses. A regression test now runs a generated continue-on-failure script and verifies that later commands still run while the final process exits nonzero after a failed command.