### PR TITLE
Fix CONTINUE_ON_FAILURE swallowing failures via mismatched var name

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -420,7 +420,7 @@ def _prepare_commands(
             if continue_on_failure:
                 # Note: We don't use a subshell here to preserve environment changes between commands
                 # (export, cd, etc).
-                commands.append(f"{{ {cmd}\n}} || __CI_OVERALL_STATUS=1")
+                commands.append(f"{{ {cmd}\n}} || CI_OVERALL_STATUS=1")
             else:
                 commands.append(cmd)
 


### PR DESCRIPTION
## Problem

In `_prepare_commands` ([buildkite/pipeline_generator/buildkite_step.py](https://github.com/vllm-project/ci-infra/blob/main/buildkite/pipeline_generator/buildkite_step.py)), the overall-status tracking under `CONTINUE_ON_FAILURE=1` uses three references to a shell variable, but they don't all agree on the name:

```python
commands.append("CI_OVERALL_STATUS=0")                       # init
commands.append(f"{{ {cmd}\n}} || __CI_OVERALL_STATUS=1")    # set on failure  ← wrong name
commands.append("exit $$CI_OVERALL_STATUS")                  # exit with it
```

`__CI_OVERALL_STATUS` and `CI_OVERALL_STATUS` are **distinct** shell variables. So when `CONTINUE_ON_FAILURE=1`:

1. `CI_OVERALL_STATUS=0` initializes the tracked variable.
2. A failing command sets `__CI_OVERALL_STATUS=1` — a different variable nothing reads.
3. `exit $CI_OVERALL_STATUS` exits with the still-`0` value.

Net effect: with continue-on-failure enabled, a step whose commands fail still **exits 0 and reports success** — the failures are silently swallowed, defeating the purpose of the overall-status tracking.

## Root cause

Commit `e93bfde` deliberately standardized the variable name on `CI_OVERALL_STATUS` (dropping the `__` prefix) and escaped `$` references as `$$` for Buildkite interpolation. PR #381 later rewrote the per-command line and reintroduced the old `__`-prefixed name, missing the rename.

## Fix

Align the per-command handler back to `CI_OVERALL_STATUS` so all three references match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)