### PR TITLE
Use dedicated github app short lived token to checkout repo

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-tpu-inference-test/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-tpu-inference-test/main.tf
@@ -9,7 +9,7 @@
 # }
 
 data "google_secret_manager_secret_version" "buildkite_agent_token_ci_cluster" {
-  secret = "projects/${var.project_id}/secrets/tpu_commons_buildkite_agent_token"
+  secret  = "projects/${var.project_id}/secrets/tpu_commons_buildkite_agent_token"
   version = "latest"
 }
 
@@ -23,10 +23,6 @@ data "google_secret_manager_secret_version" "buildkite_analytics_token_ci_cluste
   version = "latest"
 }
 
-data "google_secret_manager_secret_version" "github_deploy_key" {
-  secret  = "projects/${var.project_id}/secrets/tpu_commons_buildkite_vllm_torchtpu_deploy_key"
-  version = "latest"
-}
 
 module "ci_v6e_1" {
   source = "../modules/ci_v6e"
@@ -43,11 +39,10 @@ module "ci_v6e_1" {
   buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
   buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
   huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
-  github_deploy_key_value         = data.google_secret_manager_secret_version.github_deploy_key.secret_data
 }
 
 module "ci_v6e_8" {
-  source    = "../modules/ci_v6e"
+  source = "../modules/ci_v6e"
   providers = {
     google-beta = google-beta.southamerica-west1-a
   }
@@ -62,7 +57,6 @@ module "ci_v6e_8" {
   buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
   buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
   huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
-  github_deploy_key_value         = data.google_secret_manager_secret_version.github_deploy_key.secret_data
 }
 
 module "ci_cpu" {
@@ -74,7 +68,6 @@ module "ci_cpu" {
   instance_count          = 8
   buildkite_token_value   = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
   huggingface_token_value = data.google_secret_manager_secret_version.huggingface_token.secret_data
-  github_deploy_key_value = data.google_secret_manager_secret_version.github_deploy_key.secret_data
 }
 
 # module "ci_v5" {

--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -13,10 +13,6 @@ data "google_secret_manager_secret_version" "huggingface_token" {
   version = "latest"
 }
 
-data "google_secret_manager_secret_version" "github_deploy_key" {
-  secret  = "projects/${var.secret_project_id}/secrets/tpu_commons_buildkite_vllm_torchtpu_deploy_key"
-  version = "latest"
-}
 
 module "ci_v6e_1" {
   source = "../modules/ci_v6e"
@@ -34,7 +30,6 @@ module "ci_v6e_1" {
   buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
   buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
   huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
-  github_deploy_key_value         = data.google_secret_manager_secret_version.github_deploy_key.secret_data
 }
 
 module "ci_v6e_8" {
@@ -52,7 +47,6 @@ module "ci_v6e_8" {
   buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
   buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
   huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
-  github_deploy_key_value         = data.google_secret_manager_secret_version.github_deploy_key.secret_data
 }
 
 
@@ -72,7 +66,6 @@ module "ci_v7x_2" {
   buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
   buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
   huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
-  github_deploy_key_value         = data.google_secret_manager_secret_version.github_deploy_key.secret_data
 }
 
 module "ci_v7x_8" {
@@ -91,7 +84,6 @@ module "ci_v7x_8" {
   buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
   buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
   huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
-  github_deploy_key_value         = data.google_secret_manager_secret_version.github_deploy_key.secret_data
 }
 
 module "ci_cpu_64_core" {
@@ -109,7 +101,6 @@ module "ci_cpu_64_core" {
 
   buildkite_token_value   = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
   huggingface_token_value = data.google_secret_manager_secret_version.huggingface_token.secret_data
-  github_deploy_key_value = data.google_secret_manager_secret_version.github_deploy_key.secret_data
 }
 
 module "ci_cpu_64_core_zone_c" {
@@ -127,7 +118,6 @@ module "ci_cpu_64_core_zone_c" {
 
   buildkite_token_value   = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
   huggingface_token_value = data.google_secret_manager_secret_version.huggingface_token.secret_data
-  github_deploy_key_value = data.google_secret_manager_secret_version.github_deploy_key.secret_data
 }
 
 module "ci_monitoring" {

--- a/terraform/gcp_old/tpu-inference/modules/ci_cpu/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cpu/main.tf
@@ -48,7 +48,7 @@ resource "google_compute_instance" "buildkite-agent-instance" {
       #!/bin/bash
 
       apt-get update
-      apt-get install -y curl build-essential jq
+      apt-get install -y curl build-essential jq git python3 python3-pip
       sudo curl -L https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64 -o /usr/bin/yq && sudo chmod +x /usr/bin/yq
 
       curl -o- https://get.docker.com/ | bash -
@@ -69,25 +69,60 @@ resource "google_compute_instance" "buildkite-agent-instance" {
       # Force stop the buildkite-agent and start at the end to avoid race condition
       sudo systemctl stop buildkite-agent
 
-%{if var.github_deploy_key_value != null && var.github_deploy_key_value != ""}
-      mkdir -p /var/lib/buildkite-agent/.ssh
+      # ==========================================
+      # Setup In-Memory GitHub App Authentication
+      # ==========================================
+      pip3 install pyjwt requests cryptography --break-system-packages || pip3 install pyjwt requests cryptography
 
-      # Write the private deploy key directly from Terraform
-      cat <<EOF > /var/lib/buildkite-agent/.ssh/id_rsa
-${var.github_deploy_key_value}
-EOF
+      # 1. Create the Python script
+      cat <<'EOF' > /etc/buildkite-agent/get_github_token.py
+      import os, time, requests, jwt
 
-      # Prevent strict host checking on first clone
-      cat <<EOF > /var/lib/buildkite-agent/.ssh/config
-      Host github.com
-        StrictHostKeyChecking accept-new
-EOF
+      APP_ID = "4156238"
+      INSTALLATION_ID = "142868369"
 
-      # Secure permissions and hand ownership to buildkite-agent
-      chmod 600 /var/lib/buildkite-agent/.ssh/id_rsa
-      chmod 600 /var/lib/buildkite-agent/.ssh/config
-      chown -R buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.ssh
-%{endif}
+      signing_key = os.environ['_BK_TEMP_GITHUB_APP_PEM'].encode('utf-8')
+
+      payload = { 'iat': int(time.time()), 'exp': int(time.time()) + 600, 'iss': APP_ID }
+      encoded_jwt = jwt.encode(payload, signing_key, algorithm='RS256')
+
+      response = requests.post(
+          f'https://api.github.com/app/installations/{INSTALLATION_ID}/access_tokens',
+          headers={'Authorization': f'Bearer {encoded_jwt}', 'Accept': 'application/vnd.github.v3+json'}
+      )
+      response.raise_for_status()
+      print(response.json()['token'])
+      EOF
+
+      mkdir -p /etc/buildkite-agent/hooks
+
+      # 2. Create the Buildkite pre-checkout hook
+      cat <<'EOF' > /etc/buildkite-agent/hooks/pre-checkout
+      #!/bin/bash
+      set -e
+
+      echo "--- 🔐 Generating temporary GitHub token"
+
+      export _BK_TEMP_GITHUB_APP_PEM=$(buildkite-agent secret get ${var.github_app_secret_name})
+
+      if [ -z "$_BK_TEMP_GITHUB_APP_PEM" ]; then
+          echo "🚨 Error: Failed to fetch secret from Buildkite Secrets. Does the secret exist?"
+          exit 1
+      fi
+
+      GITHUB_TOKEN=$(python3 /etc/buildkite-agent/get_github_token.py)
+      unset _BK_TEMP_GITHUB_APP_PEM
+
+      # Static URL rewrite for SSH to HTTPS, and Basic Auth header for HTTPS authentication
+      git config --global url."https://github.com/".insteadOf "git@github.com:"
+      AUTH_TOKEN=$(echo -n "x-access-token:$GITHUB_TOKEN" | base64 | tr -d '\n')
+      git config --global http.https://github.com/.extraheader "Authorization: Basic $AUTH_TOKEN"
+      EOF
+
+      chmod 500 /etc/buildkite-agent/get_github_token.py
+      chmod +x /etc/buildkite-agent/hooks/pre-checkout
+      chown -R buildkite-agent:buildkite-agent /etc/buildkite-agent/
+      # ==========================================
 
       sudo usermod -a -G docker buildkite-agent
       sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet

--- a/terraform/gcp_old/tpu-inference/modules/ci_cpu/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cpu/variables.tf
@@ -16,10 +16,8 @@ variable "huggingface_token_value" {
   type        = string
   description = "Hugging Face token for vLLM model serving usage."
 }
-
-variable "github_deploy_key_value" {
+variable "github_app_secret_name" {
   type        = string
-  description = "Github deploy key for private repo access"
-  default     = null
-  sensitive   = true
+  description = "The Buildkite secret name for the GitHub App PEM key."
+  default     = "GITHUB_CI_BOT_PEM"
 }

--- a/terraform/gcp_old/tpu-inference/modules/ci_cpu_64_core/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cpu_64_core/main.tf
@@ -41,21 +41,23 @@ resource "google_compute_instance" "buildkite-agent-instance" {
     enable-oslogin   = "true"
     "startup-script" = <<-STARTUP_SCRIPT
       #!/bin/bash
+      set -e
 
       apt-get update
-      apt-get install -y curl build-essential jq
+      apt-get install -y curl build-essential jq git python3 python3-pip
 
       curl -o- https://get.docker.com/ | bash -
 
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-      /root/.cargo/bin/cargo install minijinja-cli
+
+      /root/.cargo/bin/cargo install minijinja-cli || true
       cp /root/.cargo/bin/minijinja-cli /usr/bin/minijinja-cli
       chmod 777 /usr/bin/minijinja-cli
 
-      curl -fsSL "https://packages.buildkite.com/buildkite/cli-deb/gpgkey" | sudo gpg --dearmor -o /usr/share/keyrings/buildkite_cli-deb-archive-keyring.gpg
+      curl -fsSL "https://packages.buildkite.com/buildkite/cli-deb/gpgkey" | sudo gpg --dearmor --yes -o /usr/share/keyrings/buildkite_cli-deb-archive-keyring.gpg
       echo -e "deb [signed-by=/usr/share/keyrings/buildkite_cli-deb-archive-keyring.gpg] https://packages.buildkite.com/buildkite/cli-deb/any/ any main\ndeb-src [signed-by=/usr/share/keyrings/buildkite_cli-deb-archive-keyring.gpg] https://packages.buildkite.com/buildkite/cli-deb/any/ any main" | sudo tee /etc/apt/sources.list.d/buildkite-buildkite-cli-deb.list
 
-      curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
+      curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | sudo gpg --dearmor --yes -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
       echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
       apt-get update
       apt-get install -y bk buildkite-agent
@@ -63,25 +65,60 @@ resource "google_compute_instance" "buildkite-agent-instance" {
       # Force stop the buildkite-agent and start at the end to avoid race condition
       sudo systemctl stop buildkite-agent
 
-%{if var.github_deploy_key_value != null && var.github_deploy_key_value != ""}
-      mkdir -p /var/lib/buildkite-agent/.ssh
+      # ==========================================
+      # Setup In-Memory GitHub App Authentication
+      # ==========================================
+      pip3 install pyjwt requests cryptography --break-system-packages || pip3 install pyjwt requests cryptography
 
-      # Write the private deploy key directly from Terraform
-      cat <<EOF > /var/lib/buildkite-agent/.ssh/id_rsa
-${var.github_deploy_key_value}
-EOF
+      # 1. Create the Python script
+      cat <<'EOF' > /etc/buildkite-agent/get_github_token.py
+      import os, time, requests, jwt
 
-      # Prevent strict host checking on first clone
-      cat <<EOF > /var/lib/buildkite-agent/.ssh/config
-      Host github.com
-        StrictHostKeyChecking accept-new
-EOF
+      APP_ID = "4156238"
+      INSTALLATION_ID = "142868369"
 
-      # Secure permissions and hand ownership to buildkite-agent
-      chmod 600 /var/lib/buildkite-agent/.ssh/id_rsa
-      chmod 600 /var/lib/buildkite-agent/.ssh/config
-      chown -R buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.ssh
-%{endif}
+      signing_key = os.environ['_BK_TEMP_GITHUB_APP_PEM'].encode('utf-8')
+
+      payload = { 'iat': int(time.time()), 'exp': int(time.time()) + 600, 'iss': APP_ID }
+      encoded_jwt = jwt.encode(payload, signing_key, algorithm='RS256')
+
+      response = requests.post(
+          f'https://api.github.com/app/installations/{INSTALLATION_ID}/access_tokens',
+          headers={'Authorization': f'Bearer {encoded_jwt}', 'Accept': 'application/vnd.github.v3+json'}
+      )
+      response.raise_for_status()
+      print(response.json()['token'])
+      EOF
+
+      mkdir -p /etc/buildkite-agent/hooks
+
+      # 2. Create the Buildkite pre-checkout hook
+      cat <<'EOF' > /etc/buildkite-agent/hooks/pre-checkout
+      #!/bin/bash
+      set -e
+
+      echo "--- 🔐 Generating temporary GitHub token"
+
+      export _BK_TEMP_GITHUB_APP_PEM=$(buildkite-agent secret get ${var.github_app_secret_name})
+
+      if [ -z "$_BK_TEMP_GITHUB_APP_PEM" ]; then
+          echo "🚨 Error: Failed to fetch secret from Buildkite Secrets. Does the secret exist?"
+          exit 1
+      fi
+
+      GITHUB_TOKEN=$(python3 /etc/buildkite-agent/get_github_token.py)
+      unset _BK_TEMP_GITHUB_APP_PEM
+
+      # Static URL rewrite for SSH to HTTPS, and Basic Auth header for HTTPS authentication
+      git config --global url."https://github.com/".insteadOf "git@github.com:"
+      AUTH_TOKEN=$(echo -n "x-access-token:$GITHUB_TOKEN" | base64 | tr -d '\n')
+      git config --global http.https://github.com/.extraheader "Authorization: Basic $AUTH_TOKEN"
+      EOF
+
+      chmod 500 /etc/buildkite-agent/get_github_token.py
+      chmod +x /etc/buildkite-agent/hooks/pre-checkout
+      chown -R buildkite-agent:buildkite-agent /etc/buildkite-agent/
+      # ==========================================
 
       sudo usermod -a -G docker buildkite-agent
       sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
@@ -89,8 +126,8 @@ EOF
 
       sudo sed -i "s/xxx/${var.buildkite_token_value}/g" /etc/buildkite-agent/buildkite-agent.cfg
       sudo sed -i 's/name="%hostname-%spawn"/name="vllm-cpu-64-core-vm-${count.index}"/' /etc/buildkite-agent/buildkite-agent.cfg
-      echo 'tags="queue=${var.buildkite_queue_name}"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
-      echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment
+      grep -q 'tags="queue=${var.buildkite_queue_name}"' /etc/buildkite-agent/buildkite-agent.cfg || echo 'tags="queue=${var.buildkite_queue_name}"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
+      grep -q "HF_TOKEN=" /etc/environment || echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment
 
       systemctl stop docker
       systemctl start docker

--- a/terraform/gcp_old/tpu-inference/modules/ci_cpu_64_core/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cpu_64_core/variables.tf
@@ -49,10 +49,8 @@ variable "resource_suffix" {
   type        = string
   default     = ""
 }
-
-variable "github_deploy_key_value" {
+variable "github_app_secret_name" {
   type        = string
-  description = "Github deploy key for private repo access"
-  default     = null
-  sensitive   = true
+  description = "The Buildkite secret name for the GitHub App PEM key."
+  default     = "GITHUB_CI_BOT_PEM"
 }

--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/main.tf
@@ -29,7 +29,7 @@ resource "google_compute_instance" "monitoring_instance" {
   }
 
   metadata = {
-    enable-oslogin = "true"
+    enable-oslogin   = "true"
     "startup-script" = <<-EOF
       #!/bin/bash
       
@@ -82,7 +82,7 @@ resource "google_bigquery_table" "step_logs" {
   dataset_id          = google_bigquery_dataset.ci_analytics.dataset_id
   project             = var.project_id
   table_id            = "step_execution_logs"
-  deletion_protection = true 
+  deletion_protection = true
 
   schema = <<EOF
 [

--- a/terraform/gcp_old/tpu-inference/modules/ci_v5/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v5/main.tf
@@ -48,7 +48,7 @@ resource "google_tpu_v2_vm" "tpu_v5" {
       #!/bin/bash
 
       apt-get update
-      apt-get install -y curl build-essential jq
+      apt-get install -y curl build-essential jq git python3 python3-pip
 
       curl -o- https://get.docker.com/ | bash -
 
@@ -61,6 +61,64 @@ resource "google_tpu_v2_vm" "tpu_v5" {
       echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
       apt-get update
       apt-get install -y buildkite-agent
+
+      # Force stop the buildkite-agent and start at the end to avoid race condition
+      sudo systemctl stop buildkite-agent
+
+      # ==========================================
+      # Setup In-Memory GitHub App Authentication
+      # ==========================================
+      pip3 install pyjwt requests cryptography --break-system-packages || pip3 install pyjwt requests cryptography
+
+      # 1. Create the Python script
+      cat <<'EOF' > /etc/buildkite-agent/get_github_token.py
+      import os, time, requests, jwt
+
+      APP_ID = "4156238"
+      INSTALLATION_ID = "142868369"
+
+      signing_key = os.environ['_BK_TEMP_GITHUB_APP_PEM'].encode('utf-8')
+
+      payload = { 'iat': int(time.time()), 'exp': int(time.time()) + 600, 'iss': APP_ID }
+      encoded_jwt = jwt.encode(payload, signing_key, algorithm='RS256')
+
+      response = requests.post(
+          f'https://api.github.com/app/installations/{INSTALLATION_ID}/access_tokens',
+          headers={'Authorization': f'Bearer {encoded_jwt}', 'Accept': 'application/vnd.github.v3+json'}
+      )
+      response.raise_for_status()
+      print(response.json()['token'])
+      EOF
+
+      mkdir -p /etc/buildkite-agent/hooks
+
+      # 2. Create the Buildkite pre-checkout hook
+      cat <<'EOF' > /etc/buildkite-agent/hooks/pre-checkout
+      #!/bin/bash
+      set -e
+
+      echo "--- 🔐 Generating temporary GitHub token"
+
+      export _BK_TEMP_GITHUB_APP_PEM=$(buildkite-agent secret get ${var.github_app_secret_name})
+
+      if [ -z "$_BK_TEMP_GITHUB_APP_PEM" ]; then
+          echo "🚨 Error: Failed to fetch secret from Buildkite Secrets. Does the secret exist?"
+          exit 1
+      fi
+
+      GITHUB_TOKEN=$(python3 /etc/buildkite-agent/get_github_token.py)
+      unset _BK_TEMP_GITHUB_APP_PEM
+
+      # Static URL rewrite for SSH to HTTPS, and Basic Auth header for HTTPS authentication
+      git config --global url."https://github.com/".insteadOf "git@github.com:"
+      AUTH_TOKEN=$(echo -n "x-access-token:$GITHUB_TOKEN" | base64 | tr -d '\n')
+      git config --global http.https://github.com/.extraheader "Authorization: Basic $AUTH_TOKEN"
+      EOF
+
+      chmod 500 /etc/buildkite-agent/get_github_token.py
+      chmod +x /etc/buildkite-agent/hooks/pre-checkout
+      chown -R buildkite-agent:buildkite-agent /etc/buildkite-agent/
+      # ==========================================
 
       sudo usermod -a -G docker buildkite-agent
       sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet

--- a/terraform/gcp_old/tpu-inference/modules/ci_v5/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v5/variables.tf
@@ -1,3 +1,10 @@
 variable "project_id" {
   default = "vllm-405802"
 }
+
+variable "github_app_secret_name" {
+  type        = string
+  description = "The Buildkite secret name for the GitHub App PEM key."
+  default     = "GITHUB_CI_BOT_PEM"
+}
+

--- a/terraform/gcp_old/tpu-inference/modules/ci_v6/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6/main.tf
@@ -6,19 +6,19 @@
 
 resource "google_compute_disk" "disk_east5_b" {
   provider = google-beta.us-east5-b
-  count = 24
+  count    = 24
 
-  name  = "tpu-disk-east5-b-${count.index}"
-  size  = 2048
-  type  = "hyperdisk-balanced"
-  zone  = "us-east5-b"
+  name = "tpu-disk-east5-b-${count.index}"
+  size = 2048
+  type = "hyperdisk-balanced"
+  zone = "us-east5-b"
 }
 
 resource "google_tpu_v2_vm" "tpu_v6_ci" {
   provider = google-beta.us-east5-b
-  count = 24
-  name = "vllm-tpu-v6-ci-${count.index}"
-  zone = "us-east5-b" 
+  count    = 24
+  name     = "vllm-tpu-v6-ci-${count.index}"
+  zone     = "us-east5-b"
 
   runtime_version = "v2-alpha-tpuv6e"
 
@@ -31,7 +31,7 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
 
   data_disks {
     source_disk = google_compute_disk.disk_east5_b[count.index].id
-    mode = "READ_WRITE"
+    mode        = "READ_WRITE"
   }
 
   metadata = {
@@ -39,7 +39,7 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       #!/bin/bash
 
       apt-get update
-      apt-get install -y curl build-essential jq
+      apt-get install -y curl build-essential jq git python3 python3-pip
 
       curl -o- https://get.docker.com/ | bash -
 
@@ -52,6 +52,64 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
       apt-get update
       apt-get install -y buildkite-agent
+
+      # Force stop the buildkite-agent and start at the end to avoid race condition
+      sudo systemctl stop buildkite-agent
+
+      # ==========================================
+      # Setup In-Memory GitHub App Authentication
+      # ==========================================
+      pip3 install pyjwt requests cryptography --break-system-packages || pip3 install pyjwt requests cryptography
+
+      # 1. Create the Python script
+      cat <<'EOF' > /etc/buildkite-agent/get_github_token.py
+      import os, time, requests, jwt
+
+      APP_ID = "4156238"
+      INSTALLATION_ID = "142868369"
+
+      signing_key = os.environ['_BK_TEMP_GITHUB_APP_PEM'].encode('utf-8')
+
+      payload = { 'iat': int(time.time()), 'exp': int(time.time()) + 600, 'iss': APP_ID }
+      encoded_jwt = jwt.encode(payload, signing_key, algorithm='RS256')
+
+      response = requests.post(
+          f'https://api.github.com/app/installations/{INSTALLATION_ID}/access_tokens',
+          headers={'Authorization': f'Bearer {encoded_jwt}', 'Accept': 'application/vnd.github.v3+json'}
+      )
+      response.raise_for_status()
+      print(response.json()['token'])
+      EOF
+
+      mkdir -p /etc/buildkite-agent/hooks
+
+      # 2. Create the Buildkite pre-checkout hook
+      cat <<'EOF' > /etc/buildkite-agent/hooks/pre-checkout
+      #!/bin/bash
+      set -e
+
+      echo "--- 🔐 Generating temporary GitHub token"
+
+      export _BK_TEMP_GITHUB_APP_PEM=$(buildkite-agent secret get ${var.github_app_secret_name})
+
+      if [ -z "$_BK_TEMP_GITHUB_APP_PEM" ]; then
+          echo "🚨 Error: Failed to fetch secret from Buildkite Secrets. Does the secret exist?"
+          exit 1
+      fi
+
+      GITHUB_TOKEN=$(python3 /etc/buildkite-agent/get_github_token.py)
+      unset _BK_TEMP_GITHUB_APP_PEM
+
+      # Static URL rewrite for SSH to HTTPS, and Basic Auth header for HTTPS authentication
+      git config --global url."https://github.com/".insteadOf "git@github.com:"
+      AUTH_TOKEN=$(echo -n "x-access-token:$GITHUB_TOKEN" | base64 | tr -d '\n')
+      git config --global http.https://github.com/.extraheader "Authorization: Basic $AUTH_TOKEN"
+      EOF
+
+      chmod 500 /etc/buildkite-agent/get_github_token.py
+      chmod +x /etc/buildkite-agent/hooks/pre-checkout
+      chown -R buildkite-agent:buildkite-agent /etc/buildkite-agent/
+      # ==========================================
 
       sudo usermod -a -G docker buildkite-agent
       sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet

--- a/terraform/gcp_old/tpu-inference/modules/ci_v6/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6/variables.tf
@@ -16,3 +16,9 @@ variable "buildkite_analytics_token_value" {
   type        = string
   description = "Analytics token used to push test data to Buildkite."
 }
+
+variable "github_app_secret_name" {
+  type        = string
+  description = "The Buildkite secret name for the GitHub App PEM key."
+  default     = "GITHUB_CI_BOT_PEM"
+}

--- a/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
@@ -47,7 +47,7 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       #!/bin/bash
 
       apt-get update
-      apt-get install -y curl build-essential jq
+      apt-get install -y curl build-essential jq git python3 python3-pip
 
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       /root/.cargo/bin/cargo install minijinja-cli
@@ -62,25 +62,60 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       # Force stop the buildkite-agent and start at the end to avoid race condition
       sudo systemctl stop buildkite-agent
 
-%{if var.github_deploy_key_value != null && var.github_deploy_key_value != ""}
-      mkdir -p /var/lib/buildkite-agent/.ssh
+      # ==========================================
+      # Setup In-Memory GitHub App Authentication
+      # ==========================================
+      pip3 install pyjwt requests cryptography --break-system-packages || pip3 install pyjwt requests cryptography
 
-      # Write the private deploy key directly from Terraform
-      cat <<EOF > /var/lib/buildkite-agent/.ssh/id_rsa
-${var.github_deploy_key_value}
-EOF
+      # 1. Create the Python script
+      cat <<'EOF' > /etc/buildkite-agent/get_github_token.py
+      import os, time, requests, jwt
 
-      # Prevent strict host checking on first clone
-      cat <<EOF > /var/lib/buildkite-agent/.ssh/config
-      Host github.com
-        StrictHostKeyChecking accept-new
-EOF
+      APP_ID = "4156238"
+      INSTALLATION_ID = "142868369"
 
-      # Secure permissions and hand ownership to buildkite-agent
-      chmod 600 /var/lib/buildkite-agent/.ssh/id_rsa
-      chmod 600 /var/lib/buildkite-agent/.ssh/config
-      chown -R buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.ssh
-%{endif}
+      signing_key = os.environ['_BK_TEMP_GITHUB_APP_PEM'].encode('utf-8')
+
+      payload = { 'iat': int(time.time()), 'exp': int(time.time()) + 600, 'iss': APP_ID }
+      encoded_jwt = jwt.encode(payload, signing_key, algorithm='RS256')
+
+      response = requests.post(
+          f'https://api.github.com/app/installations/{INSTALLATION_ID}/access_tokens',
+          headers={'Authorization': f'Bearer {encoded_jwt}', 'Accept': 'application/vnd.github.v3+json'}
+      )
+      response.raise_for_status()
+      print(response.json()['token'])
+      EOF
+
+      mkdir -p /etc/buildkite-agent/hooks
+
+      # 2. Create the Buildkite pre-checkout hook
+      cat <<'EOF' > /etc/buildkite-agent/hooks/pre-checkout
+      #!/bin/bash
+      set -e
+
+      echo "--- 🔐 Generating temporary GitHub token"
+
+      export _BK_TEMP_GITHUB_APP_PEM=$(buildkite-agent secret get ${var.github_app_secret_name})
+
+      if [ -z "$_BK_TEMP_GITHUB_APP_PEM" ]; then
+          echo "🚨 Error: Failed to fetch secret from Buildkite Secrets. Does the secret exist?"
+          exit 1
+      fi
+
+      GITHUB_TOKEN=$(python3 /etc/buildkite-agent/get_github_token.py)
+      unset _BK_TEMP_GITHUB_APP_PEM
+
+      # Static URL rewrite for SSH to HTTPS, and Basic Auth header for HTTPS authentication
+      git config --global url."https://github.com/".insteadOf "git@github.com:"
+      AUTH_TOKEN=$(echo -n "x-access-token:$GITHUB_TOKEN" | base64 | tr -d '\n')
+      git config --global http.https://github.com/.extraheader "Authorization: Basic $AUTH_TOKEN"
+      EOF
+
+      chmod 500 /etc/buildkite-agent/get_github_token.py
+      chmod +x /etc/buildkite-agent/hooks/pre-checkout
+      chown -R buildkite-agent:buildkite-agent /etc/buildkite-agent/
+      # ==========================================
 
       sudo usermod -a -G docker buildkite-agent
       sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet

--- a/terraform/gcp_old/tpu-inference/modules/ci_v6e/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6e/variables.tf
@@ -50,9 +50,8 @@ variable "buildkite_analytics_token_value" {
   description = "Analytics token used to push test data to Buildkite."
 }
 
-variable "github_deploy_key_value" {
+variable "github_app_secret_name" {
   type        = string
-  description = "Github deploy key for private repo access"
-  default     = null
-  sensitive   = true
+  description = "The Buildkite secret name for the GitHub App PEM key."
+  default     = "GITHUB_CI_BOT_PEM"
 }

--- a/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
@@ -47,7 +47,7 @@ resource "google_tpu_v2_vm" "tpu_v7x_ci" {
       #!/bin/bash
 
       apt-get update
-      apt-get install -y curl build-essential jq
+      apt-get install -y curl build-essential jq git python3 python3-pip
 
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       /root/.cargo/bin/cargo install minijinja-cli
@@ -62,25 +62,60 @@ resource "google_tpu_v2_vm" "tpu_v7x_ci" {
       # Force stop the buildkite-agent and start at the end to avoid race condition
       sudo systemctl stop buildkite-agent
 
-%{if var.github_deploy_key_value != null && var.github_deploy_key_value != ""}
-      mkdir -p /var/lib/buildkite-agent/.ssh
+      # ==========================================
+      # Setup In-Memory GitHub App Authentication
+      # ==========================================
+      pip3 install pyjwt requests cryptography --break-system-packages || pip3 install pyjwt requests cryptography
 
-      # Write the private deploy key directly from Terraform
-      cat <<EOF > /var/lib/buildkite-agent/.ssh/id_rsa
-${var.github_deploy_key_value}
-EOF
+      # 1. Create the Python script
+      cat <<'EOF' > /etc/buildkite-agent/get_github_token.py
+      import os, time, requests, jwt
 
-      # Prevent strict host checking on first clone
-      cat <<EOF > /var/lib/buildkite-agent/.ssh/config
-      Host github.com
-        StrictHostKeyChecking accept-new
-EOF
+      APP_ID = "4156238"
+      INSTALLATION_ID = "142868369"
 
-      # Secure permissions and hand ownership to buildkite-agent
-      chmod 600 /var/lib/buildkite-agent/.ssh/id_rsa
-      chmod 600 /var/lib/buildkite-agent/.ssh/config
-      chown -R buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.ssh
-%{endif}
+      signing_key = os.environ['_BK_TEMP_GITHUB_APP_PEM'].encode('utf-8')
+
+      payload = { 'iat': int(time.time()), 'exp': int(time.time()) + 600, 'iss': APP_ID }
+      encoded_jwt = jwt.encode(payload, signing_key, algorithm='RS256')
+
+      response = requests.post(
+          f'https://api.github.com/app/installations/{INSTALLATION_ID}/access_tokens',
+          headers={'Authorization': f'Bearer {encoded_jwt}', 'Accept': 'application/vnd.github.v3+json'}
+      )
+      response.raise_for_status()
+      print(response.json()['token'])
+      EOF
+
+      mkdir -p /etc/buildkite-agent/hooks
+
+      # 2. Create the Buildkite pre-checkout hook
+      cat <<'EOF' > /etc/buildkite-agent/hooks/pre-checkout
+      #!/bin/bash
+      set -e
+
+      echo "--- 🔐 Generating temporary GitHub token"
+
+      export _BK_TEMP_GITHUB_APP_PEM=$(buildkite-agent secret get ${var.github_app_secret_name})
+
+      if [ -z "$_BK_TEMP_GITHUB_APP_PEM" ]; then
+          echo "🚨 Error: Failed to fetch secret from Buildkite Secrets. Does the secret exist?"
+          exit 1
+      fi
+
+      GITHUB_TOKEN=$(python3 /etc/buildkite-agent/get_github_token.py)
+      unset _BK_TEMP_GITHUB_APP_PEM
+
+      # Static URL rewrite for SSH to HTTPS, and Basic Auth header for HTTPS authentication
+      git config --global url."https://github.com/".insteadOf "git@github.com:"
+      AUTH_TOKEN=$(echo -n "x-access-token:$GITHUB_TOKEN" | base64 | tr -d '\n')
+      git config --global http.https://github.com/.extraheader "Authorization: Basic $AUTH_TOKEN"
+      EOF
+
+      chmod 500 /etc/buildkite-agent/get_github_token.py
+      chmod +x /etc/buildkite-agent/hooks/pre-checkout
+      chown -R buildkite-agent:buildkite-agent /etc/buildkite-agent/
+      # ==========================================
 
       sudo usermod -a -G docker buildkite-agent
       sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet

--- a/terraform/gcp_old/tpu-inference/modules/ci_v7x/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v7x/variables.tf
@@ -49,9 +49,8 @@ variable "buildkite_analytics_token_value" {
   description = "Analytics token used to push test data to Buildkite."
 }
 
-variable "github_deploy_key_value" {
+variable "github_app_secret_name" {
   type        = string
-  description = "Github deploy key for private repo access"
-  default     = null
-  sensitive   = true
+  description = "The Buildkite secret name for the GitHub App PEM key."
+  default     = "GITHUB_CI_BOT_PEM"
 }


### PR DESCRIPTION
Previously we used github deploy key (ssh key) to access the private github repo.
However, deploy key is per repo and if we need to continue to the route, we need to mess with the vm ssh key everytime we set up a different repo. 
We happen to create a github app for managing vllm tpu related pr, let's reuse that instead. 
The way it works is:
1. we create a new script that can generate a short lived token based on github app private key
2. create a new buildkite hood that automatically invoke the script before checking out the repo
3. by the time we checkout the repo we will use the new github app token

Signed-off-by: Ming Huang <mhhua@google.com>