### PR TITLE
Dump nvidia-smi topo -m for multi-GPU test steps

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -376,17 +376,42 @@ def _get_variables_to_inject() -> Dict[str, str]:
     }
 
 
+def _is_multi_gpu_step(step: Step) -> bool:
+    """Whether a step exercises more than one GPU.
+
+    Multi-GPU (tensor/pipeline parallel) and multi-node steps rely on the
+    cross-GPU fabric (NVLink/NVSwitch) and P2P being healthy on whichever node
+    they land on. Single-GPU steps don't, so the topology dump is only worth the
+    log noise for these.
+    """
+    if step.num_nodes and step.num_nodes >= 2:
+        return True
+    return bool(step.num_devices and step.num_devices >= 2)
+
+
 def _get_setup_commands(step: Step, setup_profile: SetupProfile) -> List[str]:
     if step.label.startswith(":docker:") or step.no_plugin or setup_profile == "none":
         return []
 
     if setup_profile == "nvidia":
-        return [
+        commands = [
             "echo '--- :nvidia: GPU Info'",
             "(command nvidia-smi || true)",
+        ]
+        if _is_multi_gpu_step(step):
+            # Dump the GPU/NVLink topology for multi-GPU jobs so infra flakes on
+            # a node with a degraded fabric (unhealthy NVSwitch/fabric-manager,
+            # missing P2P) are visible in the log and distinguishable from real
+            # regressions. Cheap and never fails the step.
+            commands += [
+                "echo '--- :nvidia: GPU Topology'",
+                "(command nvidia-smi topo -m || true)",
+            ]
+        commands += [
             "echo '--- :gear: CUDA Coredump Setup'",
             "export CUDA_ENABLE_COREDUMP_ON_EXCEPTION=1 && export CUDA_COREDUMP_SHOW_PROGRESS=1 && export CUDA_COREDUMP_GENERATION_FLAGS='skip_nonrelocated_elf_images,skip_global_memory,skip_shared_memory,skip_local_memory,skip_constbank_memory'",
         ]
+        return commands
 
     if setup_profile == "amd":
         return [

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -206,6 +206,64 @@ def test_continue_on_failure_exits_nonzero_after_command_failure(monkeypatch):
     assert result.returncode == 1
 
 
+def test_multi_gpu_step_dumps_nvidia_topology():
+    step = Step(
+        label="Distributed Comm Ops Test",
+        group="Distributed",
+        key="distributed-comm-ops",
+        depends_on=["image-build"],
+        device="h100",
+        num_devices=2,
+        working_dir="/vllm-workspace/tests",
+        commands=["pytest tests/distributed/test_comm_ops.py"],
+    )
+
+    commands = buildkite_step._prepare_commands(step, variables_to_inject={})
+
+    assert '(command nvidia-smi topo -m || true)' in commands
+    # Topology dump comes after the base GPU info and before coredump setup.
+    topo_index = commands.index('(command nvidia-smi topo -m || true)')
+    smi_index = commands.index('(command nvidia-smi || true)')
+    assert smi_index < topo_index
+
+
+def test_multi_node_step_dumps_nvidia_topology():
+    step = Step(
+        label="Multi-node Test",
+        group="Distributed",
+        key="multi-node",
+        depends_on=["image-build"],
+        device="h100",
+        num_nodes=2,
+        num_devices=4,
+        working_dir="/vllm-workspace/tests",
+        commands=["pytest tests/distributed/test_multi_node.py"],
+    )
+
+    commands = buildkite_step._prepare_commands(step, variables_to_inject={})
+
+    assert '(command nvidia-smi topo -m || true)' in commands
+
+
+def test_single_gpu_step_skips_nvidia_topology():
+    step = Step(
+        label="Single GPU Test",
+        group="Single",
+        key="single-gpu",
+        depends_on=["image-build"],
+        device="h100",
+        num_devices=1,
+        working_dir="/vllm-workspace/tests",
+        commands=["pytest tests/basic.py"],
+    )
+
+    commands = buildkite_step._prepare_commands(step, variables_to_inject={})
+
+    # Base GPU info is still emitted, but the topology dump is multi-GPU only.
+    assert '(command nvidia-smi || true)' in commands
+    assert '(command nvidia-smi topo -m || true)' not in commands
+
+
 def test_amd_mirror_uses_shared_gating_with_amd_dependency_fallback(
     fake_global_config,
 ):


### PR DESCRIPTION
## What

Emit `nvidia-smi topo -m` in the per-step setup for **NVIDIA steps that use more than one GPU** (tensor/pipeline parallel, i.e. `num_devices >= 2`, or multi-node `num_nodes >= 2`), right after the existing `nvidia-smi` GPU-info dump. It's gated to multi-GPU steps to keep single-GPU logs clean and wrapped in `|| true` so it never fails the step.

## Why

We recently chased a flaky "Fusion E2E TP2 Quick (H100)" failure that turned out to be **infra, not code**: the pod landed on a node whose NVLink/NVSwitch fabric was degraded, so every P2P-based communicator failed to init (`CUDA driver error: invalid device ordinal`) across three independent stacks (torch symmetric memory, vLLM custom all-reduce, FlashInfer workspace). The TP group fell back to PyNCCL, the AllReduce fusion pass disabled itself, and the tests failed their fusion-count assertions (`Could not find 2 ar_rms_fusion (found 0)`).

From the assertion errors alone this looked like a real fusion regression. The signal that would have made it obviously an infra flake — the GPU topology / P2P layout on that specific node — wasn't in the log. `nvidia-smi topo -m` captures exactly that, as the container sees it (which is what matters for P2P), so a degraded-fabric node is visible at a glance and flaky-by-scheduling failures are distinguishable from code regressions.

This only matters for jobs that actually use the fabric, hence the multi-GPU gate.

## Change

In `_get_setup_commands` ([buildkite_step.py](buildkite/pipeline_generator/buildkite_step.py)), for the `nvidia` setup profile:

```
echo '--- :nvidia: GPU Info'
(command nvidia-smi || true)
echo '--- :nvidia: GPU Topology'        # multi-GPU steps only
(command nvidia-smi topo -m || true)    # multi-GPU steps only
echo '--- :gear: CUDA Coredump Setup'
export CUDA_ENABLE_COREDUMP_ON_EXCEPTION=1 && ...
```

A small `_is_multi_gpu_step()` helper gates it on `num_devices >= 2` / `num_nodes >= 2`.

## Tests

Added three cases in `test_step.py`: topology present for a TP2 step, present for a multi-node step, and absent for a single-GPU step (base `nvidia-smi` still emitted). Full suite: 10 passed.

## Notes / possible follow-ups

- **Scope:** NVIDIA only, matching the class of failure above. AMD steps encode their GPU count in the device name (`mi300_4`) rather than `num_devices`, and would need `amd-smi topology` — left out to keep this focused; easy follow-up if wanted.
- This is purely diagnostic (log output); it does not change test selection, gating, or pass/fail behavior. A louder fail-fast/skip when P2P init fails on a queue where it's expected is a separate, bigger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)