### PR TITLE
Enforce test-step timeouts in generated pipeline

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -169,6 +169,7 @@ class BuildkiteCommandStep(BaseModel):
     plugins: Optional[List[Dict[str, Any]]] = None
     env: Optional[Dict[str, str]] = None
     parallelism: Optional[int] = None
+    timeout_in_minutes: Optional[int] = None
     priority: Optional[int] = None
 
     def to_yaml(self):
@@ -184,6 +185,7 @@ class BuildkiteCommandStep(BaseModel):
             "plugins": self.plugins,
             "env": self.env,
             "parallelism": self.parallelism,
+            "timeout_in_minutes": self.timeout_in_minutes,
             "priority": self.priority,
         }
 
@@ -528,6 +530,7 @@ def convert_group_step_to_buildkite_step(
                     extra_env=step.env,
                     soft_fail=step.soft_fail,
                     parallelism=step.parallelism,
+                    timeout_in_minutes=step.timeout_in_minutes,
                 )
                 if not _step_should_run(step, list_file_diff):
                     block_step = _create_block_step(
@@ -560,6 +563,8 @@ def convert_group_step_to_buildkite_step(
                 buildkite_step.key = step.key
             if step.parallelism:
                 buildkite_step.parallelism = step.parallelism
+            if step.timeout_in_minutes:
+                buildkite_step.timeout_in_minutes = step.timeout_in_minutes
 
             if not _step_should_run(step, list_file_diff):
                 block_step = _create_block_step(
@@ -617,6 +622,7 @@ def convert_group_step_to_buildkite_step(
                     extra_env=extra_env,
                     soft_fail=amd.get("soft_fail", step.soft_fail or False),
                     parallelism=step.parallelism,
+                    timeout_in_minutes=amd.get("timeout_in_minutes"),
                 )
                 if not _step_should_run(
                     _get_amd_mirror_effective_step(step, amd), list_file_diff
@@ -722,6 +728,7 @@ def _create_amd_step(
     soft_fail: Optional[bool],
     parallelism: Optional[int],
     key: Optional[str] = None,
+    timeout_in_minutes: Optional[int] = None,
 ) -> BuildkiteCommandStep:
     """Create a Buildkite command step that runs through the AMD CI wrapper."""
     if not _is_amd_gpu_device(device):
@@ -742,4 +749,5 @@ def _create_amd_step(
         soft_fail=soft_fail or False,
         retry=AMD_RETRY,
         parallelism=parallelism,
+        timeout_in_minutes=timeout_in_minutes,
     )

--- a/buildkite/pipeline_generator/step.py
+++ b/buildkite/pipeline_generator/step.py
@@ -22,6 +22,7 @@ class Step(BaseModel):
     source_file_dependencies: Optional[List[str]] = None
     soft_fail: Optional[bool] = False
     parallelism: Optional[int] = None
+    timeout_in_minutes: Optional[int] = None
     mount_buildkite_agent: Optional[bool] = False
     env: Optional[Dict[str, str]] = None
     retry: Optional[Dict[str, Any]] = None

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -288,5 +288,149 @@ def test_torch_nightly_flag_no_separate_group(fake_global_config):
     assert not any(lbl.startswith("Torch Nightly ") for lbl in labels)
 
 
+def test_timeout_in_minutes_propagates_to_command_step():
+    step = Step(
+        label="Timed test",
+        group="Timing",
+        key="timed-test",
+        depends_on=["image-build"],
+        working_dir="/vllm-workspace/tests",
+        commands=["pytest tests/timed.py"],
+        device="h200_18gb",
+        timeout_in_minutes=42,
+    )
+
+    group_step = _render_single_step(step)
+    command_step = next(
+        s for s in group_step.steps
+        if isinstance(s, buildkite_step.BuildkiteCommandStep)
+    )
+
+    assert command_step.timeout_in_minutes == 42
+
+
+def test_missing_timeout_in_minutes_is_omitted_from_pipeline():
+    step = Step(
+        label="Untimed test",
+        group="Timing",
+        key="untimed-test",
+        depends_on=["image-build"],
+        working_dir="/vllm-workspace/tests",
+        commands=["pytest tests/untimed.py"],
+        device="h200_18gb",
+    )
+
+    group_step = _render_single_step(step)
+    command_step = next(
+        s for s in group_step.steps
+        if isinstance(s, buildkite_step.BuildkiteCommandStep)
+    )
+
+    assert command_step.timeout_in_minutes is None
+    # exclude_none is used when dumping the pipeline, so an unset timeout must
+    # not surface as a key at all.
+    assert "timeout_in_minutes" not in command_step.dict(exclude_none=True)
+
+
+def test_direct_amd_gpu_step_propagates_timeout():
+    step = Step(
+        label="AMD direct timed",
+        group="Direct AMD",
+        key="amd-direct-timed",
+        depends_on=["image-build"],
+        device="mi300_4",
+        working_dir="/vllm-workspace/tests",
+        commands=["pytest tests/foo.py"],
+        timeout_in_minutes=90,
+    )
+
+    group_step = _render_single_step(step)
+    command_step = next(
+        s for s in group_step.steps
+        if isinstance(s, buildkite_step.BuildkiteCommandStep)
+    )
+
+    assert command_step.timeout_in_minutes == 90
+
+
+def test_amd_mirror_uses_its_own_timeout_in_minutes(fake_global_config):
+    fake_global_config["list_file_diff"] = ["vllm/foo.py"]
+    step = Step(
+        label="Mirrored timed test",
+        group="Mirrors",
+        key="mirrored-timed",
+        depends_on=["image-build"],
+        working_dir="/vllm-workspace/tests",
+        commands=["pytest tests/mirror.py"],
+        source_file_dependencies=["vllm/"],
+        device="h200_18gb",
+        timeout_in_minutes=40,
+        mirror={
+            "amd": {
+                "device": "mi325_1",
+                "depends_on": ["image-build-amd"],
+                "timeout_in_minutes": 75,
+            }
+        },
+    )
+
+    group_steps = buildkite_step.convert_group_step_to_buildkite_step({
+        step.group: [step],
+    })
+    default_group = next(group for group in group_steps if group.group == "Mirrors")
+    default_command_step = next(
+        s for s in default_group.steps
+        if isinstance(s, buildkite_step.BuildkiteCommandStep)
+    )
+    amd_group = next(
+        group for group in group_steps if group.group == "Hardware-AMD Tests"
+    )
+    amd_command_step = next(
+        s for s in amd_group.steps
+        if isinstance(s, buildkite_step.BuildkiteCommandStep)
+    )
+
+    # The main step keeps its own timeout; the AMD mirror uses the (larger)
+    # timeout declared on the mirror block.
+    assert default_command_step.timeout_in_minutes == 40
+    assert amd_command_step.timeout_in_minutes == 75
+
+
+def test_amd_mirror_without_timeout_stays_unbounded(fake_global_config):
+    fake_global_config["list_file_diff"] = ["vllm/foo.py"]
+    step = Step(
+        label="Mirrored untimed test",
+        group="Mirrors",
+        key="mirrored-untimed",
+        depends_on=["image-build"],
+        working_dir="/vllm-workspace/tests",
+        commands=["pytest tests/mirror.py"],
+        source_file_dependencies=["vllm/"],
+        device="h200_18gb",
+        timeout_in_minutes=40,
+        mirror={
+            "amd": {
+                "device": "mi325_1",
+                "depends_on": ["image-build-amd"],
+            }
+        },
+    )
+
+    group_steps = buildkite_step.convert_group_step_to_buildkite_step({
+        step.group: [step],
+    })
+    amd_group = next(
+        group for group in group_steps if group.group == "Hardware-AMD Tests"
+    )
+    amd_command_step = next(
+        s for s in amd_group.steps
+        if isinstance(s, buildkite_step.BuildkiteCommandStep)
+    )
+
+    # An AMD mirror without its own timeout must not inherit the shorter main
+    # timeout (AMD runs slower); it stays unbounded until one is declared.
+    assert amd_command_step.timeout_in_minutes is None
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Purpose

Make the pipeline generator actually **enforce** the `timeout_in_minutes` declared on vLLM test steps.

Today the generator drops it: `Step` has no `timeout_in_minutes` field (pydantic silently ignores the key from the `.buildkite/test_areas/*.yaml` files) and `BuildkiteCommandStep` never emits one. So every generated Buildkite step runs with **no step timeout** — a hung job runs until the build-level cap instead of failing at its declared limit. This is visible in the nightly full run [ci/builds/77252](https://buildkite.com/vllm/ci/builds/77252), where jobs ran well past their `timeout_in_minutes` (and two hung for ~6h before the build was killed).

The timeout values themselves were just right-sized in vllm-project/vllm#48186 (merged); this PR is what makes the generator honor them.

## Changes

Propagate `timeout_in_minutes` end to end:
- Add the field to `Step` so it is parsed from the test-area yaml.
- Add it to `BuildkiteCommandStep`. The pipeline is dumped with `.dict(exclude_none=True)`, so it is emitted **only when set** — steps without a declared timeout are byte-for-byte unchanged.
- Wire it through the main command step, the direct-AMD-GPU step, and the AMD mirror step.

**AMD mirror behavior:** the mirror uses the timeout declared on its own `mirror.amd` block. It deliberately does **not** inherit the (shorter) main-step timeout, since AMD hardware runs slower; a mirror without a declared timeout stays unbounded until one is added.

## Test

```
python3 -m pytest buildkite/tests/pipeline_generator/test_step.py -q
# 13 passed
```

New tests cover main-step, direct-AMD, and mirror propagation (mirror with its own timeout, and mirror without one staying unbounded).

Also verified end-to-end by running the generator against the merged `vllm-project/vllm` `.buildkite/test_areas` and confirming the emitted pipeline carries the expected values (210 timeouts: 180 main + 30 AMD), e.g. `V1 attention (H100-MI300)` → 85, its AMD mirror → 95, `Samplers Test` → 40.

## Notes

AI assistance (Claude Code) was used to investigate and prepare this change; the maintainer has reviewed it.
