### PR TITLE
Fix pipeline generator test imports

### DIFF
--- a/buildkite/tests/pipeline_generator/test_global_config.py
+++ b/buildkite/tests/pipeline_generator/test_global_config.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import patch
-from buildkite.pipeline_generator.global_config import _validate_pipeline_config
+from global_config import _validate_pipeline_config
 
 
 def test_validate_pipeline_config_valid_repo():

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -4,9 +4,6 @@ from pathlib import Path
 
 import pytest
 
-PIPELINE_GENERATOR_DIR = Path(__file__).resolve().parents[2] / "pipeline_generator"
-sys.path.insert(0, str(PIPELINE_GENERATOR_DIR))
-
 import buildkite_step
 import step as step_module
 from constants import AgentQueue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,4 @@ requires-python = ">=3.8"
 include = ["buildkite*"]
 
 [tool.pytest.ini_options]
-pythonpath = ["."]
+pythonpath = [".", "buildkite/pipeline_generator"]


### PR DESCRIPTION
## Summary

- add the pipeline generator source directory to pytest's configured import path
- make the global-config test use the same flat-module import model as the installed generator
- remove the per-test `sys.path` mutation from `test_step.py`

## Why

The generator is distributed as top-level modules, but the newer global-config test imported it through `buildkite.pipeline_generator`. As a result, ordinary test collection failed with `ModuleNotFoundError: utils_lib`, while another test file worked around the layout by mutating `sys.path` during import.

This centralizes the test import path in pytest configuration and makes both test modules use the generator's actual installed import model.

## Impact

This is test infrastructure only; generated Buildkite pipelines and runtime behavior are unchanged.

## Validation

- `python3 -m pytest -q` — 11 passed
- `python3 -m ruff check buildkite/pipeline_generator buildkite/tests/pipeline_generator`
- `git diff --check`