### PR TITLE
Make pipeline agent routing declarative

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -232,66 +232,60 @@ def _get_amd_gpu_agent_queue(device: Optional[str]) -> Optional[AgentQueue]:
         return None
 
 
-def get_agent_queue(step: Step):
+DEVICE_AGENT_QUEUES = {
+    DeviceType.CPU_SMALL.value: AgentQueue.SMALL_CPU_PREMERGE,
+    DeviceType.CPU_MEDIUM.value: AgentQueue.MEDIUM_CPU_PREMERGE,
+    DeviceType.CPU.value: AgentQueue.CPU_PREMERGE_US_EAST_1,
+    DeviceType.A100.value: AgentQueue.A100,
+    DeviceType.H100.value: AgentQueue.MITHRIL_H100,
+    DeviceType.H200.value: AgentQueue.H200,
+    DeviceType.H200_18GB.value: AgentQueue.H200_18GB,
+    DeviceType.H200_35GB.value: AgentQueue.H200_35GB,
+    DeviceType.B200.value: AgentQueue.B200,
+    DeviceType.B200_K8S.value: AgentQueue.B200_K8S,
+    DeviceType.INTEL_CPU.value: AgentQueue.INTEL_CPU,
+    DeviceType.INTEL_HPU.value: AgentQueue.INTEL_HPU,
+    DeviceType.INTEL_GPU.value: AgentQueue.INTEL_GPU,
+    DeviceType.ARM_CPU.value: AgentQueue.ARM_CPU,
+    DeviceType.AMD_CPU.value: AgentQueue.AMD_CPU,
+    DeviceType.GH200.value: AgentQueue.GH200,
+    DeviceType.ASCEND.value: AgentQueue.ASCEND,
+    DeviceType.DGX_SPARK.value: AgentQueue.DGX_SPARK,
+}
+
+
+def _get_docker_agent_queue(label: str, branch: str) -> AgentQueue:
+    if "arm64" in label:
+        return (
+            AgentQueue.ARM64_CPU_POSTMERGE
+            if branch == "main"
+            else AgentQueue.ARM64_CPU_PREMERGE
+        )
+    return (
+        AgentQueue.CPU_POSTMERGE_US_EAST_1
+        if branch == "main"
+        else AgentQueue.CPU_PREMERGE_US_EAST_1
+    )
+
+
+def get_agent_queue(step: Step) -> AgentQueue:
     branch = get_global_config()["branch"]
+
+    # Labels encode pipeline roles, so they take precedence over device metadata.
     if step.label.startswith(":docker:"):
-        if "arm64" in step.label:
-            if branch == "main":
-                return AgentQueue.ARM64_CPU_POSTMERGE
-            else:
-                return AgentQueue.ARM64_CPU_PREMERGE
-        if branch == "main":
-            return AgentQueue.CPU_POSTMERGE_US_EAST_1
-        else:
-            return AgentQueue.CPU_PREMERGE_US_EAST_1
-    elif step.label == "Documentation Build":
+        return _get_docker_agent_queue(step.label, branch)
+    if step.label == "Documentation Build":
         return AgentQueue.SMALL_CPU_PREMERGE
-    elif step.device == DeviceType.CPU_SMALL:
-        return AgentQueue.SMALL_CPU_PREMERGE
-    elif step.device == DeviceType.CPU_MEDIUM:
-        return AgentQueue.MEDIUM_CPU_PREMERGE
-    elif step.device == DeviceType.CPU:
-        return AgentQueue.CPU_PREMERGE_US_EAST_1
-    elif step.device == DeviceType.A100:
-        return AgentQueue.A100
-    elif step.device == DeviceType.H100:
-        # Route multi-GPU H100 tests to RedHat Frankfurt queue
-        if step.num_devices is not None and step.num_devices >= 4:
-            return AgentQueue.MITHRIL_H100
-        else:
-            return AgentQueue.MITHRIL_H100
-    elif step.device == DeviceType.H200:
-        return AgentQueue.H200
-    elif step.device == DeviceType.H200_18GB:
-        return AgentQueue.H200_18GB
-    elif step.device == DeviceType.H200_35GB:
-        return AgentQueue.H200_35GB
-    elif step.device == DeviceType.B200:
-        return AgentQueue.B200
-    elif step.device == DeviceType.B200_K8S:
-        return AgentQueue.B200_K8S
-    elif step.device == DeviceType.INTEL_CPU:
-        return AgentQueue.INTEL_CPU
-    elif step.device == DeviceType.INTEL_HPU:
-        return AgentQueue.INTEL_HPU
-    elif step.device == DeviceType.INTEL_GPU:
-        return AgentQueue.INTEL_GPU
-    elif step.device == DeviceType.ARM_CPU:
-        return AgentQueue.ARM_CPU
-    elif step.device == DeviceType.AMD_CPU or step.device == DeviceType.AMD_CPU.value:
-        return AgentQueue.AMD_CPU
-    elif amd_gpu_queue := _get_amd_gpu_agent_queue(step.device):
+
+    if amd_gpu_queue := _get_amd_gpu_agent_queue(step.device):
         return amd_gpu_queue
-    elif step.device == DeviceType.GH200:
-        return AgentQueue.GH200
-    elif step.device == DeviceType.ASCEND:
-        return AgentQueue.ASCEND
-    elif step.device == DeviceType.DGX_SPARK:
-        return AgentQueue.DGX_SPARK
-    elif step.num_devices == 2 or step.num_devices == 4:
+
+    if device_queue := DEVICE_AGENT_QUEUES.get(_device_value(step.device)):
+        return device_queue
+
+    if step.num_devices in (2, 4):
         return AgentQueue.GPU_4
-    else:
-        return AgentQueue.GPU_1
+    return AgentQueue.GPU_1
 
 
 def _is_amd_gpu_device(device: Optional[str]) -> bool:

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -6,7 +6,7 @@ import pytest
 
 import buildkite_step
 import step as step_module
-from constants import AgentQueue
+from constants import AgentQueue, DeviceType
 from step import Step, group_steps, read_steps_from_job_dir
 
 TEST_JOB_DIR = Path(__file__).resolve().parent / "test_files" / "test_jobs"
@@ -91,6 +91,70 @@ def test_group_steps_sorts_steps_within_each_group():
         "Test C",
         "Test D",
     ]
+
+
+@pytest.mark.parametrize(
+    ("device", "queue"),
+    [
+        (DeviceType.CPU_SMALL, AgentQueue.SMALL_CPU_PREMERGE),
+        (DeviceType.CPU_MEDIUM, AgentQueue.MEDIUM_CPU_PREMERGE),
+        (DeviceType.CPU, AgentQueue.CPU_PREMERGE_US_EAST_1),
+        (DeviceType.A100, AgentQueue.A100),
+        (DeviceType.H100, AgentQueue.MITHRIL_H100),
+        (DeviceType.H200, AgentQueue.H200),
+        (DeviceType.H200_18GB, AgentQueue.H200_18GB),
+        (DeviceType.H200_35GB, AgentQueue.H200_35GB),
+        (DeviceType.B200, AgentQueue.B200),
+        (DeviceType.B200_K8S, AgentQueue.B200_K8S),
+        (DeviceType.INTEL_CPU, AgentQueue.INTEL_CPU),
+        (DeviceType.INTEL_HPU, AgentQueue.INTEL_HPU),
+        (DeviceType.INTEL_GPU, AgentQueue.INTEL_GPU),
+        (DeviceType.ARM_CPU, AgentQueue.ARM_CPU),
+        (DeviceType.AMD_CPU, AgentQueue.AMD_CPU),
+        (DeviceType.GH200, AgentQueue.GH200),
+        (DeviceType.ASCEND, AgentQueue.ASCEND),
+        (DeviceType.DGX_SPARK, AgentQueue.DGX_SPARK),
+    ],
+)
+def test_device_agent_queue_routing(device, queue):
+    assert buildkite_step.get_agent_queue(Step(label="test", device=device)) == queue
+
+
+@pytest.mark.parametrize(
+    ("branch", "label", "queue"),
+    [
+        ("main", ":docker: build", AgentQueue.CPU_POSTMERGE_US_EAST_1),
+        ("feature", ":docker: build", AgentQueue.CPU_PREMERGE_US_EAST_1),
+        ("main", ":docker: build arm64", AgentQueue.ARM64_CPU_POSTMERGE),
+        ("feature", ":docker: build arm64", AgentQueue.ARM64_CPU_PREMERGE),
+    ],
+)
+def test_docker_agent_queue_routing(fake_global_config, branch, label, queue):
+    fake_global_config["branch"] = branch
+
+    assert buildkite_step.get_agent_queue(Step(label=label)) == queue
+
+
+@pytest.mark.parametrize(
+    ("step", "queue"),
+    [
+        (Step(label="Documentation Build"), AgentQueue.SMALL_CPU_PREMERGE),
+        (
+            Step(label="Documentation Build", device=DeviceType.H100),
+            AgentQueue.SMALL_CPU_PREMERGE,
+        ),
+        (
+            Step(label="test", device=DeviceType.H100, num_devices=4),
+            AgentQueue.MITHRIL_H100,
+        ),
+        (Step(label="test", num_devices=2), AgentQueue.GPU_4),
+        (Step(label="test", num_devices=4), AgentQueue.GPU_4),
+        (Step(label="test", num_devices=1), AgentQueue.GPU_1),
+        (Step(label="test"), AgentQueue.GPU_1),
+    ],
+)
+def test_special_and_fallback_agent_queue_routing(step, queue):
+    assert buildkite_step.get_agent_queue(step) == queue
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- replace the long device-routing conditional with an explicit `DeviceType`-to-`AgentQueue` policy table
- isolate Docker main/pre-merge and arm64 label routing in a small helper
- preserve label, AMD, device, and GPU-count precedence explicitly
- add table-driven coverage for every static device route, Docker branch routes, documentation precedence, H100 precedence, and generic GPU fallbacks

## Why

`get_agent_queue` encoded scheduling policy in roughly 30 branches and 27 return statements. It was difficult to audit and included an H100 conditional whose two branches returned the same queue.

A declarative table makes the hardware policy visible in one place and keeps the exceptional label-based rules separate. This follows the test-collection fix merged in #409.

## Impact

Generated queue assignments are unchanged. Adding or reviewing a static device route now requires editing one table entry instead of extending a branch chain.

## Validation

- `python3 -m pytest -q` — 40 passed
- `python3 -m ruff check buildkite/pipeline_generator buildkite/tests/pipeline_generator`
- `git diff --check`
- exhaustive old/new comparison across 34,128 label, branch, device, and GPU-count combinations — zero differences