### PR TITLE
Soft fail all AMD mirror tests

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -615,7 +615,7 @@ def convert_group_step_to_buildkite_step(
                     commands_str=amd_commands_str,
                     depends_on=amd.get("depends_on"),
                     extra_env=extra_env,
-                    soft_fail=amd.get("soft_fail", step.soft_fail or False),
+                    soft_fail=True,
                     parallelism=step.parallelism,
                 )
                 if not _step_should_run(

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -220,6 +220,7 @@ def test_amd_mirror_uses_shared_gating_with_amd_dependency_fallback(
             "amd": {
                 "device": "mi325_1",
                 "depends_on": ["image-build-amd"],
+                "soft_fail": False,
                 "source_file_dependencies": ["amd-only/"],
             }
         },
@@ -242,9 +243,11 @@ def test_amd_mirror_uses_shared_gating_with_amd_dependency_fallback(
     )
 
     assert default_command_step.depends_on == ["image-build"]
+    assert default_command_step.soft_fail is False
     assert len(amd_group.steps) == 1
     assert amd_command_step.depends_on == ["image-build-amd"]
     assert amd_command_step.agents == {"queue": AgentQueue.AMD_MI325_1}
+    assert amd_command_step.soft_fail is True
     assert "ROCm debug agent disabled" in (
         amd_command_step.env["VLLM_TEST_COMMANDS"]
     )


### PR DESCRIPTION
## Summary

- force every generated `mirror.amd` test step to soft-fail
- keep the original test, direct AMD-only jobs, and AMD image/setup jobs blocking
- add regression coverage proving an explicit mirror-level `soft_fail: false` is overridden without changing the source step

## Why

AMD mirror jobs are shadow coverage and should surface failures as Buildkite warnings without blocking the parent build. The generator currently inherits or honors per-step soft-fail settings, leaving most AMD mirrors blocking.

## Impact

Current and future `mirror.amd` variants will be non-blocking. AMD-native tests and AMD image/setup dependencies retain their existing failure behavior.

## Validation

- `pytest -q buildkite/tests/pipeline_generator` — 11 passed
- `python3 -m compileall -q buildkite/pipeline_generator buildkite/tests/pipeline_generator`
- `git diff --check`
- targeted pre-commit checks: debug statements, EOF, line endings, trailing whitespace, and Ruff lint
