### PR TITLE
Add generic native pipeline renderer

### DIFF
--- a/buildkite/pipeline_generator/change_detection.py
+++ b/buildkite/pipeline_generator/change_detection.py
@@ -1,0 +1,101 @@
+"""Resolve repository changes without mutating the working tree."""
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class ChangeContext:
+    """Build context used to choose the appropriate Git comparison base."""
+
+    branch: str
+    commit: str
+    pull_request: Optional[str] = None
+    pull_request_base_branch: Optional[str] = None
+    default_branch: str = "main"
+
+    @property
+    def is_pull_request(self) -> bool:
+        return self.pull_request not in (None, "", "false")
+
+    @classmethod
+    def from_environment(
+        cls, environment: Optional[Mapping[str, str]] = None
+    ) -> "ChangeContext":
+        """Build a context from standard Buildkite environment variables."""
+        environment = os.environ if environment is None else environment
+        return cls(
+            branch=environment.get("BUILDKITE_BRANCH", ""),
+            commit=environment.get("BUILDKITE_COMMIT", "HEAD"),
+            pull_request=environment.get("BUILDKITE_PULL_REQUEST"),
+            pull_request_base_branch=environment.get(
+                "BUILDKITE_PULL_REQUEST_BASE_BRANCH"
+            ),
+            default_branch=environment.get("BUILDKITE_PIPELINE_DEFAULT_BRANCH", "main"),
+        )
+
+
+def resolve_changed_files(
+    context: ChangeContext, repo_root: Path = Path(".")
+) -> Optional[List[str]]:
+    """Return changed paths, or ``None`` when a safe diff cannot be resolved.
+
+    Pull requests are compared with the merge base of their target branch.
+    Other feature branches use the pipeline's default branch. Builds on the
+    default branch compare the current commit with its first parent.
+
+    Returning ``None`` lets callers safely fall back to running every step.
+    This function intentionally performs no fetches and never changes the Git
+    index or working tree.
+    """
+    commit = context.commit or "HEAD"
+
+    if context.is_pull_request:
+        base_branch = context.pull_request_base_branch or context.default_branch
+        base = _merge_base(repo_root, "origin/{}".format(base_branch), commit)
+    elif context.branch == context.default_branch:
+        base = _git_output(repo_root, ["rev-parse", "{}^".format(commit)])
+    else:
+        base = _merge_base(
+            repo_root, "origin/{}".format(context.default_branch), commit
+        )
+
+    if base is None:
+        return None
+
+    output = _git_output(
+        repo_root,
+        [
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMDR",
+            base,
+            commit,
+            "--",
+        ],
+    )
+    if output is None:
+        return None
+    return [path for path in output.splitlines() if path]
+
+
+def _merge_base(repo_root: Path, base_ref: str, commit: str) -> Optional[str]:
+    return _git_output(repo_root, ["merge-base", base_ref, commit])
+
+
+def _git_output(repo_root: Path, arguments: List[str]) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["git"] + arguments,
+            cwd=str(repo_root),
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return result.stdout.strip()

--- a/buildkite/pipeline_generator/pipeline_renderer.py
+++ b/buildkite/pipeline_generator/pipeline_renderer.py
@@ -1,0 +1,101 @@
+"""Render native Buildkite pipeline YAML with change-based step filtering."""
+
+import copy
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+import yaml
+
+SOURCE_DEPENDENCIES_KEY = "source_file_dependencies"
+
+
+def render_pipeline_document(
+    document: Mapping[str, Any], changed_files: Optional[Sequence[str]]
+) -> Dict[str, Any]:
+    """Filter a native Buildkite document while preserving all native fields.
+
+    ``source_file_dependencies`` is generator metadata, so it is removed from
+    every retained step. When ``changed_files`` is ``None``, filtering is
+    disabled and all steps are retained as a safe fallback.
+    """
+    if not isinstance(document, Mapping):
+        raise ValueError("pipeline document must be a mapping")
+
+    rendered = copy.deepcopy(dict(document))
+    dependencies = rendered.pop(SOURCE_DEPENDENCIES_KEY, None)
+    if dependencies is not None:
+        _validate_dependencies(dependencies)
+
+    steps = rendered.get("steps")
+    if isinstance(steps, list):
+        rendered["steps"] = _filter_steps(steps, changed_files)
+
+    return rendered
+
+
+def render_pipeline_yaml(
+    pipeline_yaml: str, changed_files: Optional[Sequence[str]]
+) -> str:
+    """Load, filter, and serialize a native Buildkite YAML document."""
+    document = yaml.safe_load(pipeline_yaml)
+    rendered = render_pipeline_document(document, changed_files)
+    return yaml.safe_dump(rendered, sort_keys=False)
+
+
+def _filter_steps(
+    steps: List[Any], changed_files: Optional[Sequence[str]]
+) -> List[Any]:
+    filtered = []
+    for step in steps:
+        if not isinstance(step, Mapping):
+            filtered.append(copy.deepcopy(step))
+            continue
+
+        rendered_step = _filter_step(step, changed_files)
+        if rendered_step is not None:
+            filtered.append(rendered_step)
+    return filtered
+
+
+def _filter_step(
+    step: Mapping[str, Any], changed_files: Optional[Sequence[str]]
+) -> Optional[Dict[str, Any]]:
+    rendered = copy.deepcopy(dict(step))
+    dependencies = rendered.pop(SOURCE_DEPENDENCIES_KEY, None)
+
+    if dependencies is not None:
+        _validate_dependencies(dependencies)
+        if changed_files is not None and dependencies:
+            if not _dependencies_match(dependencies, changed_files):
+                return None
+
+    child_steps = rendered.get("steps")
+    if isinstance(child_steps, list):
+        rendered["steps"] = _filter_steps(child_steps, changed_files)
+        if "group" in rendered and child_steps and not rendered["steps"]:
+            return None
+
+    return rendered
+
+
+def _validate_dependencies(dependencies: Any) -> None:
+    if not isinstance(dependencies, list) or not all(
+        isinstance(dependency, str) for dependency in dependencies
+    ):
+        raise ValueError(
+            "source_file_dependencies must be a list of repository-relative paths"
+        )
+
+
+def _dependencies_match(
+    dependencies: Sequence[str], changed_files: Sequence[str]
+) -> bool:
+    for dependency in dependencies:
+        normalized_dependency = dependency.rstrip("/")
+        if not normalized_dependency:
+            continue
+        for changed_file in changed_files:
+            if changed_file == normalized_dependency or changed_file.startswith(
+                normalized_dependency + "/"
+            ):
+                return True
+    return False

--- a/buildkite/pipeline_generator/pyproject.toml
+++ b/buildkite/pipeline_generator/pyproject.toml
@@ -24,6 +24,8 @@ py-modules = [
     "utils",
     "global_config",
     "constants",
+    "change_detection",
+    "pipeline_renderer",
 ]
 
 [tool.setuptools.packages.find]

--- a/buildkite/tests/pipeline_generator/test_change_detection.py
+++ b/buildkite/tests/pipeline_generator/test_change_detection.py
@@ -1,0 +1,118 @@
+import subprocess
+
+from change_detection import ChangeContext, resolve_changed_files
+
+
+def _git(repo, *arguments):
+    return subprocess.run(
+        ["git"] + list(arguments),
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _commit_file(repo, relative_path, contents, message):
+    path = repo / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)
+    _git(repo, "add", relative_path)
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _new_repository(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "Pipeline Generator Tests")
+    _git(repo, "config", "user.email", "pipeline-generator@example.com")
+    initial_commit = _commit_file(repo, "README.md", "initial\n", "initial")
+    _git(repo, "update-ref", "refs/remotes/origin/main", initial_commit)
+    return repo, initial_commit
+
+
+def test_default_branch_build_compares_commit_with_parent(tmp_path):
+    repo, _ = _new_repository(tmp_path)
+    commit = _commit_file(repo, "src/runtime.py", "new\n", "add runtime")
+
+    changed_files = resolve_changed_files(
+        ChangeContext(branch="main", commit=commit), repo
+    )
+
+    assert changed_files == ["src/runtime.py"]
+
+
+def test_pull_request_build_compares_with_target_branch_merge_base(tmp_path):
+    repo, _ = _new_repository(tmp_path)
+    _git(repo, "switch", "-c", "feature")
+    commit = _commit_file(repo, "tests/test_runtime.py", "new\n", "add test")
+
+    changed_files = resolve_changed_files(
+        ChangeContext(
+            branch="feature",
+            commit=commit,
+            pull_request="123",
+            pull_request_base_branch="main",
+        ),
+        repo,
+    )
+
+    assert changed_files == ["tests/test_runtime.py"]
+
+
+def test_feature_branch_build_compares_with_default_branch(tmp_path):
+    repo, _ = _new_repository(tmp_path)
+    _git(repo, "switch", "-c", "feature")
+    commit = _commit_file(repo, "src/feature.py", "new\n", "add feature")
+
+    changed_files = resolve_changed_files(
+        ChangeContext(branch="feature", commit=commit), repo
+    )
+
+    assert changed_files == ["src/feature.py"]
+
+
+def test_unresolvable_base_returns_none(tmp_path):
+    repo, _ = _new_repository(tmp_path)
+    _git(repo, "switch", "-c", "feature")
+    commit = _commit_file(repo, "src/feature.py", "new\n", "add feature")
+
+    changed_files = resolve_changed_files(
+        ChangeContext(branch="feature", commit=commit, default_branch="missing"),
+        repo,
+    )
+
+    assert changed_files is None
+
+
+def test_root_commit_on_default_branch_returns_none(tmp_path):
+    repo, initial_commit = _new_repository(tmp_path)
+
+    changed_files = resolve_changed_files(
+        ChangeContext(branch="main", commit=initial_commit), repo
+    )
+
+    assert changed_files is None
+
+
+def test_change_context_reads_buildkite_environment():
+    context = ChangeContext.from_environment(
+        {
+            "BUILDKITE_BRANCH": "feature",
+            "BUILDKITE_COMMIT": "abc123",
+            "BUILDKITE_PULL_REQUEST": "42",
+            "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "release",
+            "BUILDKITE_PIPELINE_DEFAULT_BRANCH": "trunk",
+        }
+    )
+
+    assert context == ChangeContext(
+        branch="feature",
+        commit="abc123",
+        pull_request="42",
+        pull_request_base_branch="release",
+        default_branch="trunk",
+    )
+    assert context.is_pull_request

--- a/buildkite/tests/pipeline_generator/test_files/native_pipeline_expected.yaml
+++ b/buildkite/tests/pipeline_generator/test_files/native_pipeline_expected.yaml
@@ -1,0 +1,41 @@
+env:
+  GLOBAL_FLAG: "1"
+notify:
+  - github_commit_status:
+      context: vllm/generic-renderer
+steps:
+  - group: GPU tests
+    key: gpu-tests
+    depends_on:
+      - image-build
+    if: build.branch != "docs"
+    steps:
+      - label: H100 unit tests
+        key: h100-unit
+        timeout_in_minutes: 45
+        command:
+          - pytest -q tests/gpu
+        agents:
+          queue: mithril-h100-pool
+        plugins:
+          - "docker#v5.13.0":
+              image: example.com/project/test:latest
+              propagate-environment: true
+        retry:
+          automatic:
+            - exit_status: -1
+              limit: 2
+        artifact_paths:
+          - test-results/**/*.xml
+        matrix:
+          setup:
+            shard:
+              - 0
+              - 1
+        env:
+          TEST_KIND: gpu
+  - wait: ~
+  - label: Always run validation
+    command: python -m compileall src
+    agents:
+      queue: cpu_queue_premerge

--- a/buildkite/tests/pipeline_generator/test_files/native_pipeline_input.yaml
+++ b/buildkite/tests/pipeline_generator/test_files/native_pipeline_input.yaml
@@ -1,0 +1,51 @@
+env:
+  GLOBAL_FLAG: "1"
+notify:
+  - github_commit_status:
+      context: vllm/generic-renderer
+steps:
+  - group: GPU tests
+    key: gpu-tests
+    depends_on:
+      - image-build
+    if: build.branch != "docs"
+    source_file_dependencies:
+      - src/
+    steps:
+      - label: H100 unit tests
+        key: h100-unit
+        timeout_in_minutes: 45
+        command:
+          - pytest -q tests/gpu
+        agents:
+          queue: mithril-h100-pool
+        plugins:
+          - "docker#v5.13.0":
+              image: example.com/project/test:latest
+              propagate-environment: true
+        retry:
+          automatic:
+            - exit_status: -1
+              limit: 2
+        artifact_paths:
+          - test-results/**/*.xml
+        matrix:
+          setup:
+            shard:
+              - 0
+              - 1
+        env:
+          TEST_KIND: gpu
+        source_file_dependencies:
+          - src/gpu/
+      - label: CPU unit tests
+        command: pytest -q tests/cpu
+        agents:
+          queue: cpu_queue_premerge
+        source_file_dependencies:
+          - src/cpu/
+  - wait: ~
+  - label: Always run validation
+    command: python -m compileall src
+    agents:
+      queue: cpu_queue_premerge

--- a/buildkite/tests/pipeline_generator/test_pipeline_renderer.py
+++ b/buildkite/tests/pipeline_generator/test_pipeline_renderer.py
@@ -1,0 +1,160 @@
+import copy
+from pathlib import Path
+
+import pytest
+import yaml
+
+from pipeline_renderer import render_pipeline_document, render_pipeline_yaml
+
+FIXTURES = Path(__file__).resolve().parent / "test_files"
+
+
+def test_render_pipeline_yaml_matches_native_pipeline_golden_file():
+    pipeline_yaml = (FIXTURES / "native_pipeline_input.yaml").read_text()
+    expected = yaml.safe_load((FIXTURES / "native_pipeline_expected.yaml").read_text())
+
+    rendered = yaml.safe_load(
+        render_pipeline_yaml(pipeline_yaml, ["src/gpu/kernel.py"])
+    )
+
+    assert rendered == expected
+
+
+def test_render_pipeline_document_does_not_mutate_input():
+    document = {
+        "steps": [
+            {
+                "label": "unit tests",
+                "command": "pytest",
+                "source_file_dependencies": ["src/"],
+            }
+        ]
+    }
+    original = copy.deepcopy(document)
+
+    render_pipeline_document(document, ["src/runtime.py"])
+
+    assert document == original
+
+
+def test_unknown_changes_keep_every_step_and_strip_metadata_recursively():
+    document = {
+        "source_file_dependencies": ["pipeline/"],
+        "steps": [
+            {
+                "group": "tests",
+                "source_file_dependencies": ["src/"],
+                "steps": [
+                    {
+                        "label": "unit tests",
+                        "source_file_dependencies": ["tests/"],
+                    }
+                ],
+            }
+        ],
+    }
+
+    rendered = render_pipeline_document(document, None)
+
+    assert rendered == {
+        "steps": [{"group": "tests", "steps": [{"label": "unit tests"}]}]
+    }
+
+
+def test_empty_change_list_only_keeps_unconditional_steps():
+    document = {
+        "steps": [
+            {
+                "label": "conditional",
+                "source_file_dependencies": ["src/"],
+            },
+            {"wait": None},
+            {"label": "always"},
+        ]
+    }
+
+    rendered = render_pipeline_document(document, [])
+
+    assert rendered == {"steps": [{"wait": None}, {"label": "always"}]}
+
+
+def test_nonmatching_group_dependency_removes_the_whole_group():
+    document = {
+        "steps": [
+            {
+                "group": "GPU tests",
+                "source_file_dependencies": ["src/gpu/"],
+                "steps": [{"label": "test"}],
+            }
+        ]
+    }
+
+    rendered = render_pipeline_document(document, ["docs/index.md"])
+
+    assert rendered == {"steps": []}
+
+
+def test_group_is_removed_when_all_of_its_children_are_filtered_out():
+    document = {
+        "steps": [
+            {
+                "group": "GPU tests",
+                "steps": [
+                    {
+                        "label": "GPU unit tests",
+                        "source_file_dependencies": ["src/gpu/"],
+                    }
+                ],
+            }
+        ]
+    }
+
+    rendered = render_pipeline_document(document, ["docs/index.md"])
+
+    assert rendered == {"steps": []}
+
+
+def test_non_mapping_step_shorthand_is_preserved():
+    document = {"steps": ["wait"]}
+
+    rendered = render_pipeline_document(document, [])
+
+    assert rendered == document
+
+
+@pytest.mark.parametrize(
+    "dependencies",
+    ["src/", ["src/", 3], {"path": "src/"}],
+)
+def test_invalid_dependency_metadata_raises(dependencies):
+    document = {
+        "steps": [
+            {
+                "label": "invalid",
+                "source_file_dependencies": dependencies,
+            }
+        ]
+    }
+
+    with pytest.raises(ValueError, match="source_file_dependencies"):
+        render_pipeline_document(document, None)
+
+
+@pytest.mark.parametrize("dependency", ["src/gpu", "src/gpu/"])
+def test_dependencies_match_exact_paths_and_directory_prefixes(dependency):
+    document = {
+        "steps": [
+            {
+                "label": "matching",
+                "source_file_dependencies": [dependency],
+            }
+        ]
+    }
+
+    exact = render_pipeline_document(document, ["src/gpu"])
+    nested = render_pipeline_document(document, ["src/gpu/kernel.py"])
+    substring = render_pipeline_document(document, ["src/gpu_extra.py"])
+
+    assert exact == {"steps": [{"label": "matching"}]}
+    assert nested == {"steps": [{"label": "matching"}]}
+    assert substring == {"steps": []}


### PR DESCRIPTION
## Summary

- add a generic renderer for native Buildkite YAML that preserves arbitrary Buildkite fields while recursively filtering `source_file_dependencies`
- add read-only Git change detection for default-branch, pull-request, and feature-branch builds, with a safe run-everything fallback when the diff cannot be resolved
- add native-YAML golden coverage and real temporary Git repository tests

This is intentionally a foundation-only PR: it does not change the existing vLLM pipeline generator, routing, queues, plugins, or uploaded pipeline output. A later small PR can add shared machine profiles, followed by an isolated vLLM-Omni pilot.

## Validation

- `python3 -m pytest -q` — 34 passed
- `python3 -m ruff check buildkite/pipeline_generator buildkite/tests/pipeline_generator`
- `python3 -m ruff format --check` on all new Python files
- `bk pipeline validate --file buildkite/tests/pipeline_generator/test_files/native_pipeline_expected.yaml`
- `git diff --cached --check`