### PR TITLE
Add IAM user + access key for the macmini wheel uploader

### DIFF
--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -51,3 +51,32 @@ terraform apply
 Confirm the changes are made on AWS and monitor changes in the new builds on Buildkite.
 
 The current state (`terraform.tfstate`) after applying will be updated in the remote data store (S3 bucket)
+
+## macOS wheel builder (`macmini` queue) credentials
+
+The Linux release builders get S3 write to `vllm-wheels` from their EC2 instance
+role. The mac mini is a self-hosted agent with no instance profile, so
+`macmini-wheel-uploader.tf` provisions an IAM user with the same
+`vllm_wheels_bucket_read_write_access` policy and an access key.
+
+After `terraform apply`, retrieve the key and place it on the mac mini for the
+`buildkite-agent` user:
+
+```bash
+terraform output -raw macmini_wheel_uploader_access_key_id
+terraform output -raw macmini_wheel_uploader_secret_access_key
+```
+
+On the agent, write `~/.aws/credentials` (or export the vars from the agent's
+`hooks/environment`):
+
+```ini
+[default]
+aws_access_key_id = <access_key_id>
+aws_secret_access_key = <secret_access_key>
+region = us-east-1
+```
+
+`upload-nightly-wheels.sh` then uploads via the `aws` CLI like the Linux
+builders. To rotate, taint `aws_iam_access_key.macmini_wheel_uploader`,
+re-apply, and update the agent.

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -54,29 +54,14 @@ The current state (`terraform.tfstate`) after applying will be updated in the re
 
 ## macOS wheel builder (`macmini` queue) credentials
 
-The Linux release builders get S3 write to `vllm-wheels` from their EC2 instance
-role. The mac mini is a self-hosted agent with no instance profile, so
-`macmini-wheel-uploader.tf` provisions an IAM user with the same
-`vllm_wheels_bucket_read_write_access` policy and an access key.
-
-After `terraform apply`, retrieve the key and place it on the mac mini for the
-`buildkite-agent` user:
+`macmini-wheel-uploader.tf` provisions an IAM user with S3 write to
+`vllm-wheels` for the self-hosted mac mini agent. After `apply`, write the key
+to `~/.aws/credentials` (region `us-east-1`) for the `buildkite-agent` user:
 
 ```bash
 terraform output -raw macmini_wheel_uploader_access_key_id
 terraform output -raw macmini_wheel_uploader_secret_access_key
 ```
 
-On the agent, write `~/.aws/credentials` (or export the vars from the agent's
-`hooks/environment`):
-
-```ini
-[default]
-aws_access_key_id = <access_key_id>
-aws_secret_access_key = <secret_access_key>
-region = us-east-1
-```
-
-`upload-nightly-wheels.sh` then uploads via the `aws` CLI like the Linux
-builders. To rotate, taint `aws_iam_access_key.macmini_wheel_uploader`,
-re-apply, and update the agent.
+To rotate, taint `aws_iam_access_key.macmini_wheel_uploader`, re-apply, and
+update the agent.

--- a/terraform/aws/macmini-wheel-uploader.tf
+++ b/terraform/aws/macmini-wheel-uploader.tf
@@ -1,12 +1,5 @@
-# Credentials for the macOS wheel builder (the `macmini` Buildkite queue).
-#
-# The Linux release builders are EC2 instances and get S3 write to vllm-wheels
-# from their instance role (see vllm_wheels_bucket_read_write_access in iam.tf).
-# The mac mini is a self-hosted agent with no instance profile, so it uses an
-# IAM user access key instead, reusing that same least-privilege policy.
-#
-# The generated key is a long-lived secret and lands in Terraform state. After
-# apply, retrieve it once and place it on the agent (see terraform/aws/README).
+# S3 write access to vllm-wheels for the self-hosted macOS wheel builder (the
+# `macmini` queue), which has no EC2 instance role. See terraform/aws/README.
 
 resource "aws_iam_user" "macmini_wheel_uploader" {
   name = "bk-macmini-wheel-uploader"

--- a/terraform/aws/macmini-wheel-uploader.tf
+++ b/terraform/aws/macmini-wheel-uploader.tf
@@ -1,0 +1,32 @@
+# Credentials for the macOS wheel builder (the `macmini` Buildkite queue).
+#
+# The Linux release builders are EC2 instances and get S3 write to vllm-wheels
+# from their instance role (see vllm_wheels_bucket_read_write_access in iam.tf).
+# The mac mini is a self-hosted agent with no instance profile, so it uses an
+# IAM user access key instead, reusing that same least-privilege policy.
+#
+# The generated key is a long-lived secret and lands in Terraform state. After
+# apply, retrieve it once and place it on the agent (see terraform/aws/README).
+
+resource "aws_iam_user" "macmini_wheel_uploader" {
+  name = "bk-macmini-wheel-uploader"
+}
+
+resource "aws_iam_user_policy_attachment" "macmini_wheels_bucket_rw" {
+  user       = aws_iam_user.macmini_wheel_uploader.name
+  policy_arn = aws_iam_policy.vllm_wheels_bucket_read_write_access.arn
+}
+
+resource "aws_iam_access_key" "macmini_wheel_uploader" {
+  user = aws_iam_user.macmini_wheel_uploader.name
+}
+
+output "macmini_wheel_uploader_access_key_id" {
+  value     = aws_iam_access_key.macmini_wheel_uploader.id
+  sensitive = true
+}
+
+output "macmini_wheel_uploader_secret_access_key" {
+  value     = aws_iam_access_key.macmini_wheel_uploader.secret
+  sensitive = true
+}


### PR DESCRIPTION
Gives the macOS wheel build (the new `macmini` Buildkite queue) S3 write access to `vllm-wheels`, like the Linux release builders.

## Why an IAM user (not a role)
The Linux `cpu_queue_release` / `arm64_cpu_queue_release` agents are EC2 instances and get S3 write from their instance role. The mac mini is a self-hosted agent with no instance profile, so it can't assume a role — this provisions an IAM user with the **same** existing `vllm_wheels_bucket_read_write_access` policy plus an access key to place on the agent.

The generated key is long-lived and lands in Terraform state; retrieve it via `terraform output -raw` after apply and drop it into the agent's `~/.aws/credentials` (see the README section). A no-static-key alternative (Buildkite OIDC → `AssumeRoleWithWebIdentity`) is possible later if we want to eliminate the on-disk secret.

## Changes
- `macmini-wheel-uploader.tf`: IAM user, policy attachment (reuses the existing least-privilege policy), access key, sensitive key outputs.
- README: short runbook for pulling the key onto the agent + rotation.

Pairs with vllm-project/vllm#48289 (the macOS wheel build step).

AI assistance (Claude) was used; I reviewed every line.