### PR TITLE
fix(buildkite): allow colon in BUILDKITE_BRANCH for fork PRs

### DIFF
--- a/buildkite/pipeline_generator/global_config.py
+++ b/buildkite/pipeline_generator/global_config.py
@@ -39,7 +39,10 @@ def init_global_config(pipeline_config_path: str):
 
     branch = os.getenv("BUILDKITE_BRANCH")
     if branch:
-        if not re.match(r"^[a-zA-Z0-9._/-]+$", branch):
+        # Fork PRs arrive as "owner:branch" (e.g. "octocat:my-feature"), so the
+        # colon must be allowed. It is not a shell metacharacter, so permitting
+        # it does not reintroduce command-injection risk.
+        if not re.match(r"^[a-zA-Z0-9._/:-]+$", branch):
             raise ValueError(
                 f"Invalid branch name: {branch}. Contains disallowed characters."
             )

--- a/buildkite/tests/pipeline_generator/test_global_config.py
+++ b/buildkite/tests/pipeline_generator/test_global_config.py
@@ -61,6 +61,34 @@ def test_init_global_config_invalid_branch(
     with patch.dict(os.environ, {"BUILDKITE_BRANCH": "invalid;branch"}):
         with pytest.raises(ValueError, match="Invalid branch name"):
             init_global_config("dummy_path")
+
+
+@patch(
+    "buildkite.pipeline_generator.global_config.get_merge_base_commit",
+    return_value="sha",
+)
+@patch(
+    "buildkite.pipeline_generator.global_config.get_list_file_diff",
+    return_value=[],
+)
+@patch(
+    "buildkite.pipeline_generator.global_config.get_pr_labels", return_value=[]
+)
+@patch(
+    "builtins.open",
+    new_callable=mock_open,
+    read_data="name: test\njob_dirs: [/tmp]\nregistries: reg\nrepositories: {main: repo}",
+)
+@patch("os.path.exists", return_value=True)
+def test_init_global_config_fork_branch(
+    mock_exists, mock_open, mock_pr_labels, mock_diff, mock_mb
+):
+    # Fork PRs arrive as "owner:branch"; the colon must be accepted.
+    with patch.dict(
+        os.environ, {"BUILDKITE_BRANCH": "octocat:update-pytorch-2.13.0"}
+    ):
+        init_global_config("dummy_path")
+        # Should succeed
 from unittest.mock import patch
 from global_config import _validate_pipeline_config
 


### PR DESCRIPTION
## Problem

#385 added `BUILDKITE_BRANCH` validation to prevent command injection, but the allowlist regex `^[a-zA-Z0-9._/-]+$` rejects the colon `:`.

Buildkite passes **fork-PR branches** in GitHub's `owner:branch` form (e.g. `atalman:update-pytorch-2.13.0`). The colon fails the regex, so `init_global_config` raises:

```
ValueError: Invalid branch name: atalman:update-pytorch-2.13.0. Contains disallowed characters.
```

This aborts the `bootstrap` step before any pipeline is generated, so **every fork-based PR fails CI**. Example failing builds: [vllm/ci #77914](https://buildkite.com/vllm/ci/builds/77914), [#77916](https://buildkite.com/vllm/ci/builds/77916).

## Fix

Add `:` to the allowed character class (`^[a-zA-Z0-9._/:-]+$`). The colon is **not** a shell metacharacter, so the command-injection protection from #385 is preserved — injection attempts using `;`, `$(...)`, spaces, etc. are still rejected.

Added a unit test covering the fork `owner:branch` form; existing tests (valid branch, injection rejection) still pass.

```
6 passed in 0.14s
```

cc @jcc-google @khluu (authors of #385)