### PR TITLE
[CI] Use a distinct -torch-nightly image tag for the full torch-nightly run

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -274,21 +274,30 @@ def _get_variables_to_inject() -> Dict[str, str]:
         return {}
 
     cache_from_tag, cache_to_tag = get_ecr_cache_registry()
+    registries = global_config["registries"]
+    repositories = global_config["repositories"]
+    repo = repositories["main"] if global_config["branch"] == "main" else repositories["premerge"]
+
+    # Build target ($IMAGE_TAG) must match what the test steps pull (get_image()).
+    # get_image() already switches to the dedicated -torch-nightly tag when
+    # torch_nightly==1, so the whole run uses a distinct tag that can't overwrite
+    # or race with the shared postmerge image. Don't publish :latest from nightly.
+    image_tag = get_image()
+    image_tag_latest = (
+        f"{registries}/{repositories['main']}:latest"
+        if global_config["branch"] == "main" and global_config["torch_nightly"] != "1"
+        else None
+    )
+
     return {
-        "$REGISTRY": global_config["registries"],
-        "$REPO": global_config["repositories"]["main"]
-        if global_config["branch"] == "main"
-        else global_config["repositories"]["premerge"],
+        "$REGISTRY": registries,
+        "$REPO": repo,
         "$BUILDKITE_COMMIT": "$$BUILDKITE_COMMIT",
         "$BRANCH": global_config["branch"],
         "$CACHE_FROM": cache_from_tag,
         "$CACHE_TO": cache_to_tag,
-        "$IMAGE_TAG": f"{global_config['registries']}/{global_config['repositories']['main']}:$BUILDKITE_COMMIT"
-            if global_config["branch"] == "main"
-            else f"{global_config['registries']}/{global_config['repositories']['premerge']}:$BUILDKITE_COMMIT",
-        "$IMAGE_TAG_LATEST": f"{global_config['registries']}/{global_config['repositories']['main']}:latest"
-            if global_config["branch"] == "main"
-            else None,
+        "$IMAGE_TAG": image_tag,
+        "$IMAGE_TAG_LATEST": image_tag_latest,
         "$IMAGE_TAG_TORCH_NIGHTLY": get_torch_nightly_image(),
     }
 

--- a/buildkite/pipeline_generator/utils_lib/docker_utils.py
+++ b/buildkite/pipeline_generator/utils_lib/docker_utils.py
@@ -16,6 +16,11 @@ def get_image(cpu: bool = False, arm64: bool = False) -> str:
         image = f"{registries}/{repositories['main']}:{commit}"
     else:
         image = f"{registries}/{repositories['premerge']}:{commit}"
+    # In the full torch-nightly run, every step must use the nightly image. Use
+    # the dedicated -torch-nightly tag so it never collides with the shared
+    # postmerge tag (no overwrite / race with the regular postmerge image).
+    if global_config.get("torch_nightly") == "1":
+        image = f"{image}-torch-nightly"
     if cpu:
         image = f"{image}-cpu"
     if arm64:

--- a/buildkite/tests/pipeline_generator/test_docker_utils.py
+++ b/buildkite/tests/pipeline_generator/test_docker_utils.py
@@ -1,0 +1,40 @@
+import utils_lib.docker_utils as docker_utils
+
+
+def _cfg(**overrides):
+    cfg = {
+        "registries": "example.com/vllm",
+        "repositories": {
+            "main": "vllm-ci-postmerge-repo",
+            "premerge": "vllm-ci-test-repo",
+        },
+        "branch": "main",
+        "torch_nightly": "0",
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def test_get_image_bare_when_not_nightly(monkeypatch):
+    monkeypatch.setattr(docker_utils, "get_global_config", lambda: _cfg())
+    assert (
+        docker_utils.get_image()
+        == "example.com/vllm/vllm-ci-postmerge-repo:$BUILDKITE_COMMIT"
+    )
+
+
+def test_get_image_uses_torch_nightly_tag(monkeypatch):
+    monkeypatch.setattr(
+        docker_utils, "get_global_config", lambda: _cfg(torch_nightly="1")
+    )
+    # Every step's image switches to the dedicated -torch-nightly tag so the
+    # nightly run can't overwrite / race with the shared postmerge image.
+    assert (
+        docker_utils.get_image()
+        == "example.com/vllm/vllm-ci-postmerge-repo:$BUILDKITE_COMMIT-torch-nightly"
+    )
+    # cpu/arm64 suffixes come after the nightly suffix.
+    assert (
+        docker_utils.get_image(cpu=True)
+        == "example.com/vllm/vllm-ci-postmerge-repo:$BUILDKITE_COMMIT-torch-nightly-cpu"
+    )

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -177,6 +177,20 @@ def test_torch_nightly_flag_no_separate_group(fake_global_config):
     assert not any(lbl.startswith("Torch Nightly ") for lbl in labels)
 
 
+def test_image_tag_matches_get_image_and_latest_suppressed_on_nightly(fake_global_config):
+    fake_global_config["branch"] = "main"
+    # Build target ($IMAGE_TAG) mirrors what test steps pull (get_image()).
+    vars_ = buildkite_step._get_variables_to_inject()
+    assert vars_["$IMAGE_TAG"] == buildkite_step.get_image()
+    assert vars_["$IMAGE_TAG_LATEST"] == "example.com/vllm/vllm-ci-postmerge-repo:latest"
+
+    # A nightly run must not publish :latest (and still mirrors get_image()).
+    fake_global_config["torch_nightly"] = "1"
+    vars_ = buildkite_step._get_variables_to_inject()
+    assert vars_["$IMAGE_TAG"] == buildkite_step.get_image()
+    assert vars_["$IMAGE_TAG_LATEST"] is None
+
+
 def test_timeout_in_minutes_propagates_to_command_step():
     step = Step(
         label="Timed test",


### PR DESCRIPTION
## Problem

The `TORCH_NIGHTLY=1` full run (added in #382) has every step use the **bare `$IMAGE_TAG`** (`<repo>:<commit>`) — the same tag the regular postmerge (stable-torch) build uses. So the nightly image build **overwrites** the postmerge image and can **race** with it (or a re-triggered nightly), leaving test steps able to pull the wrong torch flavor. (e.g. [vllm/ci 77968](https://buildkite.com/vllm/ci/builds/77968) used `vllm-ci-postmerge-repo:<sha>` with no nightly discriminator.)

The earlier curated nightly group (`NIGHTLY=1`, #310) avoided this by using a dedicated `-torch-nightly` image; the full-run approach dropped that isolation.

## Change

Every test step gets its container image from **`get_image()`**, and the image build target is `$IMAGE_TAG`. Make **both** use the dedicated `-torch-nightly` tag when `torch_nightly==1`:

- `get_image()` appends `-torch-nightly` when `torch_nightly==1` (so all test steps pull the nightly image).
- `$IMAGE_TAG` now mirrors `get_image()` (so the build target matches what the tests pull).
- `:latest` is not published from a nightly run.

The entire run — image build **and every test step** — now uses a distinct tag that can't collide with the postmerge image. No vLLM-side change needed (`image_build_torch_nightly.sh` uses `$IMAGE_TAG` verbatim). Pairs with vllm-project/vllm#48610 (force-rebuild, now race-safe on the distinct tag).

## Test Plan

- `pytest tests/pipeline_generator/` — 33 pass (30 existing + new `test_docker_utils.py::test_get_image_uses_torch_nightly_tag` and an updated `$IMAGE_TAG`/`:latest` assertion).
- New tests assert `get_image()` returns `<repo>:<sha>-torch-nightly` (and `-torch-nightly-cpu` for cpu) under `torch_nightly=1`, bare otherwise; and that `:latest` is suppressed for nightly.

Authored with assistance from an AI coding assistant; reviewed by the submitter.