### PR TITLE
[CI][AMD] Restore mirror failure policy

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -575,7 +575,7 @@ def convert_group_step_to_buildkite_step(
                     no_plugin=amd_no_plugin,
                     no_gpu=amd_no_gpu,
                     num_nodes=amd.get("num_nodes", step.num_nodes),
-                    soft_fail=True,
+                    soft_fail=amd.get("soft_fail", step.soft_fail or False),
                     parallelism=step.parallelism,
                     timeout_in_minutes=amd.get("timeout_in_minutes"),
                     agent_tags=amd.get("agent_tags"),

--- a/buildkite/test-template-amd.j2
+++ b/buildkite/test-template-amd.j2
@@ -190,11 +190,7 @@ rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT
         {% endif %}
         timeout_in_minutes: {{ step_timeout_in_minutes }}
         agents:
-          {% if step.agent_pool %}
           queue: amd_{{ step.agent_pool }}
-          {% else %}
-          queue: amd_mi300
-          {% endif %}
           {% if step.dind == false and step.agent_tags %}
             {% for key, value in step.agent_tags | items %}
               {% if key != "queue" and key and value %}

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -173,7 +173,7 @@ def test_amd_mirror_uses_shared_gating_with_amd_dependency_fallback(
     assert len(amd_group.steps) == 1
     assert amd_command_step.depends_on == ["image-build-amd"]
     assert amd_command_step.agents == {"queue": AgentQueue.AMD_MI325_1}
-    assert amd_command_step.soft_fail is True
+    assert amd_command_step.soft_fail is False
     assert "ROCm debug agent disabled" in (amd_command_step.env["VLLM_TEST_COMMANDS"])
 
 


### PR DESCRIPTION
- Restores `soft_fail` for AMD mirrors
- Removes the legacy Jinja renderer's implicit `amd_mi300` queue fallback