### PR TITLE
Add us-east-1 capacity for gpu_4_queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The AMD and Intel bootstrap scripts additionally handle:
 
 Managed via Terraform in `terraform/aws/`. Uses the [Buildkite Elastic CI Stack for AWS](https://github.com/buildkite/elastic-ci-stack-for-aws) (v6.21.0) to deploy autoscaling agent clusters as CloudFormation stacks.
 
-**Regions**: us-west-2 (GPU + CPU queues), us-east-1 (CPU build queues with warm-cache AMI, release queues)
+**Regions**: us-west-2 (GPU + CPU queues), us-east-1 (additional multi-GPU capacity, CPU build queues with warm-cache AMI, release queues)
 
 #### Agent Queues
 
@@ -110,7 +110,7 @@ Managed via Terraform in `terraform/aws/`. Uses the [Buildkite Elastic CI Stack 
 | `cpu_queue_premerge_us_east_1` | r6in.16xlarge (512GB) | 20 | CPU builds (warm-cache AMI) |
 | `arm64_cpu_queue_premerge` | r7g.16xlarge | 10 | ARM64 builds |
 | `gpu_1_queue` | g6.4xlarge (1x L4) | 208 | Single-GPU tests |
-| `gpu_4_queue` | g6.12xlarge (4x L4) | 64 | Multi-GPU tests |
+| `gpu_4_queue` (us-west-2 + us-east-1) | g6.12xlarge (4x L4) | 64 west / 19 east | Multi-GPU tests |
 
 Equivalent postmerge and release queues exist with ECR write access for pushing images. Specialized hardware (H100, H200, B200, A100) is managed via Kubernetes or dedicated pools.
 

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -3,11 +3,11 @@
 This setup is for the Buildkite Elastic CI Stack on AWS.
 Services used:
 - VPC with 4 subnets (each subnet carries 16384 IP addresses)
-- 4 CloudFormation stacks: `small-cpu-queue`, `cpu-queue`, `gpu-1-queue`, and `gpu-4-queue` which has corresponding Buildkite agent queue
+- CloudFormation stacks for `small-cpu-queue`, `cpu-queue`, `gpu-1-queue`, and `gpu-4-queue`, each with a corresponding Buildkite agent queue
     - `small_cpu_queue` is for running small CPU jobs like bootstrapping CI build or building documentation
     - `cpu_queue` is for heavier CPU jobs like building vLLM Docker image or running CPU tests
     - `gpu_1_queue` is for running all GPU tests that require 1 GPU
-    - `gpu_4_queue` is for running all GPU tests that require 2 or 4 GPUs
+    - `gpu_4_queue` is for running all GPU tests that require 2 or 4 GPUs; stacks in us-west-2 and us-east-1 both serve this queue
 - Each stack has access to write/read from ECR public repo (that stores vLLM Docker images) and AWS Secrets Manager that stores Huggingface token used for testing.
 
 ## Setup with Terraform

--- a/terraform/aws/cloudformation_stack.tf
+++ b/terraform/aws/cloudformation_stack.tf
@@ -222,6 +222,26 @@ locals {
     }
   }
 
+  # Intentionally shares gpu_4_queue with us-west-2 for regional capacity failover.
+  # Both Elastic CI Stack autoscalers may scale for the same queued jobs.
+  ci_gpu_queues_parameters_us_east_1 = {
+    gpu-4-queue-ci-us-east-1 = {
+      BuildkiteAgentTokenParameterStorePath = data.aws_ssm_parameter.bk_agent_token_cluster_ci_us_east_1.name
+      BuildkiteQueue                       = "gpu_4_queue"
+      InstanceTypes                        = "g6.12xlarge" # 4 Nvidia L4 GPUs, 192GB memory
+      MaxSize                              = 19 # Limited by the us-east-1 G/VT on-demand vCPU quota (920 / 48)
+      ECRAccessPolicy                      = "readonly"
+      InstanceOperatingSystem              = "linux"
+      OnDemandPercentage                   = 100
+      ImageId                              = aws_ami_copy.gpu_us_east_1.id # Custom AMI with Nvidia driver 570.133.20
+      BootstrapScriptUrl                   = "https://vllm-ci.s3.us-west-2.amazonaws.com/bootstrap.sh"
+      BuildkiteTerminateInstanceAfterJob   = true
+      VpcId                                = module.vpc_us_east_1.vpc_id
+      SecurityGroupIds                     = module.vpc_us_east_1.default_security_group_id
+      Subnets                              = join(",", module.vpc_us_east_1.public_subnets)
+    }
+  }
+
   queues_parameters = {
     bootstrap = {
       BuildkiteAgentTokenParameterStorePath = data.aws_ssm_parameter.bk_agent_token_cluster_perf_benchmark.name
@@ -271,6 +291,11 @@ locals {
 
   merged_parameters_ci_gpu = {
     for name, params in local.ci_gpu_queues_parameters :
+    name => merge(local.default_parameters, params)
+  }
+
+  merged_parameters_ci_gpu_us_east_1 = {
+    for name, params in local.ci_gpu_queues_parameters_us_east_1 :
     name => merge(local.default_parameters, params)
   }
 
@@ -380,6 +405,24 @@ resource "aws_cloudformation_stack" "bk_queue_ci_gpu" {
       tags_all["AppManagerCFNStackKey"],
     ]
   }
+}
+
+resource "aws_cloudformation_stack" "bk_queue_ci_gpu_us_east_1" {
+  for_each   = local.merged_parameters_ci_gpu_us_east_1
+  name       = "bk-${each.key}"
+  parameters = { for k, v in each.value : k => v if k != "elastic_ci_stack_version" }
+
+  template_url = "https://s3.amazonaws.com/buildkite-aws-stack/v${each.value["elastic_ci_stack_version"]}/aws-stack.yml"
+  capabilities = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+
+  lifecycle {
+    ignore_changes = [
+      tags["AppManagerCFNStackKey"],
+      tags_all["AppManagerCFNStackKey"],
+    ]
+  }
+
+  provider = aws.us_east_1
 }
 
 resource "aws_cloudformation_stack" "bk_queue" {

--- a/terraform/aws/cloudformation_stack.tf
+++ b/terraform/aws/cloudformation_stack.tf
@@ -238,6 +238,7 @@ locals {
       InstanceOperatingSystem              = "linux"
       OnDemandPercentage                   = 100
       ImageId                              = aws_ami_copy.gpu_us_east_1.id # Custom AMI with Nvidia driver 570.133.20
+      RootVolumeEncrypted                  = true
       BootstrapScriptUrl                   = "https://vllm-ci.s3.us-west-2.amazonaws.com/bootstrap.sh"
       BuildkiteTerminateInstanceAfterJob   = true
       VpcId                                = module.vpc_us_east_1.vpc_id

--- a/terraform/aws/cloudformation_stack.tf
+++ b/terraform/aws/cloudformation_stack.tf
@@ -23,6 +23,7 @@ locals {
       InstanceOperatingSystem              = "linux"
       OnDemandPercentage                   = 100
       EnableInstanceStorage                = "true"
+      BootstrapScriptUrl                   = "https://vllm-ci.s3.us-west-2.amazonaws.com/instance-bootstrap.sh"
     }
 
     medium-cpu-queue-premerge = {
@@ -34,6 +35,7 @@ locals {
       InstanceOperatingSystem              = "linux"
       OnDemandPercentage                   = 100
       EnableInstanceStorage                = "true"
+      BootstrapScriptUrl                   = "https://vllm-ci.s3.us-west-2.amazonaws.com/instance-bootstrap.sh"
     }
 
     cpu-queue-premerge = {
@@ -45,6 +47,7 @@ locals {
       InstanceOperatingSystem              = "linux"
       OnDemandPercentage                   = 100
       EnableInstanceStorage                = "true"
+      BootstrapScriptUrl                   = "https://vllm-ci.s3.us-west-2.amazonaws.com/instance-bootstrap.sh"
     }
 
     arm64-cpu-queue-premerge = {
@@ -56,6 +59,7 @@ locals {
       InstanceOperatingSystem              = "linux"
       OnDemandPercentage                   = 100
       EnableInstanceStorage                = "true"
+      BootstrapScriptUrl                   = "https://vllm-ci.s3.us-west-2.amazonaws.com/instance-bootstrap.sh"
     }
   }
 
@@ -252,6 +256,7 @@ locals {
       InstanceOperatingSystem              = "linux"
       OnDemandPercentage                   = 100
       EnableInstanceStorage                = "true"
+      BootstrapScriptUrl                   = "https://vllm-ci.s3.us-west-2.amazonaws.com/instance-bootstrap.sh"
     }
   }
 

--- a/terraform/aws/gpu-ami.tf
+++ b/terraform/aws/gpu-ami.tf
@@ -1,0 +1,13 @@
+resource "aws_ami_copy" "gpu_us_east_1" {
+  provider = aws.us_east_1
+
+  name              = "vllm-buildkite-stack-linux-gpu-us-east-1"
+  description       = "vLLM Buildkite GPU AMI copied from us-west-2"
+  source_ami_id     = "ami-040f1b73b7a7c7453"
+  source_ami_region = "us-west-2"
+  encrypted         = true
+
+  tags = {
+    Name = "vLLM Buildkite GPU AMI us-east-1"
+  }
+}

--- a/terraform/aws/iam.tf
+++ b/terraform/aws/iam.tf
@@ -224,7 +224,10 @@ resource "aws_iam_policy" "release_ecr_public_read_write_access_policy" {
         "ecr-public:UploadLayerPart",
         "sts:GetServiceBearerToken"
       ]
-      Resource = "arn:aws:ecr-public::936637512419:repository/vllm-release-repo"
+      Resource = [
+        "arn:aws:ecr-public::936637512419:repository/vllm-release-repo",
+        "arn:aws:ecr-public::936637512419:repository/vllm-omni-release-repo",
+      ]
     }]
   })
 }

--- a/terraform/aws/iam.tf
+++ b/terraform/aws/iam.tf
@@ -371,8 +371,9 @@ resource "aws_iam_policy" "vllm_wheels_bucket_read_write_access" {
 }
 
 resource "aws_iam_role_policy_attachment" "premerge_ecr_public_read_access" {
-  for_each   = merge(
-    aws_cloudformation_stack.bk_queue_ci_gpu
+  for_each = merge(
+    aws_cloudformation_stack.bk_queue_ci_gpu,
+    aws_cloudformation_stack.bk_queue_ci_gpu_us_east_1,
   )
   role       = each.value.outputs.InstanceRoleName
   policy_arn = aws_iam_policy.premerge_ecr_public_read_access_policy.arn
@@ -402,8 +403,9 @@ resource "aws_iam_role_policy_attachment" "premerge_ecr_cache_read_write_access"
 }
 
 resource "aws_iam_role_policy_attachment" "postmerge_ecr_public_read_access" {
-  for_each   = merge(
-    aws_cloudformation_stack.bk_queue_ci_gpu
+  for_each = merge(
+    aws_cloudformation_stack.bk_queue_ci_gpu,
+    aws_cloudformation_stack.bk_queue_ci_gpu_us_east_1,
   )
   role       = each.value.outputs.InstanceRoleName
   policy_arn = aws_iam_policy.postmerge_ecr_public_read_access_policy.arn
@@ -467,6 +469,7 @@ resource "aws_iam_role_policy_attachment" "bk_stack_secrets_access" {
     aws_cloudformation_stack.bk_queue_postmerge,
     aws_cloudformation_stack.bk_queue_postmerge_us_east_1,
     aws_cloudformation_stack.bk_queue_ci_gpu,
+    aws_cloudformation_stack.bk_queue_ci_gpu_us_east_1,
     aws_cloudformation_stack.bk_queue_release,
   )
   role       = each.value.outputs.InstanceRoleName

--- a/terraform/aws/iam.tf
+++ b/terraform/aws/iam.tf
@@ -378,7 +378,7 @@ resource "aws_iam_role_policy_attachment" "premerge_ecr_public_read_access" {
     aws_cloudformation_stack.bk_queue_ci_gpu,
     aws_cloudformation_stack.bk_queue_ci_gpu_us_east_1,
   )
-  role       = each.value.outputs.InstanceRoleName
+  role       = each.key == "gpu-4-queue-ci-us-east-1" ? "bk-gpu-4-queue-ci-us-east-1-Role" : each.value.outputs.InstanceRoleName
   policy_arn = aws_iam_policy.premerge_ecr_public_read_access_policy.arn
 }
 
@@ -410,7 +410,7 @@ resource "aws_iam_role_policy_attachment" "postmerge_ecr_public_read_access" {
     aws_cloudformation_stack.bk_queue_ci_gpu,
     aws_cloudformation_stack.bk_queue_ci_gpu_us_east_1,
   )
-  role       = each.value.outputs.InstanceRoleName
+  role       = each.key == "gpu-4-queue-ci-us-east-1" ? "bk-gpu-4-queue-ci-us-east-1-Role" : each.value.outputs.InstanceRoleName
   policy_arn = aws_iam_policy.postmerge_ecr_public_read_access_policy.arn
 }
 
@@ -475,7 +475,7 @@ resource "aws_iam_role_policy_attachment" "bk_stack_secrets_access" {
     aws_cloudformation_stack.bk_queue_ci_gpu_us_east_1,
     aws_cloudformation_stack.bk_queue_release,
   )
-  role       = each.value.outputs.InstanceRoleName
+  role       = each.key == "gpu-4-queue-ci-us-east-1" ? "bk-gpu-4-queue-ci-us-east-1-Role" : each.value.outputs.InstanceRoleName
   policy_arn = aws_iam_policy.bk_stack_secrets_access.arn
 }
 


### PR DESCRIPTION
## Summary

- add a second Buildkite Elastic CI Stack for `gpu_4_queue` in `us-east-1` while retaining the existing `us-west-2` stack
- copy the current NVIDIA GPU AMI into `us-east-1` and use the existing east-region VPC and CI agent token
- attach the same ECR read and secrets policies to the new stack
- cap the east stack at 19 `g6.12xlarge` instances based on the current 920-vCPU regional G/VT on-demand quota
- preserve the five existing `instance-bootstrap.sh` stack parameters and the live `vllm-omni-release-repo` permission in Terraform
- document that both regional stacks serve the same Buildkite queue

## Why

`gpu_4_queue` was available only from `us-west-2`, where current `g6.12xlarge` capacity is insufficient. Registering the new east-region agents to the same queue lets existing pipeline steps run in either region without pipeline changes.

The initial full Terraform plan exposed pre-existing drift. Encoding those live settings prevents unrelated CloudFormation updates and the resulting replacement of 17 IAM policy attachments.

Both Elastic CI Stack autoscalers independently observe the shared queue, so both regions may temporarily over-provision when capacity is available in each region. This is an intentional capacity-failover tradeoff.

## Validation

- `terraform validate`
- complete Terraform plan: **5 to add, 0 to change, 0 to destroy**
- confirmed the source GPU AMI is available and public for cross-region copying
- confirmed `g6.12xlarge` is offered in `us-east-1`
- confirmed the account's `us-east-1` on-demand G/VT quota is 920 vCPUs
- DCO signoff included on both commits

No Terraform apply was run.