### PR TITLE
fix(buildkite): isolate Kubernetes hostPath volumes for PR builds

### DIFF
--- a/buildkite/pipeline_generator/plugin/k8s_plugin.py
+++ b/buildkite/pipeline_generator/plugin/k8s_plugin.py
@@ -1,4 +1,5 @@
 import copy
+import os
 from step import Step
 from constants import DeviceType
 
@@ -244,4 +245,12 @@ def get_k8s_plugin(step: Step, image: str):
     plugin["kubernetes"]["podSpec"]["containers"][0]["resources"]["limits"][
         "nvidia.com/gpu"
     ] = step.num_devices or 1
+
+    pull_request = os.getenv("BUILDKITE_PULL_REQUEST")
+    if pull_request and pull_request != "false":
+        for vol in plugin["kubernetes"]["podSpec"].get("volumes", []):
+            if "hostPath" in vol and "path" in vol["hostPath"]:
+                path = vol["hostPath"]["path"]
+                if not path.endswith("-pr"):
+                    vol["hostPath"]["path"] = f"{path}-pr"
     return plugin

--- a/buildkite/pipeline_generator/plugin/k8s_plugin.py
+++ b/buildkite/pipeline_generator/plugin/k8s_plugin.py
@@ -1,4 +1,5 @@
 import copy
+import os
 from step import Step
 from constants import DeviceType
 from plugin.analytics import get_buildkite_analytics_token_env
@@ -250,4 +251,12 @@ def get_k8s_plugin(step: Step, image: str):
     plugin["kubernetes"]["podSpec"]["containers"][0]["resources"]["limits"][
         "nvidia.com/gpu"
     ] = step.num_devices or 1
+
+    pull_request = os.getenv("BUILDKITE_PULL_REQUEST")
+    if pull_request and pull_request != "false":
+        for vol in plugin["kubernetes"]["podSpec"].get("volumes", []):
+            if "hostPath" in vol and "path" in vol["hostPath"]:
+                path = vol["hostPath"]["path"]
+                if not path.endswith("-pr"):
+                    vol["hostPath"]["path"] = f"{path}-pr"
     return plugin

--- a/buildkite/tests/pipeline_generator/test_k8s_plugin.py
+++ b/buildkite/tests/pipeline_generator/test_k8s_plugin.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from pathlib import Path
+
+# Add plugin dir to path
+plugin_dir = Path(__file__).resolve().parent.parent.parent / "pipeline_generator" / "plugin"
+sys.path.insert(0, str(plugin_dir))
+sys.path.insert(0, str(plugin_dir.parent))
+
+from k8s_plugin import get_k8s_plugin
+from step import Step
+from constants import DeviceType
+
+
+def test_k8s_plugin_pr_isolation(monkeypatch):
+    step = Step(label="test", device=DeviceType.H100)
+    
+    # Non-PR build
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST", "false")
+    plugin_main = get_k8s_plugin(step, "test-image")
+    volumes_main = plugin_main["kubernetes"]["podSpec"]["volumes"]
+    hf_vol_main = next(v for v in volumes_main if v["name"] == "hf-cache")
+    assert hf_vol_main["hostPath"]["path"] == "/mnt/hf-cache"
+
+    # PR build
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST", "123")
+    plugin_pr = get_k8s_plugin(step, "test-image")
+    volumes_pr = plugin_pr["kubernetes"]["podSpec"]["volumes"]
+    hf_vol_pr = next(v for v in volumes_pr if v["name"] == "hf-cache")
+    assert hf_vol_pr["hostPath"]["path"] == "/mnt/hf-cache-pr"


### PR DESCRIPTION
Prevent host directory and cache poisoning by appending a '-pr' suffix to hostPath volume mounts when executing Kubernetes pipeline steps during pull request builds.

Signed-off-by: Jincheng Chen <chenjincheng@google.com>

BUG=b/510376194
TAG=agy