### PR TITLE
fix(buildkite): isolate Docker volume host paths for PR builds

### DIFF
--- a/buildkite/pipeline_generator/plugin/docker_plugin.py
+++ b/buildkite/pipeline_generator/plugin/docker_plugin.py
@@ -1,6 +1,7 @@
+import copy
+import os
 from step import Step
 from constants import DeviceType
-import copy
 
 docker_plugin_template = {
     "image": "",
@@ -126,5 +127,20 @@ def get_docker_plugin(step: Step, image: str):
         plugin["mount_buildkite_agent"] = True
     if step.device in (DeviceType.CPU, DeviceType.CPU_SMALL, DeviceType.CPU_MEDIUM) and plugin.get("gpus"):
         del plugin["gpus"]
+
+    pull_request = os.getenv("BUILDKITE_PULL_REQUEST")
+    if pull_request and pull_request != "false" and "volumes" in plugin:
+        new_volumes = []
+        for vol in plugin["volumes"]:
+            parts = vol.split(":")
+            if len(parts) >= 2:
+                host_path, container_path = parts[0], parts[1]
+                if host_path not in ("/dev/shm", "/dev/nvidiactl") and not host_path.endswith("_pr") and not host_path.endswith("-pr"):
+                    host_path = f"{host_path}_pr"
+                new_volumes.append(f"{host_path}:{container_path}")
+            else:
+                new_volumes.append(vol)
+        plugin["volumes"] = new_volumes
+
     # TODO: Add BUILDKITE_ANALYTICS_TOKEN and pytest addopts for fail_fast
     return plugin

--- a/buildkite/tests/pipeline_generator/test_docker_plugin.py
+++ b/buildkite/tests/pipeline_generator/test_docker_plugin.py
@@ -1,0 +1,25 @@
+import os
+import sys
+from pathlib import Path
+
+plugin_dir = Path(__file__).resolve().parent.parent.parent / "pipeline_generator" / "plugin"
+sys.path.insert(0, str(plugin_dir))
+sys.path.insert(0, str(plugin_dir.parent))
+
+from docker_plugin import get_docker_plugin
+from step import Step
+from constants import DeviceType
+
+
+def test_docker_plugin_volume_pr_isolation(monkeypatch):
+    step = Step(label="test", device=DeviceType.CPU)
+
+    # Non-PR build
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST", "false")
+    plugin_main = get_docker_plugin(step, "test-image")
+    assert "/fsx/hf_cache:/fsx/hf_cache" in plugin_main["volumes"]
+
+    # PR build
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST", "456")
+    plugin_pr = get_docker_plugin(step, "test-image")
+    assert "/fsx/hf_cache_pr:/fsx/hf_cache" in plugin_pr["volumes"]


### PR DESCRIPTION
Isolate host cache directories bound into Docker containers during PR builds by suffixing host paths with '_pr' to prevent host directory contamination.

Signed-off-by: Jincheng Chen <chenjincheng@google.com>

BUG=b/510376193
TAG=agy