### PR TITLE
fix(buildkite): disable propagate-environment and filter secrets for …

### DIFF
--- a/buildkite/pipeline_generator/plugin/docker_plugin.py
+++ b/buildkite/pipeline_generator/plugin/docker_plugin.py
@@ -1,3 +1,4 @@
+import os
 from step import Step
 from constants import DeviceType
 import copy
@@ -126,5 +127,16 @@ def get_docker_plugin(step: Step, image: str):
         plugin["mount_buildkite_agent"] = True
     if step.device in (DeviceType.CPU, DeviceType.CPU_SMALL, DeviceType.CPU_MEDIUM) and plugin.get("gpus"):
         del plugin["gpus"]
+
+    pull_request = os.getenv("BUILDKITE_PULL_REQUEST")
+    if pull_request and pull_request != "false":
+        plugin["propagate-environment"] = False
+        sensitive_tokens = {"HF_TOKEN", "CODECOV_TOKEN", "BUILDKITE_ANALYTICS_TOKEN", "RAY_COMPAT_SLACK_WEBHOOK_URL"}
+        if "environment" in plugin:
+            plugin["environment"] = [
+                env_var for env_var in plugin["environment"]
+                if env_var.split("=")[0] not in sensitive_tokens
+            ]
+
     # TODO: Add BUILDKITE_ANALYTICS_TOKEN and pytest addopts for fail_fast
     return plugin

--- a/buildkite/tests/pipeline_generator/test_docker_secrets.py
+++ b/buildkite/tests/pipeline_generator/test_docker_secrets.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from pathlib import Path
+
+plugin_dir = Path(__file__).resolve().parent.parent.parent / "pipeline_generator" / "plugin"
+sys.path.insert(0, str(plugin_dir))
+sys.path.insert(0, str(plugin_dir.parent))
+
+from docker_plugin import get_docker_plugin
+from step import Step
+from constants import DeviceType
+
+
+def test_docker_plugin_secrets_propagation(monkeypatch):
+    step = Step(label="test", device=DeviceType.CPU)
+
+    # Non-PR build
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST", "false")
+    plugin_main = get_docker_plugin(step, "test-image")
+    assert plugin_main["propagate-environment"] is True
+    assert "HF_TOKEN" in plugin_main["environment"]
+
+    # PR build
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST", "789")
+    plugin_pr = get_docker_plugin(step, "test-image")
+    assert plugin_pr["propagate-environment"] is False
+    assert "HF_TOKEN" not in plugin_pr["environment"]
+    assert "CODECOV_TOKEN" not in plugin_pr["environment"]


### PR DESCRIPTION
…PR builds

Prevent CI secret exfiltration in Docker containers during PR builds by setting propagate-environment to False and stripping secret tokens.

Signed-off-by: Jincheng Chen <chenjincheng@google.com>

BUG=b/510375841
TAG=agy