### PR TITLE
Keep GPU queue instances after jobs

### DIFF
--- a/terraform/aws/cloudformation_stack.tf
+++ b/terraform/aws/cloudformation_stack.tf
@@ -205,7 +205,8 @@ locals {
       OnDemandPercentage                   = 100
       ImageId                              = "ami-040f1b73b7a7c7453" # Custom AMI with Nvidia driver 570.133.20
       BootstrapScriptUrl                   = "https://vllm-ci.s3.us-west-2.amazonaws.com/bootstrap.sh"
-      BuildkiteTerminateInstanceAfterJob   = true
+      # Reuse scarce GPU capacity instead of terminating and replacing it after every job.
+      BuildkiteTerminateInstanceAfterJob   = false
     }
 
     gpu-4-queue-ci = {
@@ -218,7 +219,8 @@ locals {
       OnDemandPercentage                   = 100
       ImageId                              = "ami-040f1b73b7a7c7453" # Custom AMI with Nvidia driver 570.133.20
       BootstrapScriptUrl                   = "https://vllm-ci.s3.us-west-2.amazonaws.com/bootstrap.sh"
-      BuildkiteTerminateInstanceAfterJob   = true
+      # Reuse scarce GPU capacity instead of terminating and replacing it after every job.
+      BuildkiteTerminateInstanceAfterJob   = false
     }
   }
 


### PR DESCRIPTION
## Summary

- keep `gpu_1_queue` and `gpu_4_queue` instances alive after jobs finish
- retain the default minimum size of `0`, so idle capacity may still scale down normally
- avoid forced instance replacement after each job when GPU capacity is scarce

## Validation

- `terraform validate -no-color`
- targeted Terraform apply for both west-region GPU queue CloudFormation stacks: `0 added, 0 changed, 0 destroyed`

## Apply safety

A fresh full plan was intentionally not applied because it included unrelated infrastructure drift (`17 to add, 6 to change, 18 to destroy`). The verified apply was scoped to the two GPU queue stacks.