### PR TITLE
Update GPU lifecycle and preserve Omni ECR access

### DIFF
--- a/terraform/aws/cloudformation_stack.tf
+++ b/terraform/aws/cloudformation_stack.tf
@@ -205,8 +205,8 @@ locals {
       OnDemandPercentage                   = 100
       ImageId                              = "ami-040f1b73b7a7c7453" # Custom AMI with Nvidia driver 570.133.20
       BootstrapScriptUrl                   = "https://vllm-ci.s3.us-west-2.amazonaws.com/bootstrap.sh"
-      # Reuse scarce GPU capacity instead of terminating and replacing it after every job.
-      BuildkiteTerminateInstanceAfterJob   = false
+      # Recycle each GPU instance after a single job completes.
+      BuildkiteTerminateInstanceAfterJob   = true
     }
 
     gpu-4-queue-ci = {
@@ -219,8 +219,8 @@ locals {
       OnDemandPercentage                   = 100
       ImageId                              = "ami-040f1b73b7a7c7453" # Custom AMI with Nvidia driver 570.133.20
       BootstrapScriptUrl                   = "https://vllm-ci.s3.us-west-2.amazonaws.com/bootstrap.sh"
-      # Reuse scarce GPU capacity instead of terminating and replacing it after every job.
-      BuildkiteTerminateInstanceAfterJob   = false
+      # Recycle each GPU instance after a single job completes.
+      BuildkiteTerminateInstanceAfterJob   = true
     }
   }
 

--- a/terraform/aws/iam.tf
+++ b/terraform/aws/iam.tf
@@ -224,7 +224,10 @@ resource "aws_iam_policy" "release_ecr_public_read_write_access_policy" {
         "ecr-public:UploadLayerPart",
         "sts:GetServiceBearerToken"
       ]
-      Resource = "arn:aws:ecr-public::936637512419:repository/vllm-release-repo"
+      Resource = [
+        "arn:aws:ecr-public::936637512419:repository/vllm-release-repo",
+        "arn:aws:ecr-public::936637512419:repository/vllm-omni-release-repo",
+      ]
     }]
   })
 }


### PR DESCRIPTION
## Summary

- terminate `gpu_1_queue` and `gpu_4_queue` instances after each completed job
- retain `MinSize = 0` for both queues
- preserve `vllm-omni-release-repo` in the Terraform-managed release ECR policy

## Why

GPU workers should recycle immediately after finishing a job. The Omni release repository is already present in the live IAM policy, so declaring it in Terraform prevents an unrelated permission removal on future applies.

## Validation

- `terraform validate -no-color`
- focused Terraform plan for both GPU stacks and the release ECR policy: no changes
- focused Terraform apply: `0 added, 0 changed, 0 destroyed`
- live CloudFormation parameters verified as `BuildkiteTerminateInstanceAfterJob = true` for both GPU stacks

## Operational note

The original stack update replaced the underlying Auto Scaling groups. CloudFormation is gracefully draining the old protected workers. AWS reported intermittent `InsufficientInstanceCapacity` for `g6.12xlarge`, so GPU-4 replacement capacity may recover gradually.