### PR TITLE
[CI][AMD] Consolidate ROCm CI pipeline behavior

### DIFF
--- a/buildkite/pipeline_generator/amd.py
+++ b/buildkite/pipeline_generator/amd.py
@@ -31,6 +31,7 @@ AMD_ALWAYS_RUN_STEP_KEYS = frozenset(
 )
 AMD_RETRY = {
     "automatic": [
+        {"signal_reason": "stack_error", "limit": 1},
         {"exit_status": -1, "limit": 1},
         {"exit_status": 1, "limit": 1},
         {"exit_status": 128, "limit": 1},

--- a/buildkite/pipeline_generator/amd.py
+++ b/buildkite/pipeline_generator/amd.py
@@ -19,10 +19,14 @@ AMD_NATIVE_SHM_SIZE = "16Gi"
 AMD_NATIVE_RUNTIME_SOURCE_DEPENDENCIES = (
     ".buildkite/scripts/hardware_ci/run-amd-test.sh",
 )
+AMD_ROCM_BASE_REFRESH_STEP_KEY = "refresh-rocm-base-amd"
+AMD_ROCM_BASE_DOCKERFILE = "docker/Dockerfile.rocm_base"
+AMD_ROCM_BASE_REFRESH_TIMEOUT_MINUTES = 9 * 60
+AMD_ROCM_BASE_REFRESH_NOOP_TIMEOUT_MINUTES = 15
 AMD_ALWAYS_RUN_STEP_KEYS = frozenset(
     {
         "ensure-ci-base-amd",
-        "refresh-rocm-base-amd",
+        AMD_ROCM_BASE_REFRESH_STEP_KEY,
     }
 )
 AMD_RETRY = {
@@ -36,6 +40,17 @@ AMD_RETRY = {
 }
 ROCM_DEBUG_AGENT_ENV_VAR = "VLLM_CI_ENABLE_ROCM_DEBUG_AGENT"
 ROCM_DEBUG_AGENT_LIB = "/opt/rocm/lib/librocm-debug-agent.so.2"
+
+
+def get_rocm_base_refresh_timeout(list_file_diff: List[str]) -> int:
+    if os.getenv("ROCM_BASE_REFRESH_SKIP", "0") == "1":
+        return AMD_ROCM_BASE_REFRESH_NOOP_TIMEOUT_MINUTES
+    if (
+        os.getenv("ROCM_BASE_REFRESH_FORCE", "0") == "1"
+        or AMD_ROCM_BASE_DOCKERFILE in list_file_diff
+    ):
+        return AMD_ROCM_BASE_REFRESH_TIMEOUT_MINUTES
+    return AMD_ROCM_BASE_REFRESH_NOOP_TIMEOUT_MINUTES
 
 
 @dataclass(frozen=True)

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -5,8 +5,10 @@ import os
 from amd import (
     AMD_ALWAYS_RUN_STEP_KEYS,
     AMD_NATIVE_RUNTIME_SOURCE_DEPENDENCIES,
+    AMD_ROCM_BASE_REFRESH_STEP_KEY,
     build_amd_step_options,
     get_amd_agent_queue,
+    get_rocm_base_refresh_timeout,
     get_amd_setup_commands,
     is_amd_gpu_device,
 )
@@ -512,6 +514,10 @@ def convert_group_step_to_buildkite_step(
             if step.timeout_in_minutes:
                 buildkite_step.timeout_in_minutes = _get_timeout_in_minutes(
                     step.timeout_in_minutes
+                )
+            if step.key == AMD_ROCM_BASE_REFRESH_STEP_KEY:
+                buildkite_step.timeout_in_minutes = _get_timeout_in_minutes(
+                    get_rocm_base_refresh_timeout(list_file_diff)
                 )
 
             if not _step_should_run(step, list_file_diff):

--- a/buildkite/test-template-amd.j2
+++ b/buildkite/test-template-amd.j2
@@ -9,6 +9,8 @@
 {% macro amd_infra_retry(indent='', retry_exit_status_one=false) -%}
 {{ indent }}retry:
 {{ indent }}  automatic:
+{{ indent }}    - signal_reason: stack_error  # Kubernetes pod/stack provisioning failed
+{{ indent }}      limit: 1
 {% if retry_exit_status_one %}
 {{ indent }}    - exit_status: 1  # Transient Docker/BuildKit failure
 {{ indent }}      limit: 1

--- a/buildkite/test-template-amd.j2
+++ b/buildkite/test-template-amd.j2
@@ -6,9 +6,13 @@
 #}
 {% set rocm_debug_agent_setup = "echo 'ROCm debug agent disabled; re-enable rocm_debug_agent_setup in test-template-amd.j2 after validating coredump setup'" %}
 
-{% macro amd_infra_retry(indent='') -%}
+{% macro amd_infra_retry(indent='', retry_exit_status_one=false) -%}
 {{ indent }}retry:
 {{ indent }}  automatic:
+{% if retry_exit_status_one %}
+{{ indent }}    - exit_status: 1  # Transient Docker/BuildKit failure
+{{ indent }}      limit: 1
+{% endif %}
 {{ indent }}    - signal_reason: agent_stop  # Agent host stopped unexpectedly
 {{ indent }}      limit: 1
 {{ indent }}    - signal_reason: agent_refused  # Agent could not accept the job
@@ -98,11 +102,12 @@ rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT
         commands:
           - bash .buildkite/scripts/rocm/refresh-base-image.sh
         key: "refresh-rocm-base-amd"
+        timeout_in_minutes: {{ 540 if "docker/Dockerfile.rocm_base" in list_file_diff else 15 }}
         env:
           DOCKER_BUILDKIT: "1"
           BUILDKIT_PROGRESS: "tty"
           TERM: "xterm-256color"
-{{ amd_infra_retry('        ') }}
+{{ amd_infra_retry('        ', true) }}
         agents:
           queue: amd-cpu
 
@@ -120,7 +125,7 @@ rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT
           PYTORCH_ROCM_ARCH: "gfx90a;gfx942;gfx950"
           REMOTE_VLLM: "1"
           VLLM_BRANCH: "$BUILDKITE_COMMIT"
-{{ amd_infra_retry('        ') }}
+{{ amd_infra_retry('        ', true) }}
         agents:
           queue: amd-cpu
 
@@ -140,7 +145,7 @@ rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT
           IMAGE_TAG: "rocm/vllm-ci:$BUILDKITE_COMMIT"
           REMOTE_VLLM: "1"
           VLLM_BRANCH: "$BUILDKITE_COMMIT"
-{{ amd_infra_retry('        ') }}
+{{ amd_infra_retry('        ', true) }}
         agents:
           queue: amd-cpu
 
@@ -190,11 +195,7 @@ rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT
         {% endif %}
         timeout_in_minutes: {{ step_timeout_in_minutes }}
         agents:
-          {% if step.agent_pool %}
           queue: amd_{{ step.agent_pool }}
-          {% else %}
-          queue: amd_mi300
-          {% endif %}
           {% if step.dind == false and step.agent_tags %}
             {% for key, value in step.agent_tags | items %}
               {% if key != "queue" and key and value %}

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -116,7 +116,11 @@ def test_direct_amd_gpu_steps_use_dind_flag(
         assert command_step.env["DOCKER_IMAGE_NAME"] == amd.AMD_STABLE_CI_BASE_IMAGE
 
     assert command_step.retry == amd.AMD_RETRY
-    assert len(command_step.retry["automatic"]) == 5
+    assert len(command_step.retry["automatic"]) == 6
+    assert command_step.retry["automatic"][0] == {
+        "signal_reason": "stack_error",
+        "limit": 1,
+    }
 
     test_commands = command_step.env["VLLM_TEST_COMMANDS"]
     assert test_commands.startswith(f"export VLLM_TEST_GROUP_NAME={step.key}")

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -16,6 +16,54 @@ def _render_single_step(step):
     )[0]
 
 
+def _rocm_base_refresh_step():
+    return Step(
+        label="AMD: :docker: refresh ROCm base",
+        group="Hardware - AMD Build",
+        key=amd.AMD_ROCM_BASE_REFRESH_STEP_KEY,
+        device="amd_cpu",
+        no_plugin=True,
+        commands=["bash .buildkite/scripts/rocm/refresh-base-image.sh"],
+    )
+
+
+@pytest.mark.parametrize(
+    ("list_file_diff", "expected_timeout"),
+    [
+        ([], 15),
+        (["vllm/config.py"], 15),
+        ([amd.AMD_ROCM_BASE_DOCKERFILE], 540),
+    ],
+)
+def test_rocm_base_refresh_timeout_tracks_dockerfile_change(
+    fake_global_config, list_file_diff, expected_timeout
+):
+    fake_global_config["list_file_diff"] = list_file_diff
+
+    command_step = _render_single_step(_rocm_base_refresh_step()).steps[0]
+
+    assert command_step.timeout_in_minutes == expected_timeout
+
+
+def test_rocm_base_refresh_force_uses_build_timeout(monkeypatch):
+    monkeypatch.setenv("ROCM_BASE_REFRESH_FORCE", "1")
+
+    command_step = _render_single_step(_rocm_base_refresh_step()).steps[0]
+
+    assert command_step.timeout_in_minutes == 540
+
+
+def test_skip_timeout_omits_rocm_base_refresh_timeout(
+    fake_global_config, monkeypatch
+):
+    monkeypatch.setenv(buildkite_step.SKIP_TIMEOUT_ENV_VAR, "1")
+    fake_global_config["list_file_diff"] = [amd.AMD_ROCM_BASE_DOCKERFILE]
+
+    command_step = _render_single_step(_rocm_base_refresh_step()).steps[0]
+
+    assert command_step.timeout_in_minutes is None
+
+
 @pytest.mark.parametrize(
     ("device", "queue", "dind", "expected_gpu_count"),
     [


### PR DESCRIPTION
Removes the legacy `amd_mi300` queue fallback and retries transient Docker build failures or Kubernetes stack provisioning errors once. It also shortens no-op ROCm base refresh timeouts while retaining the full timeout for real rebuilds.