### PR TITLE
[CI][AMD] Add opt-in Hugging Face Hub retries

### DIFF
--- a/buildkite/bootstrap-amd.sh
+++ b/buildkite/bootstrap-amd.sh
@@ -179,6 +179,7 @@ upload_pipeline() {
             -D run_all="$RUN_ALL" \
             -D nightly="$NIGHTLY" \
             -D torch_nightly="$TORCH_NIGHTLY" \
+            -D hf_hub_mode="${VLLM_CI_HF_HUB_MODE:-}" \
             -D mirror_hw="$AMD_MIRROR_HW" \
             -D fail_fast="$FAIL_FAST" \
             -D vllm_use_precompiled="$VLLM_USE_PRECOMPILED" \

--- a/buildkite/pipeline_generator/amd.py
+++ b/buildkite/pipeline_generator/amd.py
@@ -29,6 +29,8 @@ AMD_ALWAYS_RUN_STEP_KEYS = frozenset(
         AMD_ROCM_BASE_REFRESH_STEP_KEY,
     }
 )
+# Must match vllm_test_utils.hf_hub.HF_HUB_RETRY_EXIT_STATUS.
+AMD_HF_HUB_RETRY_EXIT_STATUS = 75
 AMD_RETRY = {
     "automatic": [
         {"signal_reason": "stack_error", "limit": 1},
@@ -337,6 +339,7 @@ def build_amd_step_options(
     no_gpu: bool,
     num_nodes: Optional[int],
     agent_tags: Optional[Dict[str, str]],
+    hf_hub_mode: Optional[str] = None,
 ) -> AmdStepOptions:
     config = get_amd_device_config(device)
     if config is None:
@@ -376,6 +379,7 @@ def build_amd_step_options(
             )
         ]
 
+    retry = AMD_RETRY
     if no_plugin:
         env = dict(extra_env or {}) or None
         step_commands = [commands]
@@ -387,6 +391,14 @@ def build_amd_step_options(
             gpu_count=gpu_count,
         )
         step_commands = [AMD_TEST_COMMAND]
+        if hf_hub_mode:
+            env["VLLM_CI_HF_HUB_MODE"] = hf_hub_mode
+            retry = {
+                "automatic": [
+                    *AMD_RETRY["automatic"],
+                    {"exit_status": AMD_HF_HUB_RETRY_EXIT_STATUS, "limit": 1},
+                ]
+            }
 
     return {
         "label": get_amd_label(label, device),
@@ -396,5 +408,5 @@ def build_amd_step_options(
         "env": env,
         "plugins": plugins,
         "priority": 200,
-        "retry": AMD_RETRY,
+        "retry": retry,
     }

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -447,6 +447,11 @@ def convert_group_step_to_buildkite_step(
     print(variables_to_inject)
     global_config = get_global_config()
     list_file_diff = global_config["list_file_diff"]
+    amd_hf_hub_mode = os.getenv("VLLM_CI_HF_HUB_MODE")
+    if amd_hf_hub_mode and (
+        global_config["nightly"] == "1" or global_config["torch_nightly"] == "1"
+    ):
+        amd_hf_hub_mode = "online"
 
     amd_hardware_steps = []
 
@@ -481,6 +486,7 @@ def convert_group_step_to_buildkite_step(
                     parallelism=step.parallelism,
                     timeout_in_minutes=step.timeout_in_minutes,
                     agent_tags=step.agent_tags,
+                    hf_hub_mode=amd_hf_hub_mode,
                 )
                 if not _step_should_run(step, list_file_diff):
                     block_step = _create_block_step(
@@ -596,6 +602,7 @@ def convert_group_step_to_buildkite_step(
                     parallelism=step.parallelism,
                     timeout_in_minutes=amd.get("timeout_in_minutes"),
                     agent_tags=amd.get("agent_tags"),
+                    hf_hub_mode=amd_hf_hub_mode,
                 )
                 if not _step_should_run(
                     _get_amd_mirror_effective_step(step, amd), list_file_diff
@@ -715,6 +722,7 @@ def _create_amd_step(
     num_nodes: Optional[int],
     soft_fail: Optional[bool],
     parallelism: Optional[int],
+    hf_hub_mode: Optional[str] = None,
     key: Optional[str] = None,
     timeout_in_minutes: Optional[int] = None,
     agent_tags: Optional[Dict[str, str]] = None,
@@ -732,6 +740,7 @@ def _create_amd_step(
         no_gpu=no_gpu,
         num_nodes=num_nodes,
         agent_tags=agent_tags,
+        hf_hub_mode=hf_hub_mode,
     )
     return BuildkiteCommandStep(
         **options,

--- a/buildkite/test-template-amd.j2
+++ b/buildkite/test-template-amd.j2
@@ -1,12 +1,15 @@
 {% set default_working_dir = "/vllm-workspace/tests" %}
 {% set default_amd_timeout_in_minutes = 180 %}
 {% set list_file_diff = list_file_diff | replace("\r", "") | replace("\n", "|") | split("|") %}
+{% set requested_hf_hub_mode = hf_hub_mode | default("") %}
+{% set effective_hf_hub_mode = "online" if requested_hf_hub_mode and (nightly == "1" or torch_nightly == "1") else requested_hf_hub_mode %}
+{% set hf_retry_exit_status = 75 %}
 {# TODO: Re-enable after validating the ROCm debug agent setup.
 {% set rocm_debug_agent_setup = "if test -f /opt/rocm/lib/librocm-debug-agent.so.2; then export HSA_TOOLS_LIB=/opt/rocm/lib/librocm-debug-agent.so.2 && export HSA_ENABLE_DEBUG=1 && echo ROCm debug agent enabled: /opt/rocm/lib/librocm-debug-agent.so.2; else echo 'WARNING: ROCm debug agent not found at /opt/rocm/lib/librocm-debug-agent.so.2; skipping coredump setup'; fi" %}
 #}
 {% set rocm_debug_agent_setup = "echo 'ROCm debug agent disabled; re-enable rocm_debug_agent_setup in test-template-amd.j2 after validating coredump setup'" %}
 
-{% macro amd_infra_retry(indent='', retry_exit_status_one=false) -%}
+{% macro amd_infra_retry(indent='', retry_exit_status_one=false, hf_online_retry=false) -%}
 {{ indent }}retry:
 {{ indent }}  automatic:
 {{ indent }}    - signal_reason: stack_error  # Kubernetes pod/stack provisioning failed
@@ -22,6 +25,10 @@
 {{ indent }}    - exit_status: -1  # Lost contact with the running agent
 {{ indent }}      signal_reason: none
 {{ indent }}      limit: 1
+{% if hf_online_retry %}
+{{ indent }}    - exit_status: {{ hf_retry_exit_status }}  # Retry an HF-related failure once
+{{ indent }}      limit: 1
+{% endif %}
 {%- endmacro %}
 
 {% macro amd_step_slug(step) -%}
@@ -156,6 +163,7 @@ rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT
 
     {% set ns = namespace(blocked=1) %}
     {% set step_slug = amd_step_slug(step) %}
+    {% set hf_monitored = requested_hf_hub_mode and not step.no_plugin %}
     {% set step_timeout_in_minutes = step.timeout_in_minutes or default_amd_timeout_in_minutes %}
     {# Time out the container a minute before Buildkite times out the job. #}
     {% set container_timeout_s = (step_timeout_in_minutes * 60 - 60) if step_timeout_in_minutes > 1 else step_timeout_in_minutes * 60 %}
@@ -220,6 +228,9 @@ rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT
         command: bash .buildkite/scripts/hardware_ci/run-amd-test.sh
         env:
           NUM_NODES: "{{ step.num_nodes or 1 }}"
+          {% if hf_monitored %}
+          VLLM_CI_HF_HUB_MODE: "{{ effective_hf_hub_mode }}"
+          {% endif %}
           # Agent hooks read DOCKER_IMAGE_NAME before run-amd-test.py starts.
           {% if step.dind == false %}
           # Native: podSpecPatch sets container-0 to ci_base-<commit> from ensure-ci-base-amd.
@@ -267,6 +278,6 @@ rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT
         {% if step.parallelism %}
         parallelism: {{ step.parallelism }}
         {% endif %}
-{{ amd_infra_retry('        ') }}
+{{ amd_infra_retry('        ', hf_online_retry=hf_monitored) }}
     {% endif %}
     {% endfor %}

--- a/buildkite/tests/pipeline_generator/conftest.py
+++ b/buildkite/tests/pipeline_generator/conftest.py
@@ -7,6 +7,7 @@ import step as step_module
 @pytest.fixture
 def fake_global_config(monkeypatch):
     monkeypatch.delenv(buildkite_step.SKIP_TIMEOUT_ENV_VAR, raising=False)
+    monkeypatch.delenv("VLLM_CI_HF_HUB_MODE", raising=False)
     config = {
         "name": "vllm_ci",
         "github_repo_name": "vllm-project/vllm",

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -115,9 +115,10 @@ def test_direct_amd_gpu_steps_use_dind_flag(
         assert "AMD_CI_RUNTIME" not in command_step.env
         assert command_step.env["DOCKER_IMAGE_NAME"] == amd.AMD_STABLE_CI_BASE_IMAGE
 
+    assert "VLLM_CI_HF_HUB_MODE" not in command_step.env
     assert command_step.retry == amd.AMD_RETRY
-    assert len(command_step.retry["automatic"]) == 6
-    assert command_step.retry["automatic"][0] == {
+    assert len(amd.AMD_RETRY["automatic"]) == 6
+    assert amd.AMD_RETRY["automatic"][0] == {
         "signal_reason": "stack_error",
         "limit": 1,
     }
@@ -136,6 +137,103 @@ def test_direct_amd_gpu_steps_use_dind_flag(
     assert "pytest tests/foo.py" in test_commands
     assert "nvidia-smi" not in test_commands
     assert "CUDA_ENABLE_COREDUMP_ON_EXCEPTION" not in test_commands
+
+
+@pytest.mark.parametrize(
+    ("nightly", "torch_nightly"),
+    [("0", "0"), ("1", "0"), ("0", "1")],
+)
+def test_empty_hf_hub_mode_matches_unset_mode(
+    fake_global_config, monkeypatch, nightly, torch_nightly
+):
+    fake_global_config["nightly"] = nightly
+    fake_global_config["torch_nightly"] = torch_nightly
+    step = Step(
+        label="AMD HF Hub disabled",
+        group="Direct AMD",
+        device="mi300_1",
+        commands=["pytest tests/foo.py"],
+    )
+
+    monkeypatch.delenv("VLLM_CI_HF_HUB_MODE", raising=False)
+    without_mode = _render_single_step(step)
+    monkeypatch.setenv("VLLM_CI_HF_HUB_MODE", "")
+    with_empty_mode = _render_single_step(step)
+
+    assert with_empty_mode == without_mode
+    command_step = next(
+        rendered_step
+        for rendered_step in without_mode.steps
+        if isinstance(rendered_step, buildkite_step.BuildkiteCommandStep)
+    )
+    assert "VLLM_CI_HF_HUB_MODE" not in command_step.env
+    assert command_step.retry == amd.AMD_RETRY
+
+
+@pytest.mark.parametrize(
+    ("requested_mode", "nightly", "torch_nightly", "expected_mode"),
+    [
+        ("offline-first", "0", "0", "offline-first"),
+        ("offline-first", "1", "0", "online"),
+        ("offline-first", "0", "1", "online"),
+        ("online", "0", "0", "online"),
+    ],
+)
+def test_amd_hf_hub_mode_tracks_pipeline_type(
+    fake_global_config,
+    monkeypatch,
+    requested_mode,
+    nightly,
+    torch_nightly,
+    expected_mode,
+):
+    monkeypatch.setenv("VLLM_CI_HF_HUB_MODE", requested_mode)
+    fake_global_config["nightly"] = nightly
+    fake_global_config["torch_nightly"] = torch_nightly
+    step = Step(
+        label="AMD HF Hub policy",
+        group="Direct AMD",
+        device="mi300_1",
+        commands=["pytest tests/foo.py"],
+    )
+
+    command_step = next(
+        rendered_step
+        for rendered_step in _render_single_step(step).steps
+        if isinstance(rendered_step, buildkite_step.BuildkiteCommandStep)
+    )
+
+    assert command_step.env["VLLM_CI_HF_HUB_MODE"] == expected_mode
+    assert command_step.retry["automatic"] == [
+        *amd.AMD_RETRY["automatic"],
+        {"exit_status": amd.AMD_HF_HUB_RETRY_EXIT_STATUS, "limit": 1},
+    ]
+    assert all(
+        retry.get("exit_status") != amd.AMD_HF_HUB_RETRY_EXIT_STATUS
+        for retry in amd.AMD_RETRY["automatic"]
+    )
+
+
+def test_amd_no_plugin_step_keeps_existing_hf_and_retry_behavior(monkeypatch):
+    monkeypatch.setenv("VLLM_CI_HF_HUB_MODE", "offline-first")
+    step = Step(
+        label="AMD direct command",
+        group="Direct AMD",
+        device="mi300_1",
+        no_plugin=True,
+        commands=["echo direct"],
+    )
+
+    command_step = next(
+        rendered_step
+        for rendered_step in _render_single_step(step).steps
+        if isinstance(rendered_step, buildkite_step.BuildkiteCommandStep)
+    )
+
+    assert command_step.commands != [amd.AMD_TEST_COMMAND]
+    assert command_step.commands[0].endswith("&& echo direct")
+    assert "VLLM_CI_HF_HUB_MODE" not in (command_step.env or {})
+    assert command_step.retry == amd.AMD_RETRY
 
 
 def test_amd_device_rejects_conflicting_gpu_count():

--- a/buildkite/tests/test_amd_template_render.py
+++ b/buildkite/tests/test_amd_template_render.py
@@ -1,0 +1,153 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+import amd
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE = REPO_ROOT / "buildkite" / "test-template-amd.j2"
+AMD_BOOTSTRAP = REPO_ROOT / "buildkite" / "bootstrap-amd.sh"
+MINIJINJA = shutil.which("minijinja-cli")
+pytestmark = pytest.mark.skipif(
+    MINIJINJA is None,
+    reason="minijinja-cli is required to render the AMD pipeline template",
+)
+
+
+def _render_template(
+    *, nightly: str, torch_nightly: str, hf_hub_mode: str | None = None
+):
+    context = {
+        "steps": [
+            {
+                "label": "Monitored wrapper",
+                "mirror_hardwares": ["amdproduction"],
+                "agent_pool": "mi300_1",
+                "num_gpus": 1,
+                "dind": True,
+                "working_dir": "/vllm-workspace/tests",
+                "commands": ["pytest tests/monitored.py"],
+            },
+            {
+                "label": "Direct command",
+                "mirror_hardwares": ["amdproduction"],
+                "agent_pool": "mi300_1",
+                "num_gpus": 1,
+                "dind": True,
+                "no_plugin": True,
+                "command": "echo direct",
+            },
+        ],
+        "branch": "feature",
+        "list_file_diff": "",
+        "run_all": "1",
+        "nightly": nightly,
+        "torch_nightly": torch_nightly,
+        "mirror_hw": "amdproduction",
+    }
+    if hf_hub_mode is not None:
+        context["hf_hub_mode"] = hf_hub_mode
+    rendered = subprocess.check_output(
+        [MINIJINJA, "--format", "yaml", str(TEMPLATE), "-"],
+        cwd=REPO_ROOT,
+        input=yaml.safe_dump(context),
+        text=True,
+    )
+    pipeline = yaml.safe_load(rendered)
+    amd_group = next(group for group in pipeline if group.get("group") == "AMD Tests")
+    return {step["label"]: step for step in amd_group["steps"]}
+
+
+@pytest.mark.parametrize(
+    ("nightly", "torch_nightly", "expected_mode"),
+    [
+        ("0", "0", "offline-first"),
+        ("1", "0", "online"),
+        ("0", "1", "online"),
+    ],
+)
+def test_amd_template_selects_hf_hub_mode(nightly, torch_nightly, expected_mode):
+    steps_by_label = _render_template(
+        nightly=nightly,
+        torch_nightly=torch_nightly,
+        hf_hub_mode="offline-first",
+    )
+
+    monitored = steps_by_label["mi300_1: Monitored wrapper"]
+    assert monitored["env"]["VLLM_CI_HF_HUB_MODE"] == expected_mode
+
+
+@pytest.mark.parametrize(
+    ("nightly", "torch_nightly"),
+    [("0", "0"), ("1", "0"), ("0", "1")],
+)
+def test_amd_template_preserves_existing_data_without_hf_hub_mode(
+    nightly, torch_nightly
+):
+    without_mode = _render_template(
+        nightly=nightly,
+        torch_nightly=torch_nightly,
+    )
+    with_empty_mode = _render_template(
+        nightly=nightly,
+        torch_nightly=torch_nightly,
+        hf_hub_mode="",
+    )
+    assert with_empty_mode == without_mode
+
+    monitored = without_mode["mi300_1: Monitored wrapper"]
+    direct = without_mode["mi300_1: Direct command"]
+
+    assert "VLLM_CI_HF_HUB_MODE" not in monitored["env"]
+    assert monitored["retry"] == direct["retry"]
+    assert monitored["retry"]["automatic"] == [
+        {"signal_reason": "stack_error", "limit": 1},
+        {"signal_reason": "agent_stop", "limit": 1},
+        {"signal_reason": "agent_refused", "limit": 1},
+        {"exit_status": -1, "signal_reason": "none", "limit": 1},
+    ]
+
+
+def test_amd_bootstrap_passes_hf_hub_mode_to_template():
+    assert '-D hf_hub_mode="${VLLM_CI_HF_HUB_MODE:-}"' in AMD_BOOTSTRAP.read_text()
+
+
+def test_amd_template_scopes_hf_retry_to_wrapped_steps():
+    steps_by_label = _render_template(
+        nightly="0",
+        torch_nightly="0",
+        hf_hub_mode="offline-first",
+    )
+
+    monitored = steps_by_label["mi300_1: Monitored wrapper"]
+    direct = steps_by_label["mi300_1: Direct command"]
+    hf_retry = {
+        "exit_status": amd.AMD_HF_HUB_RETRY_EXIT_STATUS,
+        "limit": 1,
+    }
+
+    assert monitored["command"] == (
+        "bash .buildkite/scripts/hardware_ci/run-amd-test.sh"
+    )
+    assert monitored["retry"]["automatic"] == [
+        *direct["retry"]["automatic"],
+        hf_retry,
+    ]
+
+    assert direct["command"] == "echo direct"
+    steps_with_hf_mode = {
+        label
+        for label, step in steps_by_label.items()
+        if "VLLM_CI_HF_HUB_MODE" in step.get("env", {})
+    }
+    steps_with_hf_retry = {
+        label
+        for label, step in steps_by_label.items()
+        if hf_retry in step.get("retry", {}).get("automatic", [])
+    }
+    assert steps_with_hf_mode == {"mi300_1: Monitored wrapper"}
+    assert steps_with_hf_retry == {"mi300_1: Monitored wrapper"}


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!-- Suggested title: [CI][AMD] Add opt-in Hugging Face Hub retries -->

## Summary

Cached CI jobs should not contact Hugging Face Hub unless the cache is missing something. This change makes the AMD policy opt-in through `VLLM_CI_HF_HUB_MODE`. When the variable is unset or empty, both pipeline generators preserve the existing step environment and retry policy.

Using the Hub cache in online mode still performs metadata checks, which creates unnecessary traffic and exposes otherwise healthy jobs to rate limits and network timeouts. This PR supports an opt-in AMD rollout in both pipeline generators:

- Pass `VLLM_CI_HF_HUB_MODE` only to wrapped AMD test steps when it is explicitly enabled. Nightly and PyTorch-nightly builds promote an enabled mode to `online`.
- Retry exit status 75 once. The companion vLLM runner emits that status only for an offline cache miss or a transient Hub failure.
- Apply the same policy in the legacy MiniJinja template and the Python generator, including direct AMD-device steps and AMD mirrors.
- Leave the generated data unchanged when the gate is absent, including direct `no_plugin` commands, AMD infrastructure steps, the existing `AMD_RETRY` policy, and native source gating.

The error classification and request statistics live in vLLM; ci-infra only selects the mode and configures the Buildkite retry. Companion vLLM PR: https://github.com/vllm-project/vllm/pull/49401.

## Testing

- `pytest -q buildkite/tests` — 54 passed.
- `pytest -q buildkite/tests/test_amd_template_render.py` — 8 passed with MiniJinja 2.3.1.
- `ruff check buildkite/pipeline_generator/amd.py buildkite/pipeline_generator/buildkite_step.py buildkite/tests/pipeline_generator/test_amd.py buildkite/tests/test_amd_template_render.py` — passed.
- `git diff --check` — passed.
