### PR TITLE
ci: run pipeline generator tests on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Pipeline Generator Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ./buildkite/pipeline_generator pytest
+      - name: Run tests
+        run: python -m pytest buildkite/tests


### PR DESCRIPTION
## Summary

- add a `Pipeline Generator Tests` GitHub Actions workflow that runs the existing `buildkite/tests` suite on pull requests and pushes to `main`
- install `pipeline-generator` through the same subdirectory package used by the Buildkite bootstrap path
- run on Python 3.12 with current GitHub Actions, read-only repository permissions, no persisted checkout credentials, and a bounded timeout
- use the standard `ubuntu-latest` GitHub-hosted runner, which is free for public repositories

## Why

The repository already has a focused pytest suite for the pipeline generator, but no workflow runs it. This adds a lightweight test gate so generator regressions are caught before merge while also exercising the package build and dependency declarations used by the real installation path.

## Testing

- built and installed `buildkite/pipeline_generator` in a clean Python 3.12 environment
- `python -m pytest buildkite/tests` (`38 passed`)
- `actionlint` passed for the workflow
