### PR TITLE
[CI] Add modular foundation for the /ci control plane

### DIFF
--- a/.github/actions/ci-control-validate/README.md
+++ b/.github/actions/ci-control-validate/README.md
@@ -1,0 +1,21 @@
+# CI control catalog validation action
+
+This action compiles the protected vLLM policy and Buildkite job definitions
+with the versioned catalog compiler in `services/ci-control`. It rejects
+missing/duplicate keys, invalid selector metadata, aliases or tombstones,
+unknown dependencies, dependency cycles, invalid routes/profiles, and
+non-deterministic source values.
+
+Pin cross-repository use to a full `ci-infra` commit:
+
+```yaml
+- uses: vllm-project/ci-infra/.github/actions/ci-control-validate@<full-sha>
+  with:
+    repository-root: .
+    baseline-repository-root: .ci-control-baseline
+```
+
+When a baseline is supplied, removed job and area selectors require a reviewed
+alias or tombstone. The first bootstrap is allowed when the baseline predates
+`ci_control.toml`. The action is read-only and requires no GitHub or Buildkite
+credentials.

--- a/.github/actions/ci-control-validate/action.yml
+++ b/.github/actions/ci-control-validate/action.yml
@@ -1,0 +1,40 @@
+name: Validate vLLM CI control catalog
+description: Compile and validate trusted vLLM `/ci` policy and job metadata
+
+inputs:
+  repository-root:
+    description: Path to the checked-out vLLM repository
+    required: false
+    default: .
+  baseline-repository-root:
+    description: Optional base checkout for selector compatibility validation
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      with:
+        python-version: "3.12"
+
+    - name: Compile trusted CI catalog
+      shell: bash
+      env:
+        CI_CONTROL_REPOSITORY_ROOT: ${{ inputs.repository-root }}
+        CI_CONTROL_BASELINE_ROOT: ${{ inputs.baseline-repository-root }}
+      run: |
+        catalog_args=("$CI_CONTROL_REPOSITORY_ROOT")
+        if [[ -n "$CI_CONTROL_BASELINE_ROOT" ]]; then
+          if [[ -f "$CI_CONTROL_BASELINE_ROOT/.buildkite/ci_control.toml" ]]; then
+            catalog_args+=(--baseline "$CI_CONTROL_BASELINE_ROOT")
+          else
+            echo "Baseline predates ci_control.toml; validating bootstrap catalog only."
+          fi
+        fi
+        uv run \
+          --project "$GITHUB_ACTION_PATH/../../../services/ci-control" \
+          --frozen \
+          --extra repository-validation \
+          vllm-ci-catalog "${catalog_args[@]}"

--- a/.github/workflows/ci-control.yml
+++ b/.github/workflows/ci-control.yml
@@ -1,0 +1,54 @@
+name: CI control service
+
+on:
+  pull_request:
+    paths:
+      - ".github/actions/ci-control-validate/**"
+      - ".github/workflows/ci-control.yml"
+      - "buildkite/pipeline_generator/**"
+      - "buildkite/tests/pipeline_generator/**"
+      - "services/ci-control/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/actions/ci-control-validate/**"
+      - ".github/workflows/ci-control.yml"
+      - "buildkite/pipeline_generator/**"
+      - "buildkite/tests/pipeline_generator/**"
+      - "services/ci-control/**"
+
+permissions:
+  contents: read
+
+jobs:
+  service:
+    name: Domain and adapter tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.12"
+      - name: Test
+        run: >-
+          uv run --frozen --group dev --extra repository-validation
+          pytest -q
+        working-directory: services/ci-control
+      - name: Test pipeline generator integration
+        run: >-
+          uv run --project services/ci-control --frozen
+          --group dev --extra repository-validation
+          pytest -q buildkite/tests
+      - name: Lint
+        run: >-
+          uv run --frozen --group dev --extra repository-validation
+          ruff check src tests
+        working-directory: services/ci-control
+      - name: Check formatting
+        run: >-
+          uv run --frozen --group dev --extra repository-validation
+          ruff format --check src tests
+        working-directory: services/ci-control

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ ci-infra/
 │   └── gpu/               # GPU AMI with NVIDIA drivers
 ├── infra-k8s/             # Kubernetes-based Buildkite agent deployment
 ├── github/                # GitHub Actions runner groups (Neural Magic, IBM)
+├── services/
+│   └── ci-control/        # Modular `/ci` control plane and domain contracts
 ├── claude-skills/         # Portable CI automations and investigation skills
 └── usage-stats/           # Usage telemetry collection (Vector)
 ```
@@ -37,6 +39,10 @@ source-of-truth inventory of:
 - installation, failover, validation, and operational commands;
 - host-local automations that are not portable yet;
 - investigation skills that do not run on a schedule.
+
+The pull-request `/ci` control-plane foundation, compute-credit model,
+main-failure reconciliation, and PR validation architecture are documented in
+[`services/ci-control/README.md`](services/ci-control/README.md).
 
 ## How CI Works
 

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -603,6 +603,10 @@ def convert_group_step_to_buildkite_step(
 
             # Create AMD mirror step and its block step if specified/applicable
             if step.mirror and step.mirror.get("amd"):
+                if not step.key:
+                    raise ValueError(
+                        "AMD mirrored steps require an explicit stable key."
+                    )
                 amd = step.mirror["amd"]
                 amd_no_plugin = amd.get("no_plugin", False)
                 amd_no_gpu = amd.get("no_gpu", step.no_gpu or False)
@@ -643,6 +647,7 @@ def convert_group_step_to_buildkite_step(
                 extra_env.update(amd.get("env", {}))
                 amd_step = _create_amd_step(
                     label=step.label,
+                    key=f"{step.key}-amd",
                     device=amd["device"],
                     num_devices=amd_num_devices,
                     commands_str=amd_commands_str,
@@ -668,7 +673,7 @@ def convert_group_step_to_buildkite_step(
                     )
                     amd_block_step = _create_block_step(
                         block=f"Run AMD: {step.label}",
-                        key=f"block-amd-{_generate_step_key(step.label)}",
+                        key=f"block-amd-{step.key}",
                         command_step=amd_step,
                         depends_on=[mirror_build_dep],
                     )

--- a/buildkite/pipeline_generator/step.py
+++ b/buildkite/pipeline_generator/step.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import Optional, List, Dict, Any
 from pydantic import model_validator
 from typing_extensions import Self
@@ -6,6 +6,16 @@ from collections import defaultdict
 from global_config import get_global_config
 import os
 import yaml
+
+
+class CiControlMetadata(BaseModel):
+    """Repository-owned semantic metadata for the `/ci` catalog."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    groups: Optional[List[str]] = None
+    areas: Optional[List[str]] = None
+    selectable: bool = True
 
 
 class Step(BaseModel):
@@ -31,6 +41,7 @@ class Step(BaseModel):
     no_gpu: Optional[bool] = False
     dind: bool = True
     mirror: Optional[Dict[str, Dict[str, Any]]] = None
+    ci_control: Optional[CiControlMetadata] = None
 
     @model_validator(mode="after")
     def validate_multi_node(self) -> Self:

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -229,9 +229,23 @@ def test_amd_mirror_uses_shared_gating_with_amd_dependency_fallback(
     assert default_command_step.soft_fail is False
     assert len(amd_group.steps) == 1
     assert amd_command_step.depends_on == ["image-build-amd"]
+    assert amd_command_step.key == "mirrored-test-amd"
     assert amd_command_step.agents == {"queue": AgentQueue.AMD_MI325_1}
     assert amd_command_step.soft_fail is False
     assert "ROCm debug agent disabled" in (amd_command_step.env["VLLM_TEST_COMMANDS"])
+
+
+def test_amd_mirror_requires_an_explicit_stable_key():
+    step = Step(
+        label="Unkeyed mirror",
+        group="Mirrors",
+        commands=["pytest tests/mirror.py"],
+        device="h200_18gb",
+        mirror={"amd": {"device": "mi300_1"}},
+    )
+
+    with pytest.raises(ValueError, match="explicit stable key"):
+        _render_single_step(step)
 
 
 def test_dind_false_mirror_uses_native_runner_gating(fake_global_config):
@@ -241,6 +255,7 @@ def test_dind_false_mirror_uses_native_runner_gating(fake_global_config):
     step = Step(
         label="Native mirrored test",
         group="Mirrors",
+        key="native-mirrored-test",
         commands=["pytest tests/mirror.py"],
         source_file_dependencies=["vllm/"],
         device="h200_18gb",
@@ -273,6 +288,7 @@ def test_untagged_mirror_defaults_to_dind(
     step = Step(
         label="DinD mirrored test",
         group="Mirrors",
+        key="dind-mirrored-test",
         commands=["pytest tests/mirror.py"],
         source_file_dependencies=["vllm/"],
         device="h200_18gb",
@@ -413,6 +429,7 @@ def test_skip_timeout_omits_main_and_amd_mirror_timeouts(
     step = Step(
         label="Mirrored skipped timeout",
         group="Mirrors",
+        key="mirrored-skipped-timeout",
         commands=["pytest tests/mirror.py"],
         source_file_dependencies=["vllm/"],
         device="h200_18gb",

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 import buildkite_step
 from step import Step, group_steps, read_steps_from_job_dir
@@ -50,6 +51,36 @@ def test_group_steps_sorts_steps_within_each_group():
         "Test C",
         "Test D",
     ]
+
+
+def test_ci_control_metadata_is_typed_but_not_execution_configuration():
+    step = Step.from_yaml(
+        {
+            "label": "CPU models",
+            "key": "cpu-models",
+            "commands": ["pytest tests/models"],
+            "ci_control": {
+                "groups": ["cpu"],
+                "areas": ["models"],
+                "selectable": True,
+            },
+        }
+    )
+
+    assert step.ci_control is not None
+    assert step.ci_control.groups == ["cpu"]
+    assert step.ci_control.areas == ["models"]
+
+
+def test_ci_control_metadata_rejects_unknown_fields():
+    with pytest.raises(ValidationError, match="unknown"):
+        Step.from_yaml(
+            {
+                "label": "CPU models",
+                "commands": ["pytest tests/models"],
+                "ci_control": {"unknown": True},
+            }
+        )
 
 
 def test_continue_on_failure_exits_nonzero_after_command_failure(monkeypatch):

--- a/services/ci-control/.gitignore
+++ b/services/ci-control/.gitignore
@@ -1,0 +1,5 @@
+.pytest_cache/
+.ruff_cache/
+.venv/
+__pycache__/
+src/*.egg-info/

--- a/services/ci-control/README.md
+++ b/services/ci-control/README.md
@@ -1,0 +1,275 @@
+# vLLM `/ci` control plane
+
+This directory contains the provider-neutral control-plane code for vLLM CI.
+It is a separate package because it owns long-lived state and orchestration; it
+does not belong in vLLM's test definitions or in the Buildkite pipeline
+generator.
+
+The design has three independent responsibilities:
+
+1. **Control** — authorize, plan, account for, and dispatch requested work.
+2. **Evidence** — continuously reconcile canonical `main` and PR results.
+3. **Diagnosis** — compare one exact-HEAD PR run with one immutable `main`
+   snapshot.
+
+The first deployment should be a modular monolith with one transactional
+database. GitHub comments, issues, and dashboards are projections, never the
+database.
+
+This package currently implements the strict grammar, policy, catalog/compiler,
+planner, immutable credit transitions, provider adapters, evidence reduction,
+incident lifecycle, snapshot validation, and tests. It does **not** deploy a
+gateway or database. The ingestion, orchestration, and projection sections
+below are the deployment contract for the next slice; mutation commands stay
+disabled until that slice exists.
+
+## User API
+
+One exact command is accepted per PR comment. Unknown words fail parsing;
+unknown catalog selectors fail planning. Neither case dispatches work.
+
+### Read-only commands
+
+| Command | Result |
+| --- | --- |
+| `/ci help` | Syntax, selectors, and examples. |
+| `/ci status` | Current PR HEAD, latest runs, validation, `main` snapshot, and caller balance. |
+| `/ci status pr` | Failures for the exact current PR HEAD, classified against one `main` snapshot. |
+| `/ci status main` | Current failing, recovering, and recently resolved groups on canonical `main`. |
+| `/ci status refresh` | Queue evidence reconciliation without rerunning tests. |
+| `/ci status request:<id>` | Show one immutable request, provider operation, and cost. |
+| `/ci list groups` | Selectable groups, initially `upstream`, `amd`, and `cpu`. |
+| `/ci list areas` | Stable test-area names from the reviewed catalog. |
+| `/ci list jobs` | Stable job keys and their group/area membership. |
+| `/ci plan <selection>` | Exact jobs, dependency closure, and credit cost without dispatch. |
+| `/ci credits` | Available, reserved, granted, and spent credits for the caller. |
+
+### Compute commands
+
+| Command | Result |
+| --- | --- |
+| `/ci run <selection>` | Run the selected dependency-closed plan for the exact current PR HEAD. |
+| `/ci retry failures [<selection>]` | Retry each matching current failure once in its source-run lineage. |
+| `/ci credits add @user <amount> <reason>` | Append an audited credit grant. CI grant administrators only. |
+
+Examples:
+
+```text
+/ci run all
+/ci run groups:amd,cpu
+/ci run groups:upstream areas:attention,models
+/ci retry failures groups:amd
+/ci plan groups:cpu areas:models
+/ci status main groups:amd
+/ci credits add @alice 100 flaky AMD investigation
+```
+
+## Selectors
+
+A selection is one of:
+
+```text
+all
+groups:<group>[,<group>...]
+areas:<area>[,<area>...] [groups:<group>[,<group>...]]
+jobs:<stable-job-key>[,<stable-job-key>...]
+```
+
+Values in one field are ORed; different fields are ANDead. Overlap schedules a
+job once. `all` cannot be combined with another selector.
+
+Selectors resolve through a versioned catalog compiled from the protected
+vLLM default branch. Every selectable entry has a stable key, groups, area,
+execution variant, provider route, dependencies, shard count, and cost inputs.
+Labels, commands, arbitrary provider IDs, branches, and SHAs are not accepted
+as selectors.
+
+Renames require an alias. Deletions require a tombstone. The planner rejects
+unknown values, alias loops, key collisions, dependency cycles, incomplete
+dependency closure, and empty intersections. Credit reservation rejects an
+unaffordable complete plan. The validation action compiles both PR and base
+catalogs, so compatibility records are enforced for job and area selectors
+rather than merely documented.
+
+The `amd` group initially combines individually keyed mirrored jobs with one
+opaque `native-amd` lane. Area selection can target the mirrored jobs. The
+legacy native AMD Jinja source does not yet provide stable per-job identities,
+so its logical job/area always schedules the whole lane; selection of
+individual native jobs remains disabled until that source is migrated or
+explicitly keyed. A dedicated opaque-pipeline adapter checks the complete
+provider job count and retry lineages; the direct step-key adapter cannot
+silently consume this lane.
+
+## Authorization and credits
+
+Compute is fail-closed and limited to users whose live GitHub repository
+permission is `write`, `maintain`, or `admin`. Read-only status can remain
+public. Credit grants use a separately configurable, normally narrower
+permission set, and the recipient must independently satisfy the compute
+eligibility rule.
+
+Each eligible user is lazily initialized with **300 job credits**. One planned
+job or one retry costs one credit by default; policy may later assign reviewed
+resource weights. Dependency and shard jobs are included in the quoted cost.
+
+Credits use an append-only ledger:
+
+```text
+grant -> reserve whole plan -> dispatch -> settle actual work
+                                  \-> reject/confirmed failure -> refund
+                                  \-> unknown -> reconcile, never replay blindly
+```
+
+Balance checks and reservations are one transaction. A request either reserves
+its full plan or schedules nothing. Comment delivery ID is the idempotency key,
+so duplicate webhook delivery cannot spend twice.
+
+`retry.failures_limit` accepts a non-negative integer or `inf`. Unlimited retry depth
+does not mean unlimited compute: credits, exact-head checks, request caps, and
+provider eligibility still apply.
+
+## Main status and updates
+
+Buildkite remains the source of run facts. The service ingests through:
+
+- authenticated completion webhooks for low latency;
+- scheduled overlapping reconciliation for missed or reordered events; and
+- an explicit refresh request that queues the same reconciler.
+
+The ingestor always fetches authoritative build and job data, including retry
+lineage. One stable group on one distinct canonical `main` SHA becomes:
+
+| Outcome | Meaning |
+| --- | --- |
+| `clean` | Every current shard passed on its first attempt. |
+| `failed` | A current shard failed, timed out, expired, or soft-failed. |
+| `flaky` | A failure was followed by a passing retry/rebuild on the same SHA. |
+| `inconclusive` | Identity, shards, attempts, or a completed result are missing. |
+
+Absence from a selective run is no evidence. One SHA contributes at most once
+per canonical-main epoch; a retry or rebuild cannot satisfy a distinct-commit
+threshold. Force-pushed history starts a new epoch, and a changed executable
+definition starts a new incident identity, so counters cannot span either
+boundary.
+
+The default incident lifecycle is:
+
+```text
+first failing SHA       second failing SHA
+healthy ──────────────> candidate ──────────────> known
+                                                   │
+                                  first clean SHA  ▼
+                                               recovering 1/3
+                                                   │
+                                  third clean SHA  ▼
+                                                resolved
+```
+
+A failure while recovering returns the incident to `known`. A resolved
+incident requires the failure threshold again before reopening. Inconclusive,
+missing, stale, or partial evidence never confirms or resolves an incident.
+Thresholds are repository policy, not hard-coded state transitions.
+
+When a known failure starts passing, the next complete snapshot therefore
+shows `recovering`; after the clean threshold it shows `resolved`. The service
+retains the evidence and transition history.
+
+## PR validation
+
+Validation pins all reads to:
+
+- the PR's current full HEAD SHA;
+- compatible catalog schemas plus each job's execution-definition digest; and
+- one immutable `main` snapshot revision with per-lane watermarks.
+
+The snapshot retains bounded canonical history. If current `main` is newer
+than the PR base, a clean comparison uses the newest fresh compatible
+observation that is actually in the pinned base ancestry. An additive,
+unrelated catalog change therefore does not hide otherwise comparable jobs.
+
+Every current PR failure is placed in exactly one section:
+
+| Section | Required evidence |
+| --- | --- |
+| Known on `main` | Same compatible group and failure fingerprint are confirmed and currently failing. |
+| Candidate on `main` | Same compatible fingerprint is currently failing but below confirmation threshold. |
+| Seen flaky on `main` | Same fingerprint occurred in a complete retry lineage that eventually passed. |
+| Recovering on `main` | A matching confirmed incident has fresh clean evidence below its resolution threshold. |
+| Resolved on `main` | A matching incident reached its clean resolution threshold. |
+| Different failure on `main` | The compatible group is red, but normalized fingerprints differ. |
+| Group also red on `main` | The group is red, but no exact fingerprint comparison is available. |
+| Not matched on `main` | The same compatible group ran clean in fresh positive evidence from the PR base ancestry. |
+| Unable to classify | Missing key/run, incompatible catalog, stale/partial evidence, or lane absence. |
+
+“Not matched on `main`” means a **possible** PR regression, not proof that the
+PR caused it. Group-level matching also cannot prove that two different
+assertions are the same failure. Adapters accept structured test-result
+fingerprints when a lane produces them; otherwise validation says only that
+the group is also red.
+
+## Module boundaries
+
+```mermaid
+flowchart LR
+    GH[GitHub App] --> IN[Ingress]
+    IN --> CMD[Commands and policy]
+    CMD --> PLAN[Catalog and planner]
+    PLAN --> LEDGER[Credit ledger]
+    LEDGER --> EXEC[Execution coordinator]
+    EXEC --> BK[Buildkite write adapter]
+
+    BKREAD[Buildkite read adapter] --> OBS[Evidence normalizer]
+    OBS --> INC[Main incident reducer]
+    INC --> SNAP[Immutable snapshots]
+    OBS --> VAL[PR validation]
+    SNAP --> VAL
+    VAL --> VIEW[GitHub/status projections]
+```
+
+| Module | Owns |
+| --- | --- |
+| `commands` | Strict grammar and typed commands. |
+| `policy` | Versioned authorization, quota, retry, and evidence thresholds. |
+| `catalog` | Stable identities, selectors, aliases, tombstones, and dependency DAG. |
+| `credits` | Grants, reservations, settlement, refunds, and ledger invariants. |
+| `evidence` | Provider-neutral attempt and shard normalization. |
+| `incidents` | Pure replayable `main` lifecycle reduction. |
+| `validation` | Exact-HEAD comparison against one frozen snapshot. |
+| `ports` | Current catalog, credit CAS, permission, and team interfaces; execution/evidence storage ports are the next slice. |
+| `adapters` | Current GitHub, direct Buildkite, and opaque-lane Buildkite adapters; a transactional database adapter is next. |
+| `application` | Planned request idempotency and orchestration across those ports. |
+
+Only an owning module writes its tables. External mutations are recorded with
+a unique operation key before calling the provider. A timeout stays `unknown`
+until reconciliation proves whether work was accepted; it is never retried
+blindly.
+
+## Repository boundary
+
+`ci-infra` owns the service, schemas, compiler, provider adapters, storage,
+reconciliation, and deployment. `vllm` owns only:
+
+- protected default-branch policy values;
+- semantic group/area metadata and stable job keys;
+- existing Buildkite test commands and dependencies;
+- a SHA-pinned catalog validation workflow; and
+- concise contributor documentation.
+
+No Buildkite write token, credit balance, request state, incident state, or
+controller Python belongs in the vLLM repository.
+
+## Rollout
+
+The safe landing order is:
+
+1. package, policy/catalog validation, pure planner/ledger/reducer, and
+   read-only shadow status;
+2. transactional database, webhook receipts, provider-operation
+   reconciliation, and live main snapshots;
+3. credit grants and retry failures;
+4. selected fresh runs after the generated pipeline consumes a pinned plan;
+5. structured test fingerprints for test-level diagnosis.
+
+Mutation commands remain disabled until steps 1–2 are deployed. An ephemeral
+Actions file, cache, comment, or issue is not a safe implementation of the
+300-credit ledger.

--- a/services/ci-control/pyproject.toml
+++ b/services/ci-control/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vllm-ci-control"
+version = "0.1.0"
+description = "Domain foundation for the vLLM CI control plane"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+repository-validation = ["PyYAML>=6.0.2,<7"]
+
+[dependency-groups]
+dev = [
+  "click==8.1.7",
+  "pydantic==2.9.2",
+  "pytest>=8.3,<10",
+  "requests>=2.32,<3",
+  "ruff==0.14.0",
+]
+
+[project.scripts]
+vllm-ci-catalog = "vllm_ci_control.repository_catalog:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 88

--- a/services/ci-control/src/vllm_ci_control/__init__.py
+++ b/services/ci-control/src/vllm_ci_control/__init__.py
@@ -1,0 +1,3 @@
+"""Domain foundation for the vLLM CI control plane."""
+
+__version__ = "0.1.0"

--- a/services/ci-control/src/vllm_ci_control/adapters/__init__.py
+++ b/services/ci-control/src/vllm_ci_control/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""External provider adapters for the CI control plane."""

--- a/services/ci-control/src/vllm_ci_control/adapters/buildkite.py
+++ b/services/ci-control/src/vllm_ci_control/adapters/buildkite.py
@@ -1,0 +1,272 @@
+"""Buildkite REST adapter with bounded and authenticated pagination."""
+
+from __future__ import annotations
+
+import re
+import urllib.parse
+from collections.abc import Mapping, Sequence
+from typing import Any, Protocol
+
+from .http import JsonHttpTransport
+
+_SLUG = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{0,99}")
+_JOB_ID = re.compile(r"[A-Za-z0-9-]{1,100}")
+_API_ORIGIN = "https://api.buildkite.com"
+
+
+class JsonTransport(Protocol):
+    """Transport seam used by provider adapter tests."""
+
+    def request(
+        self,
+        url: str,
+        *,
+        method: str = "GET",
+        body: Mapping[str, Any] | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> Any:
+        """Perform one JSON request."""
+
+
+class BuildkiteProtocolError(RuntimeError):
+    """Buildkite returned a response that violates the expected schema."""
+
+
+class BuildkiteClient:
+    """Read authoritative jobs and perform explicitly planned mutations."""
+
+    def __init__(
+        self,
+        *,
+        token: str,
+        organization: str,
+        pipeline: str,
+        transport: JsonTransport | None = None,
+        max_pages: int = 100,
+    ) -> None:
+        if not token:
+            raise ValueError("Buildkite token must not be empty")
+        if _SLUG.fullmatch(organization) is None:
+            raise ValueError("invalid Buildkite organization slug")
+        if _SLUG.fullmatch(pipeline) is None:
+            raise ValueError("invalid Buildkite pipeline slug")
+        if max_pages < 1:
+            raise ValueError("max_pages must be positive")
+        self._organization = organization
+        self._pipeline = pipeline
+        self._transport = transport or JsonHttpTransport()
+        self._max_pages = max_pages
+        self._headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "vllm-ci-control",
+        }
+        organization_path = urllib.parse.quote(organization, safe="")
+        pipeline_path = urllib.parse.quote(pipeline, safe="")
+        self._base_path = (
+            f"/v2/organizations/{organization_path}/pipelines/{pipeline_path}/builds"
+        )
+
+    def list_builds(
+        self,
+        *,
+        branch: str | None = None,
+        commit: str | None = None,
+        states: Sequence[str] = (),
+        metadata: Mapping[str, str] | None = None,
+        exclude_jobs: bool = True,
+    ) -> tuple[dict[str, Any], ...]:
+        """List matching builds completely within the configured page bound."""
+
+        query: list[tuple[str, str]] = [
+            ("exclude_jobs", str(exclude_jobs).lower()),
+            ("exclude_pipeline", "true"),
+            ("per_page", "100"),
+        ]
+        if branch is not None:
+            query.append(("branch", branch))
+        if commit is not None:
+            query.append(("commit", commit))
+        for state in states:
+            query.append(("state[]", state))
+        for key, value in sorted((metadata or {}).items()):
+            query.append((f"meta_data[{key}]", value))
+
+        builds = []
+        for page in range(1, self._max_pages + 1):
+            response = self._request(
+                self._base_path,
+                query=[*query, ("page", str(page))],
+            )
+            if not isinstance(response, list) or not all(
+                isinstance(item, dict) for item in response
+            ):
+                raise BuildkiteProtocolError(
+                    "build list response must be an array of objects"
+                )
+            builds.extend(response)
+            if len(response) < 100:
+                return tuple(builds)
+        raise BuildkiteProtocolError(
+            "build pagination exceeded the configured page bound"
+        )
+
+    def get_build(
+        self,
+        build_number: int,
+        *,
+        include_retried_jobs: bool = True,
+    ) -> dict[str, Any]:
+        """Fetch one build with embedded jobs and explicit retry history."""
+
+        number = _positive_number(build_number, label="build number")
+        response = self._request(
+            f"{self._base_path}/{number}",
+            query=[
+                ("include_retried_jobs", str(include_retried_jobs).lower()),
+            ],
+        )
+        if not isinstance(response, dict):
+            raise BuildkiteProtocolError("build response must be an object")
+        return response
+
+    def list_jobs(
+        self,
+        build_number: int,
+        *,
+        include_retried_jobs: bool = True,
+        states: Sequence[str] = (),
+    ) -> tuple[dict[str, Any], ...]:
+        """Fetch every job using Buildkite's cursor endpoint.
+
+        The caller can treat a successful return as pagination-complete. A
+        malformed, cyclic, cross-origin, or overlong cursor chain fails closed.
+        """
+
+        number = _positive_number(build_number, label="build number")
+        query: list[tuple[str, str]] = [
+            ("include_retried_jobs", str(include_retried_jobs).lower()),
+            ("per_page", "100"),
+        ]
+        for state in states:
+            query.append(("state[]", state))
+        next_url = self._url(
+            f"{self._base_path}/{number}/jobs",
+            query=query,
+        )
+        seen_urls = set()
+        jobs = []
+
+        for _ in range(self._max_pages):
+            if next_url in seen_urls:
+                raise BuildkiteProtocolError("job pagination contains a cycle")
+            seen_urls.add(next_url)
+            _require_safe_cursor(next_url, self._base_path)
+            response = self._transport.request(
+                next_url,
+                headers=self._headers,
+            )
+            if not isinstance(response, Mapping):
+                raise BuildkiteProtocolError("job list response must be an object")
+            items = response.get("items")
+            links = response.get("links")
+            if not isinstance(items, list) or not all(
+                isinstance(item, dict) for item in items
+            ):
+                raise BuildkiteProtocolError(
+                    "job list items must be an array of objects"
+                )
+            if not isinstance(links, Mapping):
+                raise BuildkiteProtocolError("job list links must be an object")
+            jobs.extend(items)
+            candidate = links.get("next")
+            if candidate is None:
+                return tuple(jobs)
+            if not isinstance(candidate, str):
+                raise BuildkiteProtocolError(
+                    "job pagination next link must be a URL or null"
+                )
+            next_url = candidate
+        raise BuildkiteProtocolError(
+            "job pagination exceeded the configured page bound"
+        )
+
+    def create_build(
+        self,
+        payload: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Create a build from a server-derived, immutable plan payload."""
+
+        response = self._request(
+            self._base_path,
+            method="POST",
+            body=payload,
+        )
+        if not isinstance(response, dict):
+            raise BuildkiteProtocolError("create build response must be an object")
+        return response
+
+    def retry_job(
+        self,
+        *,
+        build_number: int,
+        job_id: str,
+    ) -> dict[str, Any]:
+        """Retry exactly one previously inspected job."""
+
+        number = _positive_number(build_number, label="build number")
+        if _JOB_ID.fullmatch(job_id) is None:
+            raise ValueError("invalid Buildkite job id")
+        job_path = urllib.parse.quote(job_id, safe="")
+        response = self._request(
+            f"{self._base_path}/{number}/jobs/{job_path}/retry",
+            method="PUT",
+            body={},
+        )
+        if not isinstance(response, dict):
+            raise BuildkiteProtocolError("retry job response must be an object")
+        return response
+
+    def _request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        body: Mapping[str, Any] | None = None,
+        query: Sequence[tuple[str, str]] = (),
+    ) -> Any:
+        return self._transport.request(
+            self._url(path, query=query),
+            method=method,
+            body=body,
+            headers=self._headers,
+        )
+
+    @staticmethod
+    def _url(
+        path: str,
+        *,
+        query: Sequence[tuple[str, str]] = (),
+    ) -> str:
+        url = f"{_API_ORIGIN}{path}"
+        if query:
+            url = f"{url}?{urllib.parse.urlencode(query)}"
+        return url
+
+
+def _positive_number(value: object, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{label} must be a positive integer")
+    return value
+
+
+def _require_safe_cursor(url: str, base_path: str) -> None:
+    parsed = urllib.parse.urlsplit(url)
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc != "api.buildkite.com"
+        or not parsed.path.startswith(f"{base_path}/")
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise BuildkiteProtocolError("Buildkite returned an unsafe pagination URL")

--- a/services/ci-control/src/vllm_ci_control/adapters/buildkite_evidence.py
+++ b/services/ci-control/src/vllm_ci_control/adapters/buildkite_evidence.py
@@ -1,0 +1,307 @@
+"""Translate complete Buildkite job pages into provider-neutral evidence."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from ..catalog import Catalog, ExecutionKind, JobDefinition
+from ..evidence import (
+    GroupExpectation,
+    GroupId,
+    JobAttempt,
+    ProviderReadAttestation,
+)
+from .buildkite import BuildkiteProtocolError
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedBuildkiteJobs:
+    """Typed input for the pure evidence normalizer."""
+
+    attempts: tuple[JobAttempt, ...]
+    expectations: tuple[GroupExpectation, ...]
+    read_attestation: ProviderReadAttestation
+
+
+def normalize_buildkite_jobs(
+    *,
+    catalog: Catalog,
+    pipeline: str,
+    expected_job_ids: Iterable[str],
+    jobs: Iterable[Mapping[str, Any]],
+    all_pages_fetched: bool,
+    retry_history_complete: bool,
+    fingerprints_by_job_id: Mapping[str, Iterable[str]] | None = None,
+) -> NormalizedBuildkiteJobs:
+    """Map one planned/observed job set without inferring absent execution.
+
+    ``expected_job_ids`` must come from the immutable build plan or trusted
+    provider metadata. It must never be reconstructed from whatever jobs happen
+    to be present in a selective build.
+    """
+
+    catalog_jobs = {job.job_id: job for job in catalog.jobs}
+    expected = tuple(sorted(set(expected_job_ids)))
+    if not expected:
+        raise ValueError("expected_job_ids must not be empty")
+
+    definitions = []
+    for job_id in expected:
+        try:
+            definition = catalog_jobs[job_id]
+        except KeyError as error:
+            raise ValueError(f"unknown expected catalog job: {job_id}") from error
+        if definition.pipeline != pipeline:
+            raise ValueError(
+                f"job {job_id!r} belongs to pipeline "
+                f"{definition.pipeline!r}, not {pipeline!r}"
+            )
+        if definition.execution_kind is not ExecutionKind.STEP:
+            raise ValueError(f"job {job_id!r} requires the opaque-pipeline normalizer")
+        definitions.append(definition)
+
+    expected_by_id = {item.job_id: item for item in definitions}
+    fingerprints = fingerprints_by_job_id or {}
+    attempts = []
+    for raw in jobs:
+        if raw.get("type", "script") != "script":
+            continue
+        step_key = raw.get("step_key")
+        if step_key not in expected_by_id:
+            continue
+        definition = expected_by_id[step_key]
+        shard = _shard(raw, definition)
+        job_id = _required_text(raw.get("id"), label="Buildkite job id")
+        attempts.append(
+            JobAttempt(
+                job_id=job_id,
+                group=_group_id(definition),
+                state=_state(raw),
+                shard=shard,
+                retried_in_job_id=_optional_text(
+                    raw.get("retried_in_job_id"),
+                    label="retried_in_job_id",
+                ),
+                retries_count=_retries_count(raw),
+                soft_failed=_boolean(
+                    raw.get("soft_failed", False),
+                    label="soft_failed",
+                ),
+                failure_fingerprints=frozenset(fingerprints.get(job_id, ())),
+            )
+        )
+
+    expectations = tuple(
+        GroupExpectation(
+            group=_group_id(definition),
+            shards=frozenset(str(index) for index in range(definition.shards)),
+            execution_profile=definition.execution_profile,
+            definition_digest=definition.definition_digest,
+        )
+        for definition in definitions
+    )
+    return NormalizedBuildkiteJobs(
+        attempts=tuple(attempts),
+        expectations=expectations,
+        read_attestation=ProviderReadAttestation(
+            all_pages_fetched=all_pages_fetched,
+            retry_history_complete=retry_history_complete,
+        ),
+    )
+
+
+def normalize_opaque_buildkite_lane(
+    *,
+    catalog: Catalog,
+    pipeline: str,
+    lane_job_id: str,
+    jobs: Iterable[Mapping[str, Any]],
+    all_pages_fetched: bool,
+    retry_history_complete: bool,
+    fingerprints_by_job_id: Mapping[str, Iterable[str]] | None = None,
+) -> NormalizedBuildkiteJobs:
+    """Aggregate one deliberately opaque whole-pipeline target.
+
+    Native AMD currently has no stable provider step keys. Its catalog entry
+    therefore records the expected number of executable units, and this
+    adapter maps complete retry lineages for the whole build into one logical
+    group. Direct step selection must use :func:`normalize_buildkite_jobs`.
+    """
+
+    definitions = {job.job_id: job for job in catalog.jobs}
+    try:
+        definition = definitions[lane_job_id]
+    except KeyError as error:
+        raise ValueError(f"unknown opaque lane job: {lane_job_id}") from error
+    if definition.pipeline != pipeline:
+        raise ValueError(
+            f"job {lane_job_id!r} belongs to pipeline "
+            f"{definition.pipeline!r}, not {pipeline!r}"
+        )
+    if definition.execution_kind is not ExecutionKind.OPAQUE_PIPELINE:
+        raise ValueError(f"job {lane_job_id!r} is not an opaque pipeline")
+
+    script_jobs = [raw for raw in jobs if raw.get("type", "script") == "script"]
+    raw_by_id: dict[str, Mapping[str, Any]] = {}
+    for raw in script_jobs:
+        job_id = _required_text(raw.get("id"), label="Buildkite job id")
+        if job_id in raw_by_id:
+            raise BuildkiteProtocolError("Buildkite job ids must be unique")
+        raw_by_id[job_id] = raw
+
+    predecessor_ids = {
+        job_id
+        for job_id, raw in raw_by_id.items()
+        if raw.get("retried_in_job_id") is not None
+    }
+    terminal_ids = sorted(set(raw_by_id) - predecessor_ids)
+    shard_by_terminal = {
+        job_id: str(index) for index, job_id in enumerate(terminal_ids)
+    }
+    fingerprints = fingerprints_by_job_id or {}
+    group = _group_id(definition)
+    attempts = []
+    for job_id, raw in raw_by_id.items():
+        terminal_id = _terminal_job_id(job_id, raw_by_id)
+        shard = shard_by_terminal.get(
+            terminal_id,
+            f"invalid:{job_id}",
+        )
+        attempts.append(
+            JobAttempt(
+                job_id=job_id,
+                group=group,
+                state=_state(raw),
+                shard=shard,
+                retried_in_job_id=_optional_text(
+                    raw.get("retried_in_job_id"),
+                    label="retried_in_job_id",
+                ),
+                retries_count=_retries_count(raw),
+                soft_failed=_boolean(
+                    raw.get("soft_failed", False),
+                    label="soft_failed",
+                ),
+                failure_fingerprints=frozenset(fingerprints.get(job_id, ())),
+            )
+        )
+
+    return NormalizedBuildkiteJobs(
+        attempts=tuple(attempts),
+        expectations=(
+            GroupExpectation(
+                group=group,
+                shards=frozenset(str(index) for index in range(definition.shards)),
+                execution_profile=definition.execution_profile,
+                definition_digest=definition.definition_digest,
+            ),
+        ),
+        read_attestation=ProviderReadAttestation(
+            all_pages_fetched=all_pages_fetched,
+            retry_history_complete=retry_history_complete,
+        ),
+    )
+
+
+def _group_id(definition: JobDefinition) -> GroupId:
+    return GroupId(
+        pipeline=definition.pipeline,
+        step_key=definition.job_id,
+        variant=definition.execution_profile,
+    )
+
+
+def _shard(raw: Mapping[str, Any], definition: JobDefinition) -> str:
+    index = raw.get("parallel_group_index")
+    total = raw.get("parallel_group_total")
+    if definition.shards == 1:
+        if index not in {None, 0} or total not in {None, 1}:
+            raise BuildkiteProtocolError(
+                f"job {definition.job_id!r} has unexpected shard metadata"
+            )
+        return "0"
+    if (
+        isinstance(index, bool)
+        or not isinstance(index, int)
+        or index < 0
+        or index >= definition.shards
+        or isinstance(total, bool)
+        or not isinstance(total, int)
+        or total != definition.shards
+    ):
+        raise BuildkiteProtocolError(
+            f"job {definition.job_id!r} shard metadata disagrees with catalog"
+        )
+    return str(index)
+
+
+def _state(raw: Mapping[str, Any]) -> str:
+    value = _required_text(raw.get("state"), label="job state")
+    if value != "finished":
+        return value
+    exit_status = raw.get("exit_status")
+    if exit_status == 0:
+        return "passed"
+    if isinstance(exit_status, int) and not isinstance(exit_status, bool):
+        return "failed"
+    return "unknown"
+
+
+def _required_text(value: Any, *, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise BuildkiteProtocolError(f"{label} must be non-empty text")
+    return value
+
+
+def _optional_text(value: Any, *, label: str) -> str | None:
+    if value is None:
+        return None
+    return _required_text(value, label=label)
+
+
+def _optional_non_negative_int(value: Any, *, label: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise BuildkiteProtocolError(f"{label} must be a non-negative integer or null")
+    return value
+
+
+def _retries_count(raw: Mapping[str, Any]) -> int | None:
+    """Normalize Buildkite's explicit null for an initial attempt to zero.
+
+    A missing field is different: without the provider's retry counter the
+    evidence reducer cannot prove that it received a complete lineage.
+    """
+
+    if "retries_count" not in raw:
+        return None
+    value = raw["retries_count"]
+    if value is None:
+        return 0
+    return _optional_non_negative_int(value, label="retries_count")
+
+
+def _terminal_job_id(
+    job_id: str,
+    raw_by_id: Mapping[str, Mapping[str, Any]],
+) -> str:
+    seen = set()
+    current = job_id
+    while current not in seen:
+        seen.add(current)
+        successor = raw_by_id[current].get("retried_in_job_id")
+        if successor is None:
+            return current
+        if not isinstance(successor, str) or successor not in raw_by_id:
+            return f"invalid:{job_id}"
+        current = successor
+    return f"invalid:{job_id}"
+
+
+def _boolean(value: Any, *, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise BuildkiteProtocolError(f"{label} must be boolean")
+    return value

--- a/services/ci-control/src/vllm_ci_control/adapters/github.py
+++ b/services/ci-control/src/vllm_ci_control/adapters/github.py
@@ -1,0 +1,216 @@
+"""Least-privilege GitHub REST adapter for repository and PR facts."""
+
+from __future__ import annotations
+
+import re
+import urllib.parse
+from collections.abc import Mapping
+from typing import Any
+
+from ..models import RepositoryPermission
+from .buildkite import JsonTransport
+from .http import HttpError, JsonHttpTransport
+
+_OWNER_OR_REPO = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,99}")
+_LOGIN = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})")
+_TEAM_SLUG = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,99})")
+_API_ORIGIN = "https://api.github.com"
+
+
+class GitHubProtocolError(RuntimeError):
+    """GitHub returned a response that violates the expected schema."""
+
+
+class GitHubClient:
+    """Fetch live authorization/PR state and update bot-owned projections."""
+
+    def __init__(
+        self,
+        *,
+        token: str,
+        repository: str,
+        transport: JsonTransport | None = None,
+        max_pages: int = 100,
+    ) -> None:
+        if not token:
+            raise ValueError("GitHub token must not be empty")
+        parts = repository.split("/")
+        if len(parts) != 2 or any(
+            _OWNER_OR_REPO.fullmatch(part) is None for part in parts
+        ):
+            raise ValueError("repository must be a normalized owner/name")
+        if max_pages < 1:
+            raise ValueError("max_pages must be positive")
+        self._owner, self._repo = parts
+        self._transport = transport or JsonHttpTransport()
+        self._max_pages = max_pages
+        self._headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "vllm-ci-control",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        owner_path = urllib.parse.quote(self._owner, safe="")
+        repo_path = urllib.parse.quote(self._repo, safe="")
+        self._base_path = f"/repos/{owner_path}/{repo_path}"
+
+    def get_pull_request(self, number: int) -> dict[str, Any]:
+        """Return the authoritative current PR object."""
+
+        response = self._request(f"{self._base_path}/pulls/{_positive_number(number)}")
+        if not isinstance(response, dict):
+            raise GitHubProtocolError("pull request response must be an object")
+        return response
+
+    def repository_permission(self, username: str) -> RepositoryPermission:
+        """Return the caller's live base repository permission."""
+
+        if _LOGIN.fullmatch(username) is None:
+            raise ValueError("invalid GitHub login")
+        login_path = urllib.parse.quote(username, safe="")
+        try:
+            response = self._request(
+                f"{self._base_path}/collaborators/{login_path}/permission"
+            )
+        except HttpError as error:
+            if error.status == 404:
+                return RepositoryPermission.NONE
+            raise
+        if not isinstance(response, Mapping):
+            raise GitHubProtocolError("permission response must be an object")
+        for value in (response.get("role_name"), response.get("permission")):
+            try:
+                return RepositoryPermission(value)
+            except ValueError:
+                continue
+        raise GitHubProtocolError("GitHub returned an unknown repository permission")
+
+    def is_team_member(
+        self,
+        team_slug: str,
+        username: str,
+    ) -> bool:
+        """Return active membership in one team owned by the repository org."""
+
+        if _TEAM_SLUG.fullmatch(team_slug) is None:
+            raise ValueError("invalid GitHub team slug")
+        if _LOGIN.fullmatch(username) is None:
+            raise ValueError("invalid GitHub login")
+        owner_path = urllib.parse.quote(self._owner, safe="")
+        team_path = urllib.parse.quote(team_slug, safe="")
+        login_path = urllib.parse.quote(username, safe="")
+        try:
+            response = self._request(
+                f"/orgs/{owner_path}/teams/{team_path}/memberships/{login_path}"
+            )
+        except HttpError as error:
+            if error.status == 404:
+                return False
+            raise
+        if not isinstance(response, Mapping):
+            raise GitHubProtocolError("team membership response must be an object")
+        state = response.get("state")
+        if state not in {"active", "pending"}:
+            raise GitHubProtocolError(
+                "GitHub returned an unknown team membership state"
+            )
+        return state == "active"
+
+    def list_comment_reactions(
+        self,
+        comment_id: int,
+    ) -> tuple[dict[str, Any], ...]:
+        """List all reactions so comment delivery can be deduplicated."""
+
+        return self._paginate(
+            f"{self._base_path}/issues/comments/"
+            f"{_positive_number(comment_id)}/reactions"
+        )
+
+    def add_comment(self, issue_number: int, body: str) -> dict[str, Any]:
+        """Create a user-facing projection comment."""
+
+        if not body or len(body) > 65_536:
+            raise ValueError("comment body must be non-empty and bounded")
+        response = self._request(
+            f"{self._base_path}/issues/{_positive_number(issue_number)}/comments",
+            method="POST",
+            body={"body": body},
+        )
+        if not isinstance(response, dict):
+            raise GitHubProtocolError("comment response must be an object")
+        return response
+
+    def add_reaction(
+        self,
+        comment_id: int,
+        content: str,
+    ) -> dict[str, Any]:
+        """Add a bounded command receipt/result reaction."""
+
+        allowed = {
+            "+1",
+            "-1",
+            "laugh",
+            "confused",
+            "heart",
+            "hooray",
+            "rocket",
+            "eyes",
+        }
+        if content not in allowed:
+            raise ValueError("unsupported GitHub reaction")
+        response = self._request(
+            f"{self._base_path}/issues/comments/"
+            f"{_positive_number(comment_id)}/reactions",
+            method="POST",
+            body={"content": content},
+        )
+        if not isinstance(response, dict):
+            raise GitHubProtocolError("reaction response must be an object")
+        return response
+
+    def _paginate(self, path: str) -> tuple[dict[str, Any], ...]:
+        items = []
+        for page in range(1, self._max_pages + 1):
+            response = self._request(
+                path,
+                query=[("per_page", "100"), ("page", str(page))],
+            )
+            if not isinstance(response, list) or not all(
+                isinstance(item, dict) for item in response
+            ):
+                raise GitHubProtocolError(
+                    "paginated response must be an array of objects"
+                )
+            items.extend(response)
+            if len(response) < 100:
+                return tuple(items)
+        raise GitHubProtocolError(
+            "GitHub pagination exceeded the configured page bound"
+        )
+
+    def _request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        body: Mapping[str, Any] | None = None,
+        query: list[tuple[str, str]] | None = None,
+    ) -> Any:
+        url = f"{_API_ORIGIN}{path}"
+        if query:
+            url = f"{url}?{urllib.parse.urlencode(query)}"
+        return self._transport.request(
+            url,
+            method=method,
+            body=body,
+            headers=self._headers,
+        )
+
+
+def _positive_number(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError("GitHub numeric id must be a positive integer")
+    return value

--- a/services/ci-control/src/vllm_ci_control/adapters/http.py
+++ b/services/ci-control/src/vllm_ci_control/adapters/http.py
@@ -1,0 +1,82 @@
+"""Small JSON HTTP transport shared by provider adapters."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class HttpError(RuntimeError):
+    """A remote API returned an error or an invalid response."""
+
+    status: int | None
+    message: str
+
+    def __str__(self) -> str:
+        prefix = f"HTTP {self.status}" if self.status is not None else "HTTP"
+        return f"{prefix}: {self.message}"
+
+
+class JsonHttpTransport:
+    """Perform bounded JSON requests using only the Python standard library."""
+
+    def __init__(self, *, timeout_seconds: float = 30) -> None:
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._timeout_seconds = timeout_seconds
+
+    def request(
+        self,
+        url: str,
+        *,
+        method: str = "GET",
+        body: Mapping[str, Any] | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> Any:
+        """Return a decoded JSON response, or ``None`` for an empty body."""
+
+        encoded = None
+        if body is not None:
+            encoded = json.dumps(body, separators=(",", ":")).encode()
+        request = urllib.request.Request(
+            url,
+            data=encoded,
+            headers=dict(headers or {}),
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(
+                request,
+                timeout=self._timeout_seconds,
+            ) as response:
+                response_body = response.read()
+        except urllib.error.HTTPError as error:
+            response_body = error.read()
+            raise HttpError(
+                error.code,
+                _error_message(response_body, str(error.reason)),
+            ) from error
+        except urllib.error.URLError as error:
+            raise HttpError(None, str(error.reason)) from error
+
+        if not response_body:
+            return None
+        try:
+            return json.loads(response_body)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise HttpError(None, "remote API returned invalid JSON") from error
+
+
+def _error_message(response_body: bytes, fallback: str) -> str:
+    try:
+        payload = json.loads(response_body)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return fallback
+    if isinstance(payload, Mapping) and isinstance(payload.get("message"), str):
+        return payload["message"]
+    return fallback

--- a/services/ci-control/src/vllm_ci_control/catalog.py
+++ b/services/ci-control/src/vllm_ci_control/catalog.py
@@ -1,0 +1,748 @@
+"""Versioned CI catalog validation, selection, and deterministic planning."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+
+from .models import Selector, stable_id_set, validate_stable_id
+
+_DIGEST = re.compile(r"[0-9a-f]{64}")
+
+
+class CatalogError(ValueError):
+    """Base error for an invalid catalog or selection."""
+
+
+class CatalogValidationError(CatalogError):
+    """The trusted catalog is internally inconsistent."""
+
+
+class UnknownSelectorError(CatalogError):
+    """A selector names an unknown group, area, or job."""
+
+
+class RetiredJobError(CatalogError):
+    """A selector names a tombstoned job."""
+
+
+class RetiredAreaError(CatalogError):
+    """A selector names a tombstoned area."""
+
+
+class EmptySelectionError(CatalogError):
+    """Valid selector dimensions have an empty intersection."""
+
+
+class NonSelectableJobError(CatalogError):
+    """A selector directly names an internal dependency job."""
+
+
+class ExecutionKind(StrEnum):
+    """How one logical catalog target maps to provider execution."""
+
+    STEP = "step"
+    OPAQUE_PIPELINE = "opaque_pipeline"
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class JobDefinition:
+    """One executable, billable catalog job."""
+
+    job_id: str
+    groups: frozenset[str]
+    areas: frozenset[str]
+    definition_digest: str
+    dependencies: tuple[str, ...] = ()
+    pipeline: str = "ci"
+    execution_profile: str = "default"
+    execution_kind: ExecutionKind = ExecutionKind.STEP
+    shards: int = 1
+    cost: int = 1
+    selectable: bool = True
+
+    def __post_init__(self) -> None:
+        validate_stable_id(self.job_id, label="job id")
+        validate_stable_id(self.pipeline, label="pipeline")
+        validate_stable_id(
+            self.execution_profile,
+            label="execution profile",
+        )
+        try:
+            execution_kind = ExecutionKind(self.execution_kind)
+        except ValueError as error:
+            raise CatalogValidationError("unknown execution kind") from error
+        groups = stable_id_set(self.groups, label="group")
+        areas = stable_id_set(self.areas, label="area")
+        if not groups:
+            raise CatalogValidationError(f"job {self.job_id!r} must belong to a group")
+        if not areas:
+            raise CatalogValidationError(f"job {self.job_id!r} must belong to an area")
+        dependencies = tuple(self.dependencies)
+        if len(dependencies) != len(set(dependencies)):
+            raise CatalogValidationError(
+                f"job {self.job_id!r} has duplicate dependencies"
+            )
+        for dependency in dependencies:
+            validate_stable_id(dependency, label="dependency")
+        if (
+            isinstance(self.shards, bool)
+            or not isinstance(self.shards, int)
+            or self.shards < 1
+        ):
+            raise CatalogValidationError("job shards must be a positive integer")
+        if (
+            isinstance(self.cost, bool)
+            or not isinstance(self.cost, int)
+            or self.cost < 1
+        ):
+            raise CatalogValidationError("job cost must be a positive integer")
+        if not isinstance(self.selectable, bool):
+            raise CatalogValidationError("job selectable must be boolean")
+        if _DIGEST.fullmatch(self.definition_digest) is None:
+            raise CatalogValidationError(
+                "job definition_digest must be a lowercase SHA-256 digest"
+            )
+        object.__setattr__(self, "groups", groups)
+        object.__setattr__(self, "areas", areas)
+        object.__setattr__(self, "execution_kind", execution_kind)
+        object.__setattr__(
+            self,
+            "dependencies",
+            tuple(sorted(dependencies)),
+        )
+
+    @property
+    def total_cost(self) -> int:
+        """Return the maximum planned cost across every parallel shard."""
+
+        return self.shards * self.cost
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class JobAlias:
+    """A historical selector name mapped directly to one active job."""
+
+    alias: str
+    target: str
+
+    def __post_init__(self) -> None:
+        validate_stable_id(self.alias, label="job alias")
+        validate_stable_id(self.target, label="alias target")
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class JobTombstone:
+    """A retired job identifier that must never be silently reused."""
+
+    job_id: str
+    reason: str
+    replacement: str | None = None
+
+    def __post_init__(self) -> None:
+        validate_stable_id(self.job_id, label="tombstoned job id")
+        if (
+            not self.reason
+            or self.reason.strip() != self.reason
+            or len(self.reason) > 240
+        ):
+            raise CatalogValidationError(
+                "tombstone reason must be normalized non-empty text"
+            )
+        if self.replacement is not None:
+            validate_stable_id(
+                self.replacement,
+                label="tombstone replacement",
+            )
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class AreaAlias:
+    """A historical area selector mapped to one current area."""
+
+    alias: str
+    target: str
+
+    def __post_init__(self) -> None:
+        validate_stable_id(self.alias, label="area alias")
+        validate_stable_id(self.target, label="area alias target")
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class AreaTombstone:
+    """A retired area identifier that cannot be silently reused."""
+
+    area_id: str
+    reason: str
+    replacement: str | None = None
+
+    def __post_init__(self) -> None:
+        validate_stable_id(self.area_id, label="tombstoned area id")
+        if (
+            not self.reason
+            or self.reason.strip() != self.reason
+            or len(self.reason) > 240
+        ):
+            raise CatalogValidationError(
+                "area tombstone reason must be normalized non-empty text"
+            )
+        if self.replacement is not None:
+            validate_stable_id(
+                self.replacement,
+                label="area tombstone replacement",
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class SelectionPlan:
+    """A selector result plus its complete prerequisite closure."""
+
+    catalog_version: str
+    catalog_digest: str
+    requested_jobs: tuple[str, ...]
+    jobs: tuple[str, ...]
+    dependency_jobs: tuple[str, ...]
+    total_cost: int
+
+
+@dataclass(frozen=True, slots=True)
+class Catalog:
+    """An immutable, validated catalog revision."""
+
+    version: str
+    jobs: tuple[JobDefinition, ...]
+    aliases: tuple[JobAlias, ...] = ()
+    tombstones: tuple[JobTombstone, ...] = ()
+    area_aliases: tuple[AreaAlias, ...] = ()
+    area_tombstones: tuple[AreaTombstone, ...] = ()
+
+    def __post_init__(self) -> None:
+        validate_stable_id(self.version, label="catalog version")
+        object.__setattr__(
+            self,
+            "jobs",
+            tuple(sorted(self.jobs, key=lambda job: job.job_id)),
+        )
+        object.__setattr__(
+            self,
+            "aliases",
+            tuple(sorted(self.aliases, key=lambda alias: alias.alias)),
+        )
+        object.__setattr__(
+            self,
+            "tombstones",
+            tuple(
+                sorted(
+                    self.tombstones,
+                    key=lambda tombstone: tombstone.job_id,
+                )
+            ),
+        )
+        object.__setattr__(
+            self,
+            "area_aliases",
+            tuple(sorted(self.area_aliases, key=lambda alias: alias.alias)),
+        )
+        object.__setattr__(
+            self,
+            "area_tombstones",
+            tuple(
+                sorted(
+                    self.area_tombstones,
+                    key=lambda tombstone: tombstone.area_id,
+                )
+            ),
+        )
+        self._validate()
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> Catalog:
+        """Load a catalog from a strict JSON-compatible mapping."""
+
+        _require_exact_keys(
+            value,
+            required={"version", "jobs"},
+            optional={
+                "aliases",
+                "tombstones",
+                "area_aliases",
+                "area_tombstones",
+            },
+            label="catalog",
+        )
+        raw_jobs = value["jobs"]
+        raw_aliases = value.get("aliases", [])
+        raw_tombstones = value.get("tombstones", [])
+        raw_area_aliases = value.get("area_aliases", [])
+        raw_area_tombstones = value.get("area_tombstones", [])
+        if not isinstance(raw_jobs, list):
+            raise CatalogValidationError("catalog jobs must be a list")
+        if not isinstance(raw_aliases, list):
+            raise CatalogValidationError("catalog aliases must be a list")
+        if not isinstance(raw_tombstones, list):
+            raise CatalogValidationError("catalog tombstones must be a list")
+        if not isinstance(raw_area_aliases, list):
+            raise CatalogValidationError("catalog area_aliases must be a list")
+        if not isinstance(raw_area_tombstones, list):
+            raise CatalogValidationError("catalog area_tombstones must be a list")
+
+        jobs = tuple(_job_from_mapping(item) for item in raw_jobs)
+        aliases = tuple(_alias_from_mapping(item) for item in raw_aliases)
+        tombstones = tuple(_tombstone_from_mapping(item) for item in raw_tombstones)
+        area_aliases = tuple(
+            _area_alias_from_mapping(item) for item in raw_area_aliases
+        )
+        area_tombstones = tuple(
+            _area_tombstone_from_mapping(item) for item in raw_area_tombstones
+        )
+        return cls(
+            version=value["version"],  # type: ignore[arg-type]
+            jobs=jobs,
+            aliases=aliases,
+            tombstones=tombstones,
+            area_aliases=area_aliases,
+            area_tombstones=area_tombstones,
+        )
+
+    @property
+    def digest(self) -> str:
+        """Return a deterministic digest of the validated catalog."""
+
+        encoded = json.dumps(
+            self.to_mapping(),
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+        return hashlib.sha256(encoded).hexdigest()
+
+    def to_mapping(self) -> dict[str, object]:
+        """Return the canonical JSON-compatible catalog representation."""
+
+        return {
+            "version": self.version,
+            "jobs": [
+                {
+                    "id": job.job_id,
+                    "groups": sorted(job.groups),
+                    "areas": sorted(job.areas),
+                    "dependencies": list(job.dependencies),
+                    "pipeline": job.pipeline,
+                    "execution_profile": job.execution_profile,
+                    "execution_kind": job.execution_kind.value,
+                    "shards": job.shards,
+                    "cost": job.cost,
+                    "selectable": job.selectable,
+                    "definition_digest": job.definition_digest,
+                }
+                for job in self.jobs
+            ],
+            "aliases": [
+                {"alias": alias.alias, "target": alias.target} for alias in self.aliases
+            ],
+            "tombstones": [
+                {
+                    "id": tombstone.job_id,
+                    "reason": tombstone.reason,
+                    "replacement": tombstone.replacement,
+                }
+                for tombstone in self.tombstones
+            ],
+            "area_aliases": [
+                {"alias": alias.alias, "target": alias.target}
+                for alias in self.area_aliases
+            ],
+            "area_tombstones": [
+                {
+                    "id": tombstone.area_id,
+                    "reason": tombstone.reason,
+                    "replacement": tombstone.replacement,
+                }
+                for tombstone in self.area_tombstones
+            ],
+        }
+
+    @property
+    def group_ids(self) -> tuple[str, ...]:
+        return tuple(sorted({group for job in self.jobs for group in job.groups}))
+
+    @property
+    def area_ids(self) -> tuple[str, ...]:
+        return tuple(
+            sorted({area for job in self.jobs if job.selectable for area in job.areas})
+        )
+
+    @property
+    def job_ids(self) -> tuple[str, ...]:
+        return tuple(job.job_id for job in self.jobs)
+
+    def resolve_job_id(self, value: str) -> str:
+        """Resolve one canonical or historical job selector."""
+
+        validate_stable_id(value, label="job selector")
+        jobs = self._jobs_by_id()
+        if value in jobs:
+            return value
+        aliases = {item.alias: item.target for item in self.aliases}
+        if value in aliases:
+            return aliases[value]
+        tombstones = {item.job_id: item for item in self.tombstones}
+        if value in tombstones:
+            record = tombstones[value]
+            suggestion = (
+                f"; suggested replacement: {record.replacement}"
+                if record.replacement
+                else ""
+            )
+            raise RetiredJobError(
+                f"job {value!r} is retired: {record.reason}{suggestion}"
+            )
+        raise UnknownSelectorError(f"unknown job selector: {value}")
+
+    def resolve_area_id(self, value: str) -> str:
+        """Resolve one canonical or historical area selector."""
+
+        validate_stable_id(value, label="area selector")
+        if value in self.area_ids:
+            return value
+        aliases = {item.alias: item.target for item in self.area_aliases}
+        if value in aliases:
+            return aliases[value]
+        tombstones = {item.area_id: item for item in self.area_tombstones}
+        if value in tombstones:
+            record = tombstones[value]
+            suggestion = (
+                f"; suggested replacement: {record.replacement}"
+                if record.replacement
+                else ""
+            )
+            raise RetiredAreaError(
+                f"area {value!r} is retired: {record.reason}{suggestion}"
+            )
+        raise UnknownSelectorError(f"unknown area selector: {value}")
+
+    def plan(self, selector: Selector) -> SelectionPlan:
+        """Resolve selectors, dependencies, topological order, and cost."""
+
+        jobs = self._jobs_by_id()
+        if selector.all_jobs:
+            requested = {job.job_id for job in self.jobs if job.selectable}
+        else:
+            requested = {job.job_id for job in self.jobs if job.selectable}
+            if selector.groups:
+                unknown = selector.groups - set(self.group_ids)
+                if unknown:
+                    raise UnknownSelectorError(
+                        "unknown groups: " + ", ".join(sorted(unknown))
+                    )
+                requested &= {
+                    job.job_id for job in self.jobs if job.groups & selector.groups
+                }
+            if selector.areas:
+                selected_areas = {
+                    self.resolve_area_id(value) for value in selector.areas
+                }
+                requested &= {
+                    job.job_id for job in self.jobs if job.areas & selected_areas
+                }
+            if selector.jobs:
+                selected_jobs = {self.resolve_job_id(value) for value in selector.jobs}
+                non_selectable = {
+                    job_id for job_id in selected_jobs if not jobs[job_id].selectable
+                }
+                if non_selectable:
+                    raise NonSelectableJobError(
+                        "jobs are internal dependencies: "
+                        + ", ".join(sorted(non_selectable))
+                    )
+                requested &= selected_jobs
+
+        if not requested:
+            raise EmptySelectionError("selector dimensions match no common jobs")
+        ordered = self._dependency_closure(requested)
+        dependency_jobs = tuple(job_id for job_id in ordered if job_id not in requested)
+        return SelectionPlan(
+            catalog_version=self.version,
+            catalog_digest=self.digest,
+            requested_jobs=tuple(sorted(requested)),
+            jobs=ordered,
+            dependency_jobs=dependency_jobs,
+            total_cost=sum(jobs[job_id].total_cost for job_id in ordered),
+        )
+
+    def _jobs_by_id(self) -> dict[str, JobDefinition]:
+        return {job.job_id: job for job in self.jobs}
+
+    def _validate(self) -> None:
+        if not self.jobs:
+            raise CatalogValidationError("catalog must contain at least one job")
+        jobs = self._jobs_by_id()
+        if len(jobs) != len(self.jobs):
+            raise CatalogValidationError("catalog job ids must be unique")
+
+        aliases = {item.alias: item.target for item in self.aliases}
+        if len(aliases) != len(self.aliases):
+            raise CatalogValidationError("catalog aliases must be unique")
+        tombstones = {item.job_id: item for item in self.tombstones}
+        if len(tombstones) != len(self.tombstones):
+            raise CatalogValidationError("catalog tombstones must be unique")
+
+        namespaces = [set(jobs), set(aliases), set(tombstones)]
+        if any(
+            namespaces[left] & namespaces[right]
+            for left in range(len(namespaces))
+            for right in range(left + 1, len(namespaces))
+        ):
+            raise CatalogValidationError(
+                "job ids, aliases, and tombstones share one namespace"
+            )
+        for alias, target in aliases.items():
+            if target not in jobs:
+                raise CatalogValidationError(
+                    f"alias {alias!r} must target a canonical active job"
+                )
+        for tombstone in self.tombstones:
+            if tombstone.replacement is not None and tombstone.replacement not in jobs:
+                raise CatalogValidationError(
+                    f"tombstone {tombstone.job_id!r} replacement is not active"
+                )
+
+        active_areas = set(self.area_ids)
+        area_aliases = {item.alias: item.target for item in self.area_aliases}
+        if len(area_aliases) != len(self.area_aliases):
+            raise CatalogValidationError("catalog area aliases must be unique")
+        area_tombstones = {item.area_id: item for item in self.area_tombstones}
+        if len(area_tombstones) != len(self.area_tombstones):
+            raise CatalogValidationError("catalog area tombstones must be unique")
+        area_namespaces = [
+            active_areas,
+            set(area_aliases),
+            set(area_tombstones),
+        ]
+        if any(
+            area_namespaces[left] & area_namespaces[right]
+            for left in range(len(area_namespaces))
+            for right in range(left + 1, len(area_namespaces))
+        ):
+            raise CatalogValidationError(
+                "area ids, aliases, and tombstones share one namespace"
+            )
+        for alias, target in area_aliases.items():
+            if target not in active_areas:
+                raise CatalogValidationError(
+                    f"area alias {alias!r} must target an active area"
+                )
+        for tombstone in self.area_tombstones:
+            if (
+                tombstone.replacement is not None
+                and tombstone.replacement not in active_areas
+            ):
+                raise CatalogValidationError(
+                    f"area tombstone {tombstone.area_id!r} replacement is not active"
+                )
+        for job in self.jobs:
+            for dependency in job.dependencies:
+                if dependency not in jobs:
+                    raise CatalogValidationError(
+                        f"job {job.job_id!r} has unknown dependency {dependency!r}"
+                    )
+                if dependency == job.job_id:
+                    raise CatalogValidationError(
+                        f"job {job.job_id!r} cannot depend on itself"
+                    )
+        self._dependency_closure(set(jobs))
+
+    def _dependency_closure(
+        self,
+        requested: set[str],
+    ) -> tuple[str, ...]:
+        jobs = self._jobs_by_id()
+        ordered: list[str] = []
+        permanent: set[str] = set()
+        temporary: set[str] = set()
+
+        def visit(job_id: str) -> None:
+            if job_id in permanent:
+                return
+            if job_id in temporary:
+                raise CatalogValidationError(
+                    f"dependency graph contains a cycle at {job_id!r}"
+                )
+            temporary.add(job_id)
+            for dependency in jobs[job_id].dependencies:
+                visit(dependency)
+            temporary.remove(job_id)
+            permanent.add(job_id)
+            ordered.append(job_id)
+
+        for job_id in sorted(requested):
+            visit(job_id)
+        return tuple(ordered)
+
+
+def validate_catalog_evolution(previous: Catalog, current: Catalog) -> None:
+    """Require deliberate compatibility records for removed public selectors."""
+
+    errors = []
+    current_jobs = set(current.job_ids)
+    current_job_aliases = {item.alias for item in current.aliases}
+    current_job_tombstones = {item.job_id for item in current.tombstones}
+    for job_id in sorted(
+        (set(previous.job_ids) | {item.alias for item in previous.aliases})
+        - current_jobs
+        - current_job_aliases
+        - current_job_tombstones
+    ):
+        errors.append(f"removed job selector {job_id!r} requires an alias or tombstone")
+    for tombstone in previous.tombstones:
+        if tombstone.job_id not in current_job_tombstones:
+            errors.append(
+                f"retired job selector {tombstone.job_id!r} must remain tombstoned"
+            )
+
+    current_areas = set(current.area_ids)
+    current_area_aliases = {item.alias for item in current.area_aliases}
+    current_area_tombstones = {item.area_id for item in current.area_tombstones}
+    for area_id in sorted(
+        (set(previous.area_ids) | {item.alias for item in previous.area_aliases})
+        - current_areas
+        - current_area_aliases
+        - current_area_tombstones
+    ):
+        errors.append(
+            f"removed area selector {area_id!r} requires an alias or tombstone"
+        )
+    for tombstone in previous.area_tombstones:
+        if tombstone.area_id not in current_area_tombstones:
+            errors.append(
+                f"retired area selector {tombstone.area_id!r} must remain tombstoned"
+            )
+
+    if errors:
+        raise CatalogValidationError("; ".join(errors))
+
+
+def _require_exact_keys(
+    value: object,
+    *,
+    required: set[str],
+    optional: set[str] = frozenset(),
+    label: str,
+) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise CatalogValidationError(f"{label} must be an object")
+    keys = set(value)
+    missing = required - keys
+    unknown = keys - required - optional
+    if missing:
+        raise CatalogValidationError(
+            f"{label} is missing fields: " + ", ".join(sorted(missing))
+        )
+    if unknown:
+        raise CatalogValidationError(
+            f"{label} has unknown fields: " + ", ".join(sorted(unknown))
+        )
+    return value
+
+
+def _string_list(value: object, *, label: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise CatalogValidationError(f"{label} must be a list of strings")
+    return value
+
+
+def _job_from_mapping(value: object) -> JobDefinition:
+    item = _require_exact_keys(
+        value,
+        required={"id", "groups", "areas", "definition_digest"},
+        optional={
+            "dependencies",
+            "pipeline",
+            "execution_profile",
+            "execution_kind",
+            "shards",
+            "cost",
+            "selectable",
+        },
+        label="job",
+    )
+    return JobDefinition(
+        job_id=item["id"],  # type: ignore[arg-type]
+        groups=frozenset(_string_list(item["groups"], label="job groups")),
+        areas=frozenset(_string_list(item["areas"], label="job areas")),
+        dependencies=tuple(
+            _string_list(
+                item.get("dependencies", []),
+                label="job dependencies",
+            )
+        ),
+        pipeline=item.get("pipeline", "ci"),  # type: ignore[arg-type]
+        execution_profile=item.get(
+            "execution_profile",
+            "default",
+        ),  # type: ignore[arg-type]
+        execution_kind=item.get(
+            "execution_kind",
+            ExecutionKind.STEP,
+        ),  # type: ignore[arg-type]
+        shards=item.get("shards", 1),  # type: ignore[arg-type]
+        cost=item.get("cost", 1),  # type: ignore[arg-type]
+        selectable=item.get("selectable", True),  # type: ignore[arg-type]
+        definition_digest=item["definition_digest"],  # type: ignore[arg-type]
+    )
+
+
+def _alias_from_mapping(value: object) -> JobAlias:
+    item = _require_exact_keys(
+        value,
+        required={"alias", "target"},
+        label="alias",
+    )
+    return JobAlias(
+        alias=item["alias"],  # type: ignore[arg-type]
+        target=item["target"],  # type: ignore[arg-type]
+    )
+
+
+def _tombstone_from_mapping(value: object) -> JobTombstone:
+    item = _require_exact_keys(
+        value,
+        required={"id", "reason"},
+        optional={"replacement"},
+        label="tombstone",
+    )
+    return JobTombstone(
+        job_id=item["id"],  # type: ignore[arg-type]
+        reason=item["reason"],  # type: ignore[arg-type]
+        replacement=item.get("replacement"),  # type: ignore[arg-type]
+    )
+
+
+def _area_alias_from_mapping(value: object) -> AreaAlias:
+    item = _require_exact_keys(
+        value,
+        required={"alias", "target"},
+        label="area alias",
+    )
+    return AreaAlias(
+        alias=item["alias"],  # type: ignore[arg-type]
+        target=item["target"],  # type: ignore[arg-type]
+    )
+
+
+def _area_tombstone_from_mapping(value: object) -> AreaTombstone:
+    item = _require_exact_keys(
+        value,
+        required={"id", "reason"},
+        optional={"replacement"},
+        label="area tombstone",
+    )
+    return AreaTombstone(
+        area_id=item["id"],  # type: ignore[arg-type]
+        reason=item["reason"],  # type: ignore[arg-type]
+        replacement=item.get("replacement"),  # type: ignore[arg-type]
+    )

--- a/services/ci-control/src/vllm_ci_control/commands.py
+++ b/services/ci-control/src/vllm_ci_control/commands.py
@@ -1,0 +1,319 @@
+"""Strict parser for the public ``/ci`` comment grammar."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TypeAlias
+
+from .models import DomainValidationError, Selector, validate_stable_id
+
+MAX_COMMAND_LENGTH = 1_000
+MAX_REASON_LENGTH = 240
+MAX_SELECTOR_VALUES = 100
+_GITHUB_LOGIN_PATTERN = re.compile(r"@[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})")
+
+
+class CommandParseError(ValueError):
+    """A comment starts with ``/ci`` but is not a valid command."""
+
+
+class UnrelatedComment(ValueError):
+    """A comment is not addressed to the CI control plane."""
+
+
+class CommandKind(StrEnum):
+    """Supported command operations."""
+
+    HELP = "help"
+    STATUS = "status"
+    STATUS_REFRESH = "status_refresh"
+    STATUS_REQUEST = "status_request"
+    LIST = "list"
+    PLAN = "plan"
+    RUN = "run"
+    RETRY_FAILURES = "retry_failures"
+    CREDITS = "credits"
+    CREDITS_ADD = "credits_add"
+
+
+class StatusTarget(StrEnum):
+    """Optional status view."""
+
+    SUMMARY = "summary"
+    PR = "pr"
+    MAIN = "main"
+
+
+class ListTarget(StrEnum):
+    """Optional catalog list view."""
+
+    ALL = "all"
+    GROUPS = "groups"
+    AREAS = "areas"
+    JOBS = "jobs"
+
+
+@dataclass(frozen=True, slots=True)
+class HelpCommand:
+    kind: CommandKind = field(default=CommandKind.HELP, init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class StatusCommand:
+    target: StatusTarget = StatusTarget.SUMMARY
+    selector: Selector | None = None
+    kind: CommandKind = field(default=CommandKind.STATUS, init=False)
+
+    def __post_init__(self) -> None:
+        if self.target is StatusTarget.SUMMARY and self.selector is not None:
+            raise DomainValidationError("summary status cannot include a selector")
+
+
+@dataclass(frozen=True, slots=True)
+class StatusRefreshCommand:
+    kind: CommandKind = field(
+        default=CommandKind.STATUS_REFRESH,
+        init=False,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class StatusRequestCommand:
+    request_id: str
+    kind: CommandKind = field(
+        default=CommandKind.STATUS_REQUEST,
+        init=False,
+    )
+
+    def __post_init__(self) -> None:
+        validate_stable_id(self.request_id, label="request id")
+
+
+@dataclass(frozen=True, slots=True)
+class ListCommand:
+    target: ListTarget = ListTarget.ALL
+    kind: CommandKind = field(default=CommandKind.LIST, init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class PlanCommand:
+    selector: Selector
+    kind: CommandKind = field(default=CommandKind.PLAN, init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class RunCommand:
+    selector: Selector
+    kind: CommandKind = field(default=CommandKind.RUN, init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class RetryFailuresCommand:
+    selector: Selector | None = None
+    kind: CommandKind = field(
+        default=CommandKind.RETRY_FAILURES,
+        init=False,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class CreditsCommand:
+    kind: CommandKind = field(default=CommandKind.CREDITS, init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class CreditsAddCommand:
+    username: str
+    amount: int
+    reason: str
+    kind: CommandKind = field(default=CommandKind.CREDITS_ADD, init=False)
+
+    def __post_init__(self) -> None:
+        if _GITHUB_LOGIN_PATTERN.fullmatch(f"@{self.username}") is None:
+            raise DomainValidationError("username is not a valid GitHub login")
+        if self.amount <= 0:
+            raise DomainValidationError("credit amount must be positive")
+        _validate_reason(self.reason)
+
+
+ParsedCommand: TypeAlias = (
+    HelpCommand
+    | StatusCommand
+    | StatusRefreshCommand
+    | StatusRequestCommand
+    | ListCommand
+    | PlanCommand
+    | RunCommand
+    | RetryFailuresCommand
+    | CreditsCommand
+    | CreditsAddCommand
+)
+StatusParsedCommand: TypeAlias = (
+    StatusCommand | StatusRefreshCommand | StatusRequestCommand
+)
+
+
+def parse_command(body: object) -> ParsedCommand:
+    """Parse one exact command from a GitHub comment body.
+
+    Leading whitespace, newlines, quoting, shell syntax, unknown fields, and
+    extra arguments are rejected. ASCII spaces and tabs may separate tokens or
+    trail the command.
+    """
+
+    if not isinstance(body, str):
+        raise UnrelatedComment("comment body is not text")
+    if not body.startswith("/ci"):
+        raise UnrelatedComment("comment is not addressed to /ci")
+    if len(body) > MAX_COMMAND_LENGTH:
+        raise CommandParseError("command is too long")
+    if "\r" in body or "\n" in body:
+        raise CommandParseError("commands must occupy exactly one line")
+
+    normalized = body.rstrip(" \t")
+    if not normalized.startswith("/ci") or (
+        len(normalized) > 3 and normalized[3] not in {" ", "\t"}
+    ):
+        raise CommandParseError("expected /ci followed by a command")
+    tokens = re.split(r"[ \t]+", normalized)
+    if not tokens or tokens[0] != "/ci" or len(tokens) == 1:
+        raise CommandParseError("missing /ci command")
+
+    operation = tokens[1]
+    arguments = tokens[2:]
+    if operation == "help":
+        _require_arity(arguments, 0, "/ci help")
+        return HelpCommand()
+    if operation == "status":
+        return _parse_status(arguments)
+    if operation == "list":
+        return _parse_list(arguments)
+    if operation == "plan":
+        return PlanCommand(_parse_selector(arguments))
+    if operation == "run":
+        return RunCommand(_parse_selector(arguments))
+    if operation == "retry":
+        if not arguments or arguments[0] != "failures":
+            raise CommandParseError("expected /ci retry failures")
+        selector = _parse_selector(arguments[1:]) if len(arguments) > 1 else None
+        return RetryFailuresCommand(selector)
+    if operation == "credits":
+        return _parse_credits(arguments)
+    raise CommandParseError(f"unknown /ci command: {operation}")
+
+
+def _parse_status(arguments: list[str]) -> StatusParsedCommand:
+    if not arguments:
+        return StatusCommand()
+    if arguments == ["refresh"]:
+        return StatusRefreshCommand()
+    if arguments[0].startswith("request:"):
+        _require_arity(arguments, 1, "/ci status request:<id>")
+        request_id = arguments[0].removeprefix("request:")
+        try:
+            return StatusRequestCommand(request_id)
+        except DomainValidationError as exc:
+            raise CommandParseError(str(exc)) from exc
+    if arguments[0] not in {"pr", "main"}:
+        raise CommandParseError(
+            "status target must be pr, main, refresh, or request:<id>"
+        )
+    target = StatusTarget(arguments[0])
+    selector = _parse_selector(arguments[1:]) if len(arguments) > 1 else None
+    return StatusCommand(target, selector)
+
+
+def _parse_list(arguments: list[str]) -> ListCommand:
+    if not arguments:
+        return ListCommand()
+    _require_arity(arguments, 1, "/ci list [groups|areas|jobs]")
+    try:
+        return ListCommand(ListTarget(arguments[0]))
+    except ValueError as exc:
+        raise CommandParseError("list target must be groups, areas, or jobs") from exc
+
+
+def _parse_credits(arguments: list[str]) -> ParsedCommand:
+    if not arguments:
+        return CreditsCommand()
+    if len(arguments) < 4 or arguments[0] != "add":
+        raise CommandParseError("expected /ci credits add @user <amount> <reason>")
+    login = arguments[1]
+    if _GITHUB_LOGIN_PATTERN.fullmatch(login) is None:
+        raise CommandParseError("credit recipient must be a GitHub @user")
+    amount_text = arguments[2]
+    if not amount_text.isascii() or not amount_text.isdecimal():
+        raise CommandParseError("credit amount must be a positive integer")
+    amount = int(amount_text)
+    if amount <= 0 or amount > 1_000_000_000:
+        raise CommandParseError("credit amount is outside the accepted range")
+    reason = " ".join(arguments[3:])
+    try:
+        _validate_reason(reason)
+    except DomainValidationError as exc:
+        raise CommandParseError(str(exc)) from exc
+    return CreditsAddCommand(
+        username=login[1:].lower(),
+        amount=amount,
+        reason=reason,
+    )
+
+
+def _parse_selector(arguments: list[str]) -> Selector:
+    if not arguments:
+        raise CommandParseError("plan and run require a selector")
+    if arguments == ["all"]:
+        return Selector.all()
+    if "all" in arguments:
+        raise CommandParseError("all cannot be combined with another selector")
+
+    parsed: dict[str, frozenset[str]] = {}
+    for token in arguments:
+        if ":" not in token:
+            raise CommandParseError(f"invalid selector token: {token}")
+        dimension, raw_values = token.split(":", 1)
+        if dimension not in {"groups", "areas", "jobs"}:
+            raise CommandParseError(f"unknown selector dimension: {dimension}")
+        if dimension in parsed:
+            raise CommandParseError(f"selector dimension repeated: {dimension}")
+        values = raw_values.split(",")
+        if not values or any(not value for value in values):
+            raise CommandParseError(f"{dimension} selector contains an empty value")
+        if len(values) > MAX_SELECTOR_VALUES:
+            raise CommandParseError(f"{dimension} selector has too many values")
+        if len(set(values)) != len(values):
+            raise CommandParseError(f"{dimension} selector contains duplicate values")
+        try:
+            parsed[dimension] = frozenset(
+                validate_stable_id(value, label=dimension[:-1]) for value in values
+            )
+        except DomainValidationError as exc:
+            raise CommandParseError(str(exc)) from exc
+    return Selector(
+        groups=parsed.get("groups", frozenset()),
+        areas=parsed.get("areas", frozenset()),
+        jobs=parsed.get("jobs", frozenset()),
+    )
+
+
+def _validate_reason(reason: object) -> str:
+    if (
+        not isinstance(reason, str)
+        or not reason
+        or len(reason) > MAX_REASON_LENGTH
+        or reason.strip(" \t") != reason
+        or any(ord(character) < 32 or ord(character) == 127 for character in reason)
+    ):
+        raise DomainValidationError("credit reason must be normalized printable text")
+    return reason
+
+
+def _require_arity(
+    arguments: list[str],
+    expected: int,
+    syntax: str,
+) -> None:
+    if len(arguments) != expected:
+        raise CommandParseError(f"expected {syntax}")

--- a/services/ci-control/src/vllm_ci_control/credits.py
+++ b/services/ci-control/src/vllm_ci_control/credits.py
@@ -1,0 +1,479 @@
+"""Pure immutable credit ledger and reservation transitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import StrEnum
+
+MAX_CREDIT_VALUE = 2**63 - 1
+MAX_KEY_LENGTH = 240
+MAX_TEXT_LENGTH = 240
+
+
+class CreditError(ValueError):
+    """Base error for credit state or a requested transition."""
+
+
+class ConcurrentCreditUpdate(CreditError):
+    """The caller planned a transition from an obsolete account version."""
+
+
+class InsufficientCredits(CreditError):
+    """The account cannot cover a requested reservation."""
+
+
+class IdempotencyConflict(CreditError):
+    """An idempotency key was reused for a different operation."""
+
+
+class InvalidCreditTransition(CreditError):
+    """A reservation cannot undergo the requested state transition."""
+
+
+class ReservationStatus(StrEnum):
+    """Terminal state of one credit reservation."""
+
+    ACTIVE = "active"
+    SETTLED = "settled"
+    REFUNDED = "refunded"
+
+
+class CreditOperationKind(StrEnum):
+    """Append-only credit ledger operation types."""
+
+    INITIAL_GRANT = "initial_grant"
+    GRANT = "grant"
+    RESERVE = "reserve"
+    SETTLE = "settle"
+    REFUND = "refund"
+
+
+@dataclass(frozen=True, slots=True)
+class CreditReservation:
+    """Reserved maximum cost for one idempotent CI request."""
+
+    key: str
+    amount: int
+    status: ReservationStatus = ReservationStatus.ACTIVE
+    charged: int = 0
+
+    def __post_init__(self) -> None:
+        _validate_key(self.key, label="reservation key")
+        _validate_amount(self.amount, label="reservation amount", positive=True)
+        _validate_amount(self.charged, label="charged amount", positive=False)
+        if self.charged > self.amount:
+            raise CreditError("charged amount cannot exceed reservation")
+        if self.status is ReservationStatus.ACTIVE and self.charged:
+            raise CreditError("active reservation cannot already be charged")
+        if self.status is ReservationStatus.REFUNDED and self.charged:
+            raise CreditError("refunded reservation cannot be charged")
+
+
+@dataclass(frozen=True, slots=True)
+class CreditOperation:
+    """One immutable, idempotent ledger operation."""
+
+    idempotency_key: str
+    kind: CreditOperationKind
+    amount: int
+    reservation_key: str | None = None
+    actor_id: str | None = None
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        _validate_key(self.idempotency_key, label="idempotency key")
+        _validate_amount(self.amount, label="operation amount", positive=False)
+        if self.reservation_key is not None:
+            _validate_key(self.reservation_key, label="reservation key")
+        if self.actor_id is not None:
+            _validate_text(self.actor_id, label="actor id")
+        if self.reason is not None:
+            _validate_text(self.reason, label="reason")
+
+
+@dataclass(frozen=True, slots=True)
+class CreditAccount:
+    """Immutable account state derived through append-only operations."""
+
+    user_id: str
+    version: int
+    granted: int
+    spent: int
+    reservations: tuple[CreditReservation, ...]
+    operations: tuple[CreditOperation, ...]
+
+    def __post_init__(self) -> None:
+        _validate_text(self.user_id, label="user id")
+        if self.version < 1:
+            raise CreditError("account version must be positive")
+        _validate_amount(self.granted, label="granted credits", positive=False)
+        _validate_amount(self.spent, label="spent credits", positive=False)
+        if self.spent > self.granted:
+            raise CreditError("spent credits cannot exceed granted credits")
+        reservation_keys = [item.key for item in self.reservations]
+        if len(reservation_keys) != len(set(reservation_keys)):
+            raise CreditError("reservation keys must be unique")
+        operation_keys = [item.idempotency_key for item in self.operations]
+        if len(operation_keys) != len(set(operation_keys)):
+            raise CreditError("idempotency keys must be unique")
+        if self.version != len(self.operations):
+            raise CreditError(
+                "account version must match the number of ledger operations"
+            )
+        initial_operations = [
+            item
+            for item in self.operations
+            if item.kind is CreditOperationKind.INITIAL_GRANT
+        ]
+        if len(initial_operations) != 1:
+            raise CreditError("ledger must contain exactly one initial grant")
+        if not self.operations or self.operations[0] is not initial_operations[0]:
+            raise CreditError("initial grant must be the first operation")
+        if self.granted != sum(
+            item.amount
+            for item in self.operations
+            if item.kind
+            in {
+                CreditOperationKind.INITIAL_GRANT,
+                CreditOperationKind.GRANT,
+            }
+        ):
+            raise CreditError("granted total does not match ledger operations")
+        if self.spent != sum(
+            item.amount
+            for item in self.operations
+            if item.kind is CreditOperationKind.SETTLE
+        ):
+            raise CreditError("spent total does not match ledger operations")
+        if self.available < 0:
+            raise CreditError("active reservations overdraw the account")
+        self._validate_reservation_ledger()
+
+    @classmethod
+    def open(
+        cls,
+        *,
+        user_id: str,
+        initial_credits: int = 300,
+        idempotency_key: str | None = None,
+    ) -> CreditAccount:
+        """Create a new account with one idempotent initial grant."""
+
+        _validate_text(user_id, label="user id")
+        _validate_amount(
+            initial_credits,
+            label="initial credits",
+            positive=False,
+        )
+        key = idempotency_key or f"initial:{user_id}:v1"
+        operation = CreditOperation(
+            idempotency_key=key,
+            kind=CreditOperationKind.INITIAL_GRANT,
+            amount=initial_credits,
+            actor_id="system",
+            reason="initial credit grant",
+        )
+        return cls(
+            user_id=user_id,
+            version=1,
+            granted=initial_credits,
+            spent=0,
+            reservations=(),
+            operations=(operation,),
+        )
+
+    @property
+    def reserved(self) -> int:
+        """Credits held by active requests."""
+
+        return sum(
+            item.amount
+            for item in self.reservations
+            if item.status is ReservationStatus.ACTIVE
+        )
+
+    @property
+    def available(self) -> int:
+        """Credits available for a new reservation."""
+
+        return self.granted - self.spent - self.reserved
+
+    def grant(
+        self,
+        *,
+        expected_version: int,
+        idempotency_key: str,
+        amount: int,
+        actor_id: str,
+        reason: str,
+    ) -> CreditAccount:
+        """Add an audited grant, or return unchanged on exact replay."""
+
+        _validate_amount(amount, label="grant amount", positive=True)
+        operation = CreditOperation(
+            idempotency_key=idempotency_key,
+            kind=CreditOperationKind.GRANT,
+            amount=amount,
+            actor_id=actor_id,
+            reason=reason,
+        )
+        if self._is_replay(operation):
+            return self
+        self._require_version(expected_version)
+        _checked_add(self.granted, amount)
+        return replace(
+            self,
+            version=self.version + 1,
+            granted=self.granted + amount,
+            operations=(*self.operations, operation),
+        )
+
+    def reserve(
+        self,
+        *,
+        expected_version: int,
+        idempotency_key: str,
+        amount: int,
+    ) -> CreditAccount:
+        """Reserve a server-derived maximum request cost atomically."""
+
+        _validate_amount(amount, label="reservation amount", positive=True)
+        operation = CreditOperation(
+            idempotency_key=idempotency_key,
+            kind=CreditOperationKind.RESERVE,
+            amount=amount,
+            reservation_key=idempotency_key,
+        )
+        if self._is_replay(operation):
+            return self
+        self._require_version(expected_version)
+        if amount > self.available:
+            raise InsufficientCredits(
+                f"reservation requires {amount} credits; {self.available} available"
+            )
+        reservation = CreditReservation(
+            key=idempotency_key,
+            amount=amount,
+        )
+        return replace(
+            self,
+            version=self.version + 1,
+            reservations=(*self.reservations, reservation),
+            operations=(*self.operations, operation),
+        )
+
+    def settle(
+        self,
+        *,
+        expected_version: int,
+        idempotency_key: str,
+        reservation_key: str,
+        charged: int,
+    ) -> CreditAccount:
+        """Charge accepted work and release the unused reservation."""
+
+        _validate_amount(charged, label="settlement charge", positive=False)
+        operation = CreditOperation(
+            idempotency_key=idempotency_key,
+            kind=CreditOperationKind.SETTLE,
+            amount=charged,
+            reservation_key=reservation_key,
+        )
+        if self._is_replay(operation):
+            return self
+        self._require_version(expected_version)
+        reservation = self._reservation(reservation_key)
+        if reservation.status is not ReservationStatus.ACTIVE:
+            raise InvalidCreditTransition("only an active reservation can be settled")
+        if charged > reservation.amount:
+            raise InvalidCreditTransition("settlement cannot exceed the reservation")
+        _checked_add(self.spent, charged)
+        updated = replace(
+            reservation,
+            status=ReservationStatus.SETTLED,
+            charged=charged,
+        )
+        return replace(
+            self,
+            version=self.version + 1,
+            spent=self.spent + charged,
+            reservations=self._replace_reservation(updated),
+            operations=(*self.operations, operation),
+        )
+
+    def refund(
+        self,
+        *,
+        expected_version: int,
+        idempotency_key: str,
+        reservation_key: str,
+    ) -> CreditAccount:
+        """Release a reservation after confirmed undispatched work."""
+
+        operation = CreditOperation(
+            idempotency_key=idempotency_key,
+            kind=CreditOperationKind.REFUND,
+            amount=0,
+            reservation_key=reservation_key,
+        )
+        if self._is_replay(operation):
+            return self
+        self._require_version(expected_version)
+        reservation = self._reservation(reservation_key)
+        if reservation.status is not ReservationStatus.ACTIVE:
+            raise InvalidCreditTransition("only an active reservation can be refunded")
+        updated = replace(
+            reservation,
+            status=ReservationStatus.REFUNDED,
+        )
+        return replace(
+            self,
+            version=self.version + 1,
+            reservations=self._replace_reservation(updated),
+            operations=(*self.operations, operation),
+        )
+
+    def _require_version(self, expected_version: int) -> None:
+        if expected_version != self.version:
+            raise ConcurrentCreditUpdate(
+                f"expected account version {expected_version}; "
+                f"current version is {self.version}"
+            )
+
+    def _is_replay(self, operation: CreditOperation) -> bool:
+        for existing in self.operations:
+            if existing.idempotency_key != operation.idempotency_key:
+                continue
+            if existing != operation:
+                raise IdempotencyConflict(
+                    "idempotency key was reused with different operation data"
+                )
+            return True
+        return False
+
+    def _reservation(self, key: str) -> CreditReservation:
+        _validate_key(key, label="reservation key")
+        for reservation in self.reservations:
+            if reservation.key == key:
+                return reservation
+        raise InvalidCreditTransition(f"unknown reservation: {key}")
+
+    def _replace_reservation(
+        self,
+        replacement: CreditReservation,
+    ) -> tuple[CreditReservation, ...]:
+        return tuple(
+            replacement if item.key == replacement.key else item
+            for item in self.reservations
+        )
+
+    def _validate_reservation_ledger(self) -> None:
+        reservations = {item.key: item for item in self.reservations}
+        reserve_operations: dict[str, CreditOperation] = {}
+        terminal_operations: dict[str, list[CreditOperation]] = {}
+
+        for operation in self.operations:
+            if operation.kind in {
+                CreditOperationKind.INITIAL_GRANT,
+                CreditOperationKind.GRANT,
+            }:
+                if operation.reservation_key is not None:
+                    raise CreditError("grant operations cannot name a reservation")
+                continue
+            if operation.reservation_key is None:
+                raise CreditError("reservation operations must name a reservation")
+            if operation.kind is CreditOperationKind.RESERVE:
+                if operation.reservation_key in reserve_operations:
+                    raise CreditError(
+                        "a reservation must have exactly one reserve operation"
+                    )
+                reserve_operations[operation.reservation_key] = operation
+            else:
+                terminal_operations.setdefault(
+                    operation.reservation_key,
+                    [],
+                ).append(operation)
+
+        if set(reserve_operations) != set(reservations):
+            raise CreditError("reservations and reserve operations must correspond")
+        for key, reservation in reservations.items():
+            reserve = reserve_operations[key]
+            if reserve.amount != reservation.amount:
+                raise CreditError("reservation amount does not match reserve operation")
+            terminals = terminal_operations.get(key, [])
+            if reservation.status is ReservationStatus.ACTIVE:
+                if terminals:
+                    raise CreditError(
+                        "active reservation cannot have a terminal operation"
+                    )
+                continue
+            if len(terminals) != 1:
+                raise CreditError(
+                    "terminal reservation must have one terminal operation"
+                )
+            terminal = terminals[0]
+            if reservation.status is ReservationStatus.SETTLED:
+                if (
+                    terminal.kind is not CreditOperationKind.SETTLE
+                    or terminal.amount != reservation.charged
+                ):
+                    raise CreditError(
+                        "settled reservation does not match its operation"
+                    )
+            elif (
+                terminal.kind is not CreditOperationKind.REFUND or terminal.amount != 0
+            ):
+                raise CreditError("refunded reservation does not match its operation")
+
+        unknown_terminal_keys = set(terminal_operations) - set(reservations)
+        if unknown_terminal_keys:
+            raise CreditError("terminal operation references an unknown reservation")
+
+
+def _validate_amount(
+    value: object,
+    *,
+    label: str,
+    positive: bool,
+) -> int:
+    minimum = 1 if positive else 0
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < minimum
+        or value > MAX_CREDIT_VALUE
+    ):
+        qualifier = "positive" if positive else "non-negative"
+        raise CreditError(f"{label} must be a bounded {qualifier} integer")
+    return value
+
+
+def _validate_key(value: object, *, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > MAX_KEY_LENGTH
+        or value.strip() != value
+        or any(ord(character) < 33 or ord(character) == 127 for character in value)
+    ):
+        raise CreditError(f"{label} must be bounded printable text without whitespace")
+    return value
+
+
+def _validate_text(value: object, *, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > MAX_TEXT_LENGTH
+        or value.strip() != value
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise CreditError(f"{label} must be bounded normalized printable text")
+    return value
+
+
+def _checked_add(left: int, right: int) -> int:
+    result = left + right
+    if result > MAX_CREDIT_VALUE:
+        raise CreditError("credit total exceeds the supported range")
+    return result

--- a/services/ci-control/src/vllm_ci_control/evidence.py
+++ b/services/ci-control/src/vllm_ci_control/evidence.py
@@ -1,0 +1,507 @@
+"""Normalize provider job attempts into conservative, comparable observations."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+_COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
+_FAILED_STATES = frozenset({"failed", "timed_out", "expired"})
+_CLEAN_STATES = frozenset({"passed"})
+_MAX_METADATA_LENGTH = 240
+
+
+class Outcome(StrEnum):
+    """A conservative outcome for one stable test group on one commit."""
+
+    CLEAN = "clean"
+    FAILED = "failed"
+    FLAKY = "flaky"
+    INCONCLUSIVE = "inconclusive"
+
+
+@dataclass(frozen=True, order=True)
+class GroupId:
+    """Stable identity shared by main and pull-request observations."""
+
+    pipeline: str
+    step_key: str
+    variant: str = "default"
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("pipeline", self.pipeline),
+            ("step_key", self.step_key),
+            ("variant", self.variant),
+        ):
+            _validate_metadata(value, label=name)
+
+    @property
+    def display(self) -> str:
+        """Return a compact, unambiguous representation for user output."""
+
+        suffix = "" if self.variant == "default" else f" [{self.variant}]"
+        return f"{self.pipeline}/{self.step_key}{suffix}"
+
+
+@dataclass(frozen=True, order=True)
+class MainPosition:
+    """Canonical ordering assigned by the trusted default-branch registry."""
+
+    epoch: int
+    sequence: int
+
+    def __post_init__(self) -> None:
+        for label, value in (("epoch", self.epoch), ("sequence", self.sequence)):
+            if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+                raise ValueError(f"main {label} must be a positive integer")
+
+
+@dataclass(frozen=True)
+class ProviderReadAttestation:
+    """Provider-read facts required before an execution can be conclusive."""
+
+    all_pages_fetched: bool
+    retry_history_complete: bool
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.all_pages_fetched, bool):
+            raise TypeError("all_pages_fetched must be boolean")
+        if not isinstance(self.retry_history_complete, bool):
+            raise TypeError("retry_history_complete must be boolean")
+
+    @property
+    def complete(self) -> bool:
+        return self.all_pages_fetched and self.retry_history_complete
+
+
+@dataclass(frozen=True)
+class GroupExpectation:
+    """Trusted execution metadata and exact shards expected from one group."""
+
+    group: GroupId
+    shards: frozenset[str]
+    execution_profile: str | None = None
+    definition_digest: str | None = None
+
+    def __post_init__(self) -> None:
+        shards = frozenset(self.shards)
+        if not shards:
+            raise ValueError("expected shard set must not be empty")
+        for shard in shards:
+            _validate_metadata(shard, label="expected shard")
+        _validate_optional_metadata(
+            self.execution_profile,
+            label="execution profile",
+        )
+        _validate_optional_metadata(
+            self.definition_digest,
+            label="definition digest",
+        )
+        object.__setattr__(self, "shards", shards)
+
+
+@dataclass(frozen=True)
+class JobAttempt:
+    """Provider-neutral facts about one execution attempt."""
+
+    job_id: str
+    group: GroupId
+    state: str
+    shard: str = "0"
+    retried_in_job_id: str | None = None
+    retries_count: int | None = None
+    soft_failed: bool = False
+    failure_fingerprints: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        _validate_metadata(self.job_id, label="job id")
+        _validate_metadata(self.shard, label="shard")
+        _validate_metadata(self.state, label="job state")
+        if self.retried_in_job_id is not None:
+            _validate_metadata(
+                self.retried_in_job_id,
+                label="retried-in job id",
+            )
+        if self.retries_count is not None and (
+            isinstance(self.retries_count, bool)
+            or not isinstance(self.retries_count, int)
+            or self.retries_count < 0
+        ):
+            raise ValueError("retries_count must be a non-negative integer")
+        if not isinstance(self.soft_failed, bool):
+            raise TypeError("soft_failed must be boolean")
+        fingerprints = _fingerprint_set(self.failure_fingerprints)
+        object.__setattr__(self, "failure_fingerprints", fingerprints)
+
+
+@dataclass(frozen=True)
+class GroupObservation:
+    """Evidence for one group in one completed provider build."""
+
+    group: GroupId
+    commit: str
+    outcome: Outcome
+    build_number: int
+    observed_at: datetime
+    build_url: str
+    trusted_main: bool
+    main_position: MainPosition | None
+    execution_profile: str | None = None
+    definition_digest: str | None = None
+    failure_fingerprints: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        if not self.commit:
+            raise ValueError("commit must not be empty")
+        if self.trusted_main and _COMMIT_PATTERN.fullmatch(self.commit) is None:
+            raise ValueError("trusted main commit must be a full lowercase SHA")
+        if self.build_number < 1:
+            raise ValueError("build_number must be positive")
+        if self.observed_at.tzinfo is None:
+            raise ValueError("observed_at must be timezone-aware")
+        _validate_metadata(self.build_url, label="build URL")
+        if not isinstance(self.trusted_main, bool):
+            raise TypeError("trusted_main must be boolean")
+        if self.trusted_main != (self.main_position is not None):
+            raise ValueError("trusted main evidence requires a canonical main position")
+        _validate_optional_metadata(
+            self.execution_profile,
+            label="execution profile",
+        )
+        _validate_optional_metadata(
+            self.definition_digest,
+            label="definition digest",
+        )
+        fingerprints = _fingerprint_set(self.failure_fingerprints)
+        if self.outcome in {Outcome.CLEAN, Outcome.INCONCLUSIVE} and fingerprints:
+            raise ValueError("only failed or flaky observations may carry fingerprints")
+        object.__setattr__(self, "failure_fingerprints", fingerprints)
+
+
+def observe_attempts(
+    *,
+    attempts: Iterable[JobAttempt],
+    expectations: Iterable[GroupExpectation],
+    read_attestation: ProviderReadAttestation,
+    build_number: int,
+    build_url: str,
+    commit: str,
+    observed_at: datetime,
+    trusted_main: bool,
+    main_position: MainPosition | None,
+) -> tuple[GroupObservation, ...]:
+    """Aggregate complete retry lineages and exact shard sets.
+
+    A clean result requires a complete provider read, every expected current
+    shard, and a zero-retry passing attempt for every shard. Missing expected
+    groups are inconclusive; callers omit groups that were intentionally not
+    selected.
+    """
+
+    by_group: dict[GroupId, list[JobAttempt]] = defaultdict(list)
+    for attempt in attempts:
+        by_group[attempt.group].append(attempt)
+
+    expected_by_group: dict[GroupId, GroupExpectation] = {}
+    for expectation in expectations:
+        if expectation.group in expected_by_group:
+            raise ValueError("group expectations must be unique")
+        expected_by_group[expectation.group] = expectation
+
+    observations = []
+    for group in sorted(set(by_group) | set(expected_by_group)):
+        expectation = expected_by_group.get(group)
+        if expectation is None:
+            outcome, fingerprints = Outcome.INCONCLUSIVE, frozenset()
+            execution_profile = None
+            definition_digest = None
+        else:
+            outcome, fingerprints = _observe_group(
+                by_group.get(group, []),
+                expected_shards=expectation.shards,
+                read_attestation=read_attestation,
+            )
+            execution_profile = expectation.execution_profile
+            definition_digest = expectation.definition_digest
+        observations.append(
+            GroupObservation(
+                group=group,
+                commit=commit,
+                outcome=outcome,
+                build_number=build_number,
+                observed_at=observed_at,
+                build_url=build_url,
+                trusted_main=trusted_main,
+                main_position=main_position,
+                execution_profile=execution_profile,
+                definition_digest=definition_digest,
+                failure_fingerprints=fingerprints,
+            )
+        )
+    return tuple(observations)
+
+
+def _observe_group(
+    attempts: list[JobAttempt],
+    *,
+    expected_shards: frozenset[str],
+    read_attestation: ProviderReadAttestation,
+) -> tuple[Outcome, frozenset[str]]:
+    if not read_attestation.complete or not attempts:
+        return Outcome.INCONCLUSIVE, frozenset()
+
+    by_id = {attempt.job_id: attempt for attempt in attempts}
+    if len(by_id) != len(attempts):
+        raise ValueError("job_id values must be unique within a build")
+    if any(attempt.retries_count is None for attempt in attempts):
+        return Outcome.INCONCLUSIVE, frozenset()
+    if any(attempt.shard not in expected_shards for attempt in attempts):
+        return Outcome.INCONCLUSIVE, frozenset()
+    if any(
+        attempt.retried_in_job_id is not None and attempt.retried_in_job_id not in by_id
+        for attempt in attempts
+    ):
+        return Outcome.INCONCLUSIVE, frozenset()
+
+    predecessor_ids = {
+        attempt.job_id for attempt in attempts if attempt.retried_in_job_id is not None
+    }
+    current = [attempt for attempt in attempts if attempt.job_id not in predecessor_ids]
+    if {attempt.shard for attempt in current} != expected_shards:
+        return Outcome.INCONCLUSIVE, frozenset()
+    if len(current) != len(expected_shards):
+        return Outcome.INCONCLUSIVE, frozenset()
+
+    shard_results = []
+    covered_ids: set[str] = set()
+    for attempt in current:
+        previous = _find_predecessors(attempt.job_id, by_id)
+        if previous is None:
+            return Outcome.INCONCLUSIVE, frozenset()
+        expected_counts = tuple(
+            range(attempt.retries_count - 1, -1, -1)  # type: ignore[operator]
+        )
+        actual_counts = tuple(item.retries_count for item in previous)
+        if len(previous) != attempt.retries_count or actual_counts != expected_counts:
+            return Outcome.INCONCLUSIVE, frozenset()
+        lineage_ids = {attempt.job_id, *(item.job_id for item in previous)}
+        if covered_ids & lineage_ids:
+            return Outcome.INCONCLUSIVE, frozenset()
+        covered_ids.update(lineage_ids)
+        shard_results.append(_observe_current_attempt(attempt, previous))
+
+    if covered_ids != set(by_id):
+        return Outcome.INCONCLUSIVE, frozenset()
+
+    outcomes = [outcome for outcome, _ in shard_results]
+    if Outcome.FAILED in outcomes:
+        outcome = Outcome.FAILED
+    elif Outcome.INCONCLUSIVE in outcomes:
+        outcome = Outcome.INCONCLUSIVE
+    elif Outcome.FLAKY in outcomes:
+        outcome = Outcome.FLAKY
+    else:
+        outcome = Outcome.CLEAN
+
+    if outcome in {Outcome.FAILED, Outcome.FLAKY}:
+        fingerprints = frozenset(
+            fingerprint
+            for shard_outcome, shard_fingerprints in shard_results
+            if shard_outcome in {Outcome.FAILED, Outcome.FLAKY}
+            for fingerprint in shard_fingerprints
+        )
+    else:
+        fingerprints = frozenset()
+    return outcome, fingerprints
+
+
+def _observe_current_attempt(
+    current: JobAttempt,
+    previous: tuple[JobAttempt, ...],
+) -> tuple[Outcome, frozenset[str]]:
+    if current.soft_failed or current.state in _FAILED_STATES:
+        return Outcome.FAILED, current.failure_fingerprints
+    if current.state not in _CLEAN_STATES:
+        return Outcome.INCONCLUSIVE, frozenset()
+    if not previous:
+        return Outcome.CLEAN, frozenset()
+
+    failed_predecessors = [
+        attempt
+        for attempt in previous
+        if attempt.soft_failed or attempt.state in _FAILED_STATES
+    ]
+    if failed_predecessors:
+        return (
+            Outcome.FLAKY,
+            frozenset(
+                fingerprint
+                for attempt in failed_predecessors
+                for fingerprint in attempt.failure_fingerprints
+            ),
+        )
+    # A retried pass is never clean first-attempt evidence. If the preceding
+    # state was not a recognized failure, the lineage is inconclusive.
+    return Outcome.INCONCLUSIVE, frozenset()
+
+
+def _find_predecessors(
+    current_job_id: str,
+    attempts_by_id: Mapping[str, JobAttempt],
+) -> tuple[JobAttempt, ...] | None:
+    """Follow reverse Buildkite retry links while rejecting malformed graphs."""
+
+    predecessors = []
+    seen = {current_job_id}
+    cursor = current_job_id
+    while True:
+        matches = [
+            attempt
+            for attempt in attempts_by_id.values()
+            if attempt.retried_in_job_id == cursor
+        ]
+        if not matches:
+            return tuple(predecessors)
+        if len(matches) != 1:
+            return None
+        predecessor = matches[0]
+        if predecessor.job_id in seen:
+            return None
+        successor = attempts_by_id[cursor]
+        if predecessor.group != successor.group or predecessor.shard != successor.shard:
+            return None
+        seen.add(predecessor.job_id)
+        predecessors.append(predecessor)
+        cursor = predecessor.job_id
+
+
+def collapse_distinct_commits(
+    observations: Iterable[GroupObservation],
+) -> tuple[GroupObservation, ...]:
+    """Collapse rebuilds so one main SHA contributes once per main epoch."""
+
+    values = tuple(observations)
+    _validate_trusted_main_positions(values)
+    by_identity: dict[
+        tuple[GroupId, int, str],
+        list[GroupObservation],
+    ] = defaultdict(list)
+    for observation in values:
+        position = observation.main_position
+        assert position is not None
+        by_identity[(observation.group, position.epoch, observation.commit)].append(
+            observation
+        )
+
+    collapsed = []
+    for (group, _epoch, commit), items in by_identity.items():
+        positions = {item.main_position for item in items}
+        if len(positions) != 1:
+            raise ValueError("one main commit cannot have multiple positions")
+        items.sort(key=lambda item: (item.observed_at, item.build_number))
+        latest = items[-1]
+        outcomes = {item.outcome for item in items}
+        profiles = {item.execution_profile for item in items}
+        definitions = {item.definition_digest for item in items}
+        if latest.outcome is Outcome.INCONCLUSIVE:
+            # Preserve the newest attempted rebuild as incomplete. Otherwise
+            # its timestamp could make older conclusive evidence look current.
+            outcome = Outcome.INCONCLUSIVE
+        elif len(profiles) != 1 or len(definitions) != 1:
+            outcome = Outcome.INCONCLUSIVE
+        elif Outcome.FAILED in outcomes:
+            outcome = (
+                Outcome.FLAKY
+                if Outcome.CLEAN in outcomes or Outcome.FLAKY in outcomes
+                else Outcome.FAILED
+            )
+        elif Outcome.FLAKY in outcomes:
+            outcome = Outcome.FLAKY
+        elif Outcome.CLEAN in outcomes:
+            outcome = Outcome.CLEAN
+        else:
+            outcome = Outcome.INCONCLUSIVE
+        fingerprints = (
+            frozenset(
+                fingerprint
+                for item in items
+                if item.outcome in {Outcome.FAILED, Outcome.FLAKY}
+                for fingerprint in item.failure_fingerprints
+            )
+            if outcome in {Outcome.FAILED, Outcome.FLAKY}
+            else frozenset()
+        )
+        collapsed.append(
+            GroupObservation(
+                group=group,
+                commit=commit,
+                outcome=outcome,
+                build_number=latest.build_number,
+                observed_at=latest.observed_at,
+                build_url=latest.build_url,
+                trusted_main=True,
+                main_position=latest.main_position,
+                execution_profile=(
+                    latest.execution_profile if len(profiles) == 1 else None
+                ),
+                definition_digest=(
+                    latest.definition_digest if len(definitions) == 1 else None
+                ),
+                failure_fingerprints=fingerprints,
+            )
+        )
+    return tuple(
+        sorted(
+            collapsed,
+            key=lambda item: (
+                item.main_position,
+                item.group,
+            ),
+        )
+    )
+
+
+def _validate_trusted_main_positions(
+    observations: tuple[GroupObservation, ...],
+) -> None:
+    commits_by_position: dict[MainPosition, str] = {}
+    for observation in observations:
+        if not observation.trusted_main or observation.main_position is None:
+            raise ValueError(
+                "incident evidence must have trusted canonical-main provenance"
+            )
+        existing = commits_by_position.setdefault(
+            observation.main_position,
+            observation.commit,
+        )
+        if existing != observation.commit:
+            raise ValueError("one main position cannot identify multiple commits")
+
+
+def _fingerprint_set(values: Iterable[str]) -> frozenset[str]:
+    result = frozenset(values)
+    for value in result:
+        _validate_metadata(value, label="failure fingerprint")
+    return result
+
+
+def _validate_optional_metadata(value: str | None, *, label: str) -> None:
+    if value is not None:
+        _validate_metadata(value, label=label)
+
+
+def _validate_metadata(value: object, *, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > _MAX_METADATA_LENGTH
+        or value.strip() != value
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise ValueError(f"{label} must be bounded normalized printable text")
+    return value

--- a/services/ci-control/src/vllm_ci_control/incidents.py
+++ b/services/ci-control/src/vllm_ci_control/incidents.py
@@ -1,0 +1,254 @@
+"""Deterministic lifecycle reduction for trusted canonical-main evidence."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import StrEnum
+from itertools import groupby
+
+from .evidence import (
+    GroupId,
+    GroupObservation,
+    Outcome,
+    collapse_distinct_commits,
+)
+
+
+class IncidentState(StrEnum):
+    """Lifecycle of one stable main-branch test group."""
+
+    HEALTHY = "healthy"
+    CANDIDATE = "candidate"
+    KNOWN = "known"
+    RECOVERING = "recovering"
+    RESOLVED = "resolved"
+
+
+@dataclass(frozen=True)
+class IncidentThresholds:
+    """Distinct-main-position thresholds for failure and recovery."""
+
+    confirm_failures: int = 2
+    begin_recovery: int = 1
+    resolve_clean: int = 3
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("confirm_failures", self.confirm_failures),
+            ("begin_recovery", self.begin_recovery),
+            ("resolve_clean", self.resolve_clean),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+                raise ValueError(f"{label} must be a positive integer")
+        if self.resolve_clean < self.begin_recovery:
+            raise ValueError(
+                "resolve_clean must be greater than or equal to begin_recovery"
+            )
+
+
+_DEFAULT_THRESHOLDS = IncidentThresholds()
+
+
+@dataclass(frozen=True)
+class Incident:
+    """Current lifecycle plus the latest attempted and conclusive evidence."""
+
+    group: GroupId
+    state: IncidentState
+    failure_count: int
+    clean_count: int
+    ever_known: bool
+    latest_attempted_observation: GroupObservation | None
+    last_conclusive_observation: GroupObservation | None
+    last_failure_observation: GroupObservation | None
+    confirmed_failure_fingerprints: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("failure_count", self.failure_count),
+            ("clean_count", self.clean_count),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{label} must be a non-negative integer")
+        for observation in (
+            self.latest_attempted_observation,
+            self.last_conclusive_observation,
+            self.last_failure_observation,
+        ):
+            if observation is not None and observation.group != self.group:
+                raise ValueError("incident observation identities must match")
+        if self.last_failure_observation is not None and (
+            self.last_failure_observation.outcome not in {Outcome.FAILED, Outcome.FLAKY}
+        ):
+            raise ValueError("last failure observation must be failure-bearing")
+        fingerprints = frozenset(self.confirmed_failure_fingerprints)
+        object.__setattr__(
+            self,
+            "confirmed_failure_fingerprints",
+            fingerprints,
+        )
+
+
+def reduce_incident(
+    group: GroupId,
+    observations: Iterable[GroupObservation],
+    thresholds: IncidentThresholds = _DEFAULT_THRESHOLDS,
+) -> Incident:
+    """Replay one lifecycle in canonical ``(main epoch, sequence)`` order."""
+
+    relevant = [
+        observation
+        for observation in collapse_distinct_commits(observations)
+        if observation.group == group
+    ]
+    relevant.sort(key=lambda item: item.main_position)
+
+    state = IncidentState.HEALTHY
+    failure_count = 0
+    clean_count = 0
+    ever_known = False
+    last_conclusive: GroupObservation | None = None
+    last_failure: GroupObservation | None = None
+    current_epoch: int | None = None
+    current_definition: str | None = None
+    definition_initialized = False
+    fingerprint_failure_counts: dict[str, int] = {}
+    confirmed_fingerprints: set[str] = set()
+
+    for observation in relevant:
+        position = observation.main_position
+        assert position is not None
+        if current_epoch is None:
+            current_epoch = position.epoch
+        elif position.epoch != current_epoch:
+            (
+                state,
+                failure_count,
+                clean_count,
+            ) = _enter_main_epoch(state)
+            fingerprint_failure_counts.clear()
+            current_epoch = position.epoch
+
+        if not definition_initialized:
+            current_definition = observation.definition_digest
+            definition_initialized = True
+        elif observation.definition_digest != current_definition:
+            # A changed test definition is a new incident identity. Historical
+            # evidence remains available for audit, but it cannot confirm or
+            # recover the new executable definition.
+            state = IncidentState.HEALTHY
+            failure_count = 0
+            clean_count = 0
+            fingerprint_failure_counts.clear()
+            confirmed_fingerprints.clear()
+            current_definition = observation.definition_digest
+
+        if observation.outcome is Outcome.INCONCLUSIVE:
+            continue
+        last_conclusive = observation
+
+        if observation.outcome is Outcome.FLAKY:
+            clean_count = 0
+            last_failure = observation
+            if state in {IncidentState.KNOWN, IncidentState.RECOVERING}:
+                # Preserve a previously confirmed incident, but do not treat a
+                # retry-pass as a currently failing or confirming observation.
+                state = IncidentState.KNOWN
+                failure_count = max(
+                    failure_count,
+                    thresholds.confirm_failures,
+                )
+            elif state is IncidentState.RESOLVED:
+                state = IncidentState.CANDIDATE
+                failure_count = 0
+            else:
+                state = IncidentState.CANDIDATE
+            continue
+
+        if observation.outcome is Outcome.FAILED:
+            clean_count = 0
+            last_failure = observation
+            if state is IncidentState.RESOLVED:
+                fingerprint_failure_counts.clear()
+            for fingerprint in observation.failure_fingerprints:
+                count = fingerprint_failure_counts.get(fingerprint, 0) + 1
+                fingerprint_failure_counts[fingerprint] = count
+                if count >= thresholds.confirm_failures:
+                    confirmed_fingerprints.add(fingerprint)
+            if state in {IncidentState.KNOWN, IncidentState.RECOVERING}:
+                state = IncidentState.KNOWN
+                failure_count = max(
+                    failure_count,
+                    thresholds.confirm_failures,
+                )
+                continue
+            if state is IncidentState.RESOLVED:
+                failure_count = 0
+            failure_count += 1
+            if failure_count >= thresholds.confirm_failures:
+                state = IncidentState.KNOWN
+                ever_known = True
+            else:
+                state = IncidentState.CANDIDATE
+            continue
+
+        # A complete clean first attempt is the only recovery evidence.
+        failure_count = 0
+        fingerprint_failure_counts.clear()
+        if state is IncidentState.CANDIDATE:
+            state = IncidentState.RESOLVED if ever_known else IncidentState.HEALTHY
+            clean_count = 1
+        elif state in {IncidentState.KNOWN, IncidentState.RECOVERING}:
+            clean_count += 1
+            if clean_count >= thresholds.resolve_clean:
+                state = IncidentState.RESOLVED
+            elif clean_count >= thresholds.begin_recovery:
+                state = IncidentState.RECOVERING
+        else:
+            clean_count += 1
+
+    return Incident(
+        group=group,
+        state=state,
+        failure_count=failure_count,
+        clean_count=clean_count,
+        ever_known=ever_known,
+        latest_attempted_observation=relevant[-1] if relevant else None,
+        last_conclusive_observation=last_conclusive,
+        last_failure_observation=last_failure,
+        confirmed_failure_fingerprints=frozenset(confirmed_fingerprints),
+    )
+
+
+def reduce_registry(
+    observations: Iterable[GroupObservation],
+    thresholds: IncidentThresholds = _DEFAULT_THRESHOLDS,
+) -> tuple[Incident, ...]:
+    """Reduce all trusted main groups into a stable registry snapshot."""
+
+    collapsed = collapse_distinct_commits(observations)
+    ordered = sorted(collapsed, key=lambda item: item.group)
+    return tuple(
+        reduce_incident(group, items, thresholds)
+        for group, grouped in groupby(ordered, key=lambda item: item.group)
+        for items in [tuple(grouped)]
+    )
+
+
+def _enter_main_epoch(
+    state: IncidentState,
+) -> tuple[IncidentState, int, int]:
+    """Reset per-epoch evidence without erasing confirmed history.
+
+    An unconfirmed candidate cannot cross a force-push boundary. A previously
+    confirmed incident remains known, but recovery must restart entirely in the
+    new epoch. Resolved history stays resolved and requires fresh confirmation
+    before reopening.
+    """
+
+    if state is IncidentState.CANDIDATE:
+        state = IncidentState.HEALTHY
+    elif state is IncidentState.RECOVERING:
+        state = IncidentState.KNOWN
+    return state, 0, 0

--- a/services/ci-control/src/vllm_ci_control/models.py
+++ b/services/ci-control/src/vllm_ci_control/models.py
@@ -1,0 +1,95 @@
+"""Shared immutable domain values."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import StrEnum
+
+_STABLE_ID_PATTERN = re.compile(r"[a-z0-9][a-z0-9._:-]{0,99}")
+
+
+class DomainValidationError(ValueError):
+    """A domain value does not satisfy the public contract."""
+
+
+def validate_stable_id(value: object, *, label: str = "identifier") -> str:
+    """Validate a bounded, lowercase identifier used by the public API."""
+
+    if not isinstance(value, str) or _STABLE_ID_PATTERN.fullmatch(value) is None:
+        raise DomainValidationError(
+            f"{label} must match {_STABLE_ID_PATTERN.pattern!r}"
+        )
+    return value
+
+
+def stable_id_set(
+    values: Iterable[str],
+    *,
+    label: str,
+) -> frozenset[str]:
+    """Return validated identifiers as an immutable set."""
+
+    result = frozenset(values)
+    for value in result:
+        validate_stable_id(value, label=label)
+    return result
+
+
+class RepositoryPermission(StrEnum):
+    """GitHub's repository permission levels."""
+
+    NONE = "none"
+    READ = "read"
+    TRIAGE = "triage"
+    WRITE = "write"
+    MAINTAIN = "maintain"
+    ADMIN = "admin"
+
+
+MUTATION_PERMISSIONS = frozenset(
+    {
+        RepositoryPermission.WRITE,
+        RepositoryPermission.MAINTAIN,
+        RepositoryPermission.ADMIN,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Selector:
+    """Normalized selector expression used by planning and execution."""
+
+    all_jobs: bool = False
+    groups: frozenset[str] = frozenset()
+    areas: frozenset[str] = frozenset()
+    jobs: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "groups",
+            stable_id_set(self.groups, label="group"),
+        )
+        object.__setattr__(
+            self,
+            "areas",
+            stable_id_set(self.areas, label="area"),
+        )
+        object.__setattr__(
+            self,
+            "jobs",
+            stable_id_set(self.jobs, label="job"),
+        )
+        dimensions = self.groups or self.areas or self.jobs
+        if self.all_jobs and dimensions:
+            raise DomainValidationError("all cannot be combined with another selector")
+        if not self.all_jobs and not dimensions:
+            raise DomainValidationError("at least one selector is required")
+
+    @classmethod
+    def all(cls) -> Selector:
+        """Select every active catalog job."""
+
+        return cls(all_jobs=True)

--- a/services/ci-control/src/vllm_ci_control/policy.py
+++ b/services/ci-control/src/vllm_ci_control/policy.py
@@ -1,0 +1,531 @@
+"""Reviewed policy values and authorization decisions."""
+
+from __future__ import annotations
+
+import tomllib
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from .models import (
+    RepositoryPermission,
+    stable_id_set,
+    validate_stable_id,
+)
+
+
+class PolicyValidationError(ValueError):
+    """Policy input is invalid or unsafe."""
+
+
+@dataclass(frozen=True, slots=True)
+class RetryLimit:
+    """Maximum retries after the initial attempt; ``None`` means unlimited."""
+
+    maximum: int | None
+
+    def __post_init__(self) -> None:
+        if self.maximum is not None and (
+            isinstance(self.maximum, bool)
+            or not isinstance(self.maximum, int)
+            or self.maximum < 0
+        ):
+            raise PolicyValidationError(
+                "retry limit must be a non-negative integer or inf"
+            )
+
+    @classmethod
+    def infinite(cls) -> RetryLimit:
+        """Return an unbounded retry-depth policy."""
+
+        return cls(None)
+
+    @classmethod
+    def parse(cls, value: object) -> RetryLimit:
+        """Parse a trusted configuration value."""
+
+        if value == "inf":
+            return cls.infinite()
+        if isinstance(value, int) and not isinstance(value, bool):
+            return cls(value)
+        raise PolicyValidationError(
+            "retry limit must be a non-negative integer or 'inf'"
+        )
+
+    @property
+    def is_infinite(self) -> bool:
+        return self.maximum is None
+
+    def allows(self, completed_retries: int) -> bool:
+        """Return whether one additional retry is permitted."""
+
+        if completed_retries < 0:
+            raise PolicyValidationError("completed retries cannot be negative")
+        return self.maximum is None or completed_retries < self.maximum
+
+
+_PERMISSION_RANK = {
+    RepositoryPermission.NONE: 0,
+    RepositoryPermission.READ: 1,
+    RepositoryPermission.TRIAGE: 2,
+    RepositoryPermission.WRITE: 3,
+    RepositoryPermission.MAINTAIN: 4,
+    RepositoryPermission.ADMIN: 5,
+}
+_RETRY_STATES = frozenset({"failed", "timed_out", "expired"})
+
+
+@dataclass(frozen=True, slots=True)
+class Policy:
+    """Immutable policy loaded from the reviewed vLLM overlay."""
+
+    api_version: int = 1
+    catalog_groups: frozenset[str] = frozenset({"upstream", "cpu", "amd"})
+    catalog_aliases: tuple[tuple[str, str], ...] = ()
+    catalog_tombstones: tuple[str, ...] = ()
+    catalog_area_aliases: tuple[tuple[str, str], ...] = ()
+    catalog_area_tombstones: tuple[str, ...] = ()
+    native_amd_selection: str = "whole_lane"
+    minimum_compute_permission: RepositoryPermission = RepositoryPermission.WRITE
+    minimum_refresh_permission: RepositoryPermission = RepositoryPermission.WRITE
+    minimum_credit_grant_permission: RepositoryPermission = (
+        RepositoryPermission.MAINTAIN
+    )
+    committer_teams: tuple[str, ...] = ("vllm-committers",)
+    credit_admin_teams: tuple[str, ...] = ("vllm-ci-admins",)
+    initial_credits: int = 300
+    credit_reset: str = "none"
+    retry_limit: RetryLimit = field(default_factory=RetryLimit.infinite)
+    retry_states: frozenset[str] = _RETRY_STATES
+    confirmation_distinct_shas: int = 2
+    resolution_clean_distinct_shas: int = 3
+    evidence_max_age_hours: int = 72
+
+    def __post_init__(self) -> None:
+        if self.api_version != 1:
+            raise PolicyValidationError("unsupported policy api_version")
+
+        groups = stable_id_set(self.catalog_groups, label="catalog group")
+        if not groups:
+            raise PolicyValidationError(
+                "catalog groups must contain at least one group"
+            )
+        aliases = tuple(sorted(self.catalog_aliases))
+        alias_names: set[str] = set()
+        for alias, target in aliases:
+            validate_stable_id(alias, label="catalog alias")
+            validate_stable_id(target, label="catalog alias target")
+            if alias in alias_names:
+                raise PolicyValidationError("catalog aliases must be unique")
+            alias_names.add(alias)
+        tombstones = tuple(sorted(self.catalog_tombstones))
+        for tombstone in tombstones:
+            validate_stable_id(tombstone, label="catalog tombstone")
+        if len(tombstones) != len(set(tombstones)):
+            raise PolicyValidationError("catalog tombstones must be unique")
+        if alias_names & set(tombstones):
+            raise PolicyValidationError(
+                "catalog aliases and tombstones share one job namespace"
+            )
+        area_aliases = tuple(sorted(self.catalog_area_aliases))
+        area_alias_names: set[str] = set()
+        for alias, target in area_aliases:
+            validate_stable_id(alias, label="catalog area alias")
+            validate_stable_id(target, label="catalog area alias target")
+            if alias in area_alias_names:
+                raise PolicyValidationError("catalog area aliases must be unique")
+            area_alias_names.add(alias)
+        area_tombstones = tuple(sorted(self.catalog_area_tombstones))
+        for tombstone in area_tombstones:
+            validate_stable_id(tombstone, label="catalog area tombstone")
+        if len(area_tombstones) != len(set(area_tombstones)):
+            raise PolicyValidationError("catalog area tombstones must be unique")
+        if area_alias_names & set(area_tombstones):
+            raise PolicyValidationError(
+                "catalog area aliases and tombstones share one namespace"
+            )
+        if self.native_amd_selection != "whole_lane":
+            raise PolicyValidationError("native_amd_selection must be 'whole_lane'")
+
+        _validate_minimum_permission(
+            self.minimum_compute_permission,
+            label="minimum compute permission",
+        )
+        _validate_minimum_permission(
+            self.minimum_refresh_permission,
+            label="minimum refresh permission",
+        )
+        _validate_minimum_permission(
+            self.minimum_credit_grant_permission,
+            label="minimum credit grant permission",
+        )
+        committer_teams = _normalized_team_slugs(
+            self.committer_teams,
+            label="committer teams",
+        )
+        credit_admin_teams = _normalized_team_slugs(
+            self.credit_admin_teams,
+            label="credit admin teams",
+        )
+
+        _non_negative_int(self.initial_credits, label="initial grant")
+        if self.credit_reset != "none":
+            raise PolicyValidationError("credit reset must be 'none'")
+
+        retry_states = frozenset(self.retry_states)
+        if not retry_states or not retry_states <= _RETRY_STATES:
+            raise PolicyValidationError(
+                "retry states must contain only failed, timed_out, and expired"
+            )
+        _positive_int(
+            self.confirmation_distinct_shas,
+            label="confirmation distinct SHAs",
+        )
+        _positive_int(
+            self.resolution_clean_distinct_shas,
+            label="resolution clean distinct SHAs",
+        )
+        _positive_int(
+            self.evidence_max_age_hours,
+            label="evidence max age hours",
+        )
+
+        object.__setattr__(self, "catalog_groups", groups)
+        object.__setattr__(self, "catalog_aliases", aliases)
+        object.__setattr__(self, "catalog_tombstones", tombstones)
+        object.__setattr__(self, "catalog_area_aliases", area_aliases)
+        object.__setattr__(
+            self,
+            "catalog_area_tombstones",
+            area_tombstones,
+        )
+        object.__setattr__(self, "committer_teams", committer_teams)
+        object.__setattr__(
+            self,
+            "credit_admin_teams",
+            credit_admin_teams,
+        )
+        object.__setattr__(self, "retry_states", retry_states)
+
+    @classmethod
+    def from_toml(cls, document: str) -> Policy:
+        """Parse one complete reviewed TOML policy document."""
+
+        if not isinstance(document, str):
+            raise PolicyValidationError("policy TOML must be text")
+        try:
+            value = tomllib.loads(document)
+        except tomllib.TOMLDecodeError as exc:
+            raise PolicyValidationError(f"invalid policy TOML: {exc}") from exc
+        return cls.from_mapping(value)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> Policy:
+        """Parse the exact nested shape of ``.buildkite/ci_control.toml``."""
+
+        root = _exact_mapping(
+            value,
+            required={
+                "api_version",
+                "catalog",
+                "authorization",
+                "credits",
+                "retry",
+                "main_status",
+            },
+            label="policy",
+        )
+        catalog = _exact_mapping(
+            root["catalog"],
+            required={
+                "groups",
+                "aliases",
+                "tombstones",
+                "area_aliases",
+                "area_tombstones",
+                "native_amd_selection",
+            },
+            label="catalog",
+        )
+        authorization = _exact_mapping(
+            root["authorization"],
+            required={
+                "minimum_compute_permission",
+                "minimum_refresh_permission",
+                "minimum_credit_grant_permission",
+                "committer_teams",
+                "credit_admin_teams",
+            },
+            label="authorization",
+        )
+        credits = _exact_mapping(
+            root["credits"],
+            required={"initial_grant", "reset"},
+            label="credits",
+        )
+        retry = _exact_mapping(
+            root["retry"],
+            required={"failures_limit", "include_states"},
+            label="retry",
+        )
+        main_status = _exact_mapping(
+            root["main_status"],
+            required={
+                "confirmation_distinct_shas",
+                "resolution_clean_distinct_shas",
+                "evidence_max_age_hours",
+            },
+            label="main_status",
+        )
+
+        raw_aliases = _mapping(catalog["aliases"], label="catalog aliases")
+        aliases: list[tuple[str, str]] = []
+        for alias, target in raw_aliases.items():
+            if not isinstance(alias, str) or not isinstance(target, str):
+                raise PolicyValidationError(
+                    "catalog aliases must map strings to strings"
+                )
+            aliases.append((alias, target))
+        raw_area_aliases = _mapping(
+            catalog["area_aliases"],
+            label="catalog area aliases",
+        )
+        area_aliases: list[tuple[str, str]] = []
+        for alias, target in raw_area_aliases.items():
+            if not isinstance(alias, str) or not isinstance(target, str):
+                raise PolicyValidationError(
+                    "catalog area aliases must map strings to strings"
+                )
+            area_aliases.append((alias, target))
+
+        return cls(
+            api_version=_integer(root["api_version"], label="api_version"),
+            catalog_groups=frozenset(
+                _string_list(catalog["groups"], label="catalog groups")
+            ),
+            catalog_aliases=tuple(aliases),
+            catalog_tombstones=tuple(
+                _string_list(
+                    catalog["tombstones"],
+                    label="catalog tombstones",
+                )
+            ),
+            catalog_area_aliases=tuple(area_aliases),
+            catalog_area_tombstones=tuple(
+                _string_list(
+                    catalog["area_tombstones"],
+                    label="catalog area tombstones",
+                )
+            ),
+            native_amd_selection=_string(
+                catalog["native_amd_selection"],
+                label="native_amd_selection",
+            ),
+            minimum_compute_permission=_permission(
+                authorization["minimum_compute_permission"],
+                label="minimum compute permission",
+            ),
+            minimum_refresh_permission=_permission(
+                authorization["minimum_refresh_permission"],
+                label="minimum refresh permission",
+            ),
+            minimum_credit_grant_permission=_permission(
+                authorization["minimum_credit_grant_permission"],
+                label="minimum credit grant permission",
+            ),
+            committer_teams=tuple(
+                _string_list(
+                    authorization["committer_teams"],
+                    label="committer teams",
+                )
+            ),
+            credit_admin_teams=tuple(
+                _string_list(
+                    authorization["credit_admin_teams"],
+                    label="credit admin teams",
+                )
+            ),
+            initial_credits=_integer(
+                credits["initial_grant"],
+                label="initial grant",
+            ),
+            credit_reset=_string(credits["reset"], label="credit reset"),
+            retry_limit=RetryLimit.parse(retry["failures_limit"]),
+            retry_states=frozenset(
+                _string_list(
+                    retry["include_states"],
+                    label="retry include states",
+                )
+            ),
+            confirmation_distinct_shas=_integer(
+                main_status["confirmation_distinct_shas"],
+                label="confirmation distinct SHAs",
+            ),
+            resolution_clean_distinct_shas=_integer(
+                main_status["resolution_clean_distinct_shas"],
+                label="resolution clean distinct SHAs",
+            ),
+            evidence_max_age_hours=_integer(
+                main_status["evidence_max_age_hours"],
+                label="evidence max age hours",
+            ),
+        )
+
+    def can_mutate(
+        self,
+        permission: RepositoryPermission,
+        teams: frozenset[str] = frozenset(),
+    ) -> bool:
+        """Return whether a caller may dispatch or retry compute."""
+
+        return _permission_at_least(
+            permission,
+            self.minimum_compute_permission,
+        ) or bool(set(teams) & set(self.committer_teams))
+
+    def can_refresh(
+        self,
+        permission: RepositoryPermission,
+        teams: frozenset[str] = frozenset(),
+    ) -> bool:
+        """Return whether a caller may refresh main-branch evidence."""
+
+        return _permission_at_least(
+            permission,
+            self.minimum_refresh_permission,
+        ) or bool(set(teams) & set(self.committer_teams))
+
+    def can_receive_compute_credits(
+        self,
+        permission: RepositoryPermission,
+        teams: frozenset[str] = frozenset(),
+    ) -> bool:
+        """Return whether an account may be opened or topped up."""
+
+        return self.can_mutate(permission, teams)
+
+    def can_top_up(
+        self,
+        permission: RepositoryPermission,
+        teams: frozenset[str] = frozenset(),
+    ) -> bool:
+        """Return whether a caller may grant audited credit top-ups."""
+
+        return _permission_at_least(
+            permission,
+            self.minimum_credit_grant_permission,
+        ) or bool(set(teams) & set(self.credit_admin_teams))
+
+
+def _permission_at_least(
+    actual: RepositoryPermission,
+    minimum: RepositoryPermission,
+) -> bool:
+    return _PERMISSION_RANK[actual] >= _PERMISSION_RANK[minimum]
+
+
+def _validate_minimum_permission(
+    value: RepositoryPermission,
+    *,
+    label: str,
+) -> None:
+    if _PERMISSION_RANK[value] < _PERMISSION_RANK[RepositoryPermission.WRITE]:
+        raise PolicyValidationError(f"{label} must be write or higher")
+
+
+def _normalized_team_slugs(
+    values: tuple[str, ...],
+    *,
+    label: str,
+) -> tuple[str, ...]:
+    result = tuple(sorted(values))
+    if len(result) != len(set(result)):
+        raise PolicyValidationError(f"{label} must be unique")
+    for value in result:
+        if (
+            not isinstance(value, str)
+            or not value
+            or len(value) > 100
+            or value.strip() != value
+            or not all(
+                character.isascii()
+                and (character.islower() or character.isdigit() or character == "-")
+                for character in value
+            )
+        ):
+            raise PolicyValidationError(
+                f"{label} must contain normalized GitHub team slugs"
+            )
+    return result
+
+
+def _exact_mapping(
+    value: object,
+    *,
+    required: set[str],
+    label: str,
+) -> Mapping[str, object]:
+    result = _mapping(value, label=label)
+    keys = set(result)
+    missing = required - keys
+    unknown = keys - required
+    if missing:
+        raise PolicyValidationError(
+            f"{label} is missing fields: " + ", ".join(sorted(missing))
+        )
+    if unknown:
+        raise PolicyValidationError(
+            f"{label} has unknown fields: " + ", ".join(sorted(unknown))
+        )
+    return result
+
+
+def _mapping(value: object, *, label: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise PolicyValidationError(f"{label} must be an object")
+    if not all(isinstance(key, str) for key in value):
+        raise PolicyValidationError(f"{label} keys must be strings")
+    return value
+
+
+def _string_list(value: object, *, label: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise PolicyValidationError(f"{label} must be a list of strings")
+    return value
+
+
+def _string(value: object, *, label: str) -> str:
+    if not isinstance(value, str):
+        raise PolicyValidationError(f"{label} must be text")
+    return value
+
+
+def _integer(value: object, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise PolicyValidationError(f"{label} must be an integer")
+    return value
+
+
+def _positive_int(value: object, *, label: str) -> int:
+    result = _integer(value, label=label)
+    if result < 1:
+        raise PolicyValidationError(f"{label} must be positive")
+    return result
+
+
+def _non_negative_int(value: object, *, label: str) -> int:
+    result = _integer(value, label=label)
+    if result < 0:
+        raise PolicyValidationError(f"{label} must be non-negative")
+    return result
+
+
+def _permission(
+    value: object,
+    *,
+    label: str,
+) -> RepositoryPermission:
+    text = _string(value, label=label)
+    try:
+        return RepositoryPermission(text)
+    except ValueError as exc:
+        raise PolicyValidationError(f"{label} is not recognized") from exc

--- a/services/ci-control/src/vllm_ci_control/ports.py
+++ b/services/ci-control/src/vllm_ci_control/ports.py
@@ -1,0 +1,57 @@
+"""Storage and external-service ports for the pure domain package."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from .catalog import Catalog
+from .credits import CreditAccount
+from .models import RepositoryPermission
+
+
+@runtime_checkable
+class CatalogPort(Protocol):
+    """Load an immutable catalog revision from trusted storage."""
+
+    def load_catalog(self, version: str | None = None) -> Catalog:
+        """Return the requested catalog, or the current trusted revision."""
+
+
+@runtime_checkable
+class CreditAccountPort(Protocol):
+    """Persist credit state with optimistic compare-and-swap semantics."""
+
+    def load_account(self, user_id: str) -> CreditAccount | None:
+        """Return one account if it already exists."""
+
+    def compare_and_swap(
+        self,
+        *,
+        user_id: str,
+        expected_version: int | None,
+        account: CreditAccount,
+    ) -> bool:
+        """Atomically persist state when the stored version still matches."""
+
+
+@runtime_checkable
+class PermissionPort(Protocol):
+    """Read live authorization from a repository-bound adapter."""
+
+    def repository_permission(
+        self,
+        username: str,
+    ) -> RepositoryPermission:
+        """Return the caller's current base repository permission."""
+
+
+@runtime_checkable
+class TeamMembershipPort(Protocol):
+    """Read live team membership from a repository-bound adapter."""
+
+    def is_team_member(
+        self,
+        team_slug: str,
+        username: str,
+    ) -> bool:
+        """Return whether the caller is an active member of the named team."""

--- a/services/ci-control/src/vllm_ci_control/repository_catalog.py
+++ b/services/ci-control/src/vllm_ci_control/repository_catalog.py
@@ -1,0 +1,495 @@
+"""Compile the reviewed vLLM Buildkite sources into a selector catalog."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from .catalog import (
+    AreaAlias,
+    AreaTombstone,
+    Catalog,
+    CatalogValidationError,
+    ExecutionKind,
+    JobAlias,
+    JobDefinition,
+    JobTombstone,
+    validate_catalog_evolution,
+)
+from .policy import Policy
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - exercised by packaging, not logic
+    yaml = None
+
+
+class RepositoryCatalogError(ValueError):
+    """Repository CI sources cannot produce a safe deterministic catalog."""
+
+
+_PRIMARY_PIPELINE = "ci"
+_NATIVE_AMD_PIPELINE = "amd-ci"
+_CPU_FILE = Path(".buildkite/hardware_tests/cpu.yaml")
+_AMD_PREREQUISITES_FILE = Path(".buildkite/hardware_tests/amd.yaml")
+_DEFINITION_SCHEMA = "buildkite-effective-v1"
+_DIRECT_EXECUTION_FIELDS = (
+    "commands",
+    "working_dir",
+    "device",
+    "agent_tags",
+    "num_devices",
+    "num_nodes",
+    "soft_fail",
+    "parallelism",
+    "timeout_in_minutes",
+    "mount_buildkite_agent",
+    "env",
+    "retry",
+    "no_plugin",
+    "no_gpu",
+    "dind",
+)
+
+
+def compile_repository_catalog(repository_root: Path) -> Catalog:
+    """Compile selectable jobs from one trusted vLLM default-branch checkout."""
+
+    root = repository_root.resolve()
+    policy_path = root / ".buildkite/ci_control.toml"
+    policy = Policy.from_toml(_read_text(policy_path))
+    required_groups = {"upstream", "cpu", "amd"}
+    if not required_groups <= policy.catalog_groups:
+        raise RepositoryCatalogError(
+            "catalog policy must define upstream, cpu, and amd groups"
+        )
+
+    source_files = [
+        *sorted((root / ".buildkite/image_build").glob("*.yaml")),
+        *sorted((root / ".buildkite/test_areas").glob("*.yaml")),
+        root / _CPU_FILE,
+        root / _AMD_PREREQUISITES_FILE,
+    ]
+    jobs: list[JobDefinition] = []
+    for source_path in source_files:
+        jobs.extend(_compile_source(root, source_path))
+
+    native_path = root / ".buildkite/test-amd.yaml"
+    native_document = _load_yaml(native_path)
+    native_steps = _step_list(native_document, native_path)
+    if policy.native_amd_selection == "whole_lane":
+        jobs.append(
+            JobDefinition(
+                job_id="native-amd-lane",
+                groups=frozenset({"amd"}),
+                areas=frozenset({"native-amd"}),
+                pipeline=_NATIVE_AMD_PIPELINE,
+                execution_profile="amd-native",
+                execution_kind=ExecutionKind.OPAQUE_PIPELINE,
+                shards=sum(_parallelism(step, native_path) for step in native_steps),
+                definition_digest=_definition_digest(
+                    _opaque_pipeline_definition(native_steps)
+                ),
+            )
+        )
+
+    unknown_groups = {
+        group
+        for job in jobs
+        for group in job.groups
+        if group not in policy.catalog_groups
+    }
+    if unknown_groups:
+        raise RepositoryCatalogError(
+            "compiled jobs use groups outside protected policy: "
+            + ", ".join(sorted(unknown_groups))
+        )
+
+    aliases = tuple(JobAlias(alias, target) for alias, target in policy.catalog_aliases)
+    tombstones = tuple(
+        JobTombstone(
+            job_id,
+            reason="retired by protected repository policy",
+        )
+        for job_id in policy.catalog_tombstones
+    )
+    area_aliases = tuple(
+        AreaAlias(alias, target) for alias, target in policy.catalog_area_aliases
+    )
+    area_tombstones = tuple(
+        AreaTombstone(
+            area_id,
+            reason="retired by protected repository policy",
+        )
+        for area_id in policy.catalog_area_tombstones
+    )
+    try:
+        return Catalog(
+            version=f"schema-{policy.api_version}",
+            jobs=tuple(jobs),
+            aliases=aliases,
+            tombstones=tombstones,
+            area_aliases=area_aliases,
+            area_tombstones=area_tombstones,
+        )
+    except CatalogValidationError as error:
+        raise RepositoryCatalogError(str(error)) from error
+
+
+def _compile_source(
+    root: Path,
+    source_path: Path,
+) -> list[JobDefinition]:
+    document = _load_yaml(source_path)
+    steps = _step_list(document, source_path)
+    relative = source_path.relative_to(root)
+    group_dependencies = _dependencies(
+        document.get("depends_on", []),
+        source_path,
+    )
+
+    jobs = []
+    for step in steps:
+        key = step.get("key")
+        if not isinstance(key, str) or not key:
+            raise RepositoryCatalogError(
+                f"{relative}: selectable step {step.get('label')!r} "
+                "requires an explicit key"
+            )
+        metadata = _metadata(step, source_path)
+        dependencies = _dependencies(
+            step.get("depends_on") or group_dependencies,
+            source_path,
+        )
+        groups, areas, selectable = _classify(
+            relative=relative,
+            key=key,
+            metadata=metadata,
+        )
+        profile = _profile(step.get("device"))
+        jobs.append(
+            JobDefinition(
+                job_id=key,
+                groups=groups,
+                areas=areas,
+                dependencies=dependencies,
+                pipeline=_PRIMARY_PIPELINE,
+                execution_profile=profile,
+                shards=_parallelism(step, source_path),
+                selectable=selectable,
+                definition_digest=_definition_digest(
+                    _direct_execution_definition(step, dependencies)
+                ),
+            )
+        )
+
+        mirror = step.get("mirror")
+        if mirror is None:
+            continue
+        if not isinstance(mirror, Mapping):
+            raise RepositoryCatalogError(f"{relative}: mirror must be an object")
+        amd = mirror.get("amd")
+        if amd is None:
+            continue
+        if not isinstance(amd, Mapping):
+            raise RepositoryCatalogError(f"{relative}: mirror.amd must be an object")
+        mirror_dependencies = _normalize_amd_dependencies(
+            _dependencies(
+                amd.get("depends_on"),
+                source_path,
+            )
+        )
+        mirror_id = f"{key}-amd"
+        jobs.append(
+            JobDefinition(
+                job_id=mirror_id,
+                groups=frozenset({"amd"}),
+                areas=areas,
+                dependencies=mirror_dependencies,
+                pipeline=_PRIMARY_PIPELINE,
+                execution_profile=_profile(amd.get("device"), prefix="amd"),
+                shards=_parallelism(step, source_path),
+                selectable=selectable,
+                definition_digest=_definition_digest(
+                    _amd_execution_definition(
+                        step,
+                        amd,
+                        mirror_dependencies,
+                    )
+                ),
+            )
+        )
+    return jobs
+
+
+def _classify(
+    *,
+    relative: Path,
+    key: str,
+    metadata: Mapping[str, Any],
+) -> tuple[frozenset[str], frozenset[str], bool]:
+    explicit_groups = metadata.get("groups")
+    explicit_areas = metadata.get("areas")
+    structurally_internal = relative == _AMD_PREREQUISITES_FILE or relative.parts[
+        :2
+    ] == (".buildkite", "image_build")
+    selectable = bool(metadata.get("selectable", True)) and not structurally_internal
+
+    if explicit_groups is not None:
+        groups = frozenset(_string_sequence(explicit_groups, "ci_control.groups"))
+    elif relative == _CPU_FILE:
+        groups = frozenset({"cpu"})
+    elif relative == _AMD_PREREQUISITES_FILE:
+        groups = frozenset({"amd"})
+    elif relative.parts[:2] == (".buildkite", "image_build"):
+        if "amd" in key:
+            groups = frozenset({"amd"})
+        elif "cpu" in key or "arm" in key:
+            groups = frozenset({"cpu"})
+        else:
+            groups = frozenset({"upstream"})
+    else:
+        groups = frozenset({"upstream"})
+
+    if explicit_areas is not None:
+        areas = frozenset(_string_sequence(explicit_areas, "ci_control.areas"))
+    elif relative.parts[:2] == (".buildkite", "test_areas"):
+        stem = relative.stem.replace("_", "-")
+        values = {stem}
+        if stem.startswith("model"):
+            values.add("models")
+        areas = frozenset(values)
+    else:
+        areas = frozenset({"infrastructure"})
+    return groups, areas, selectable
+
+
+def _metadata(
+    step: Mapping[str, Any],
+    source_path: Path,
+) -> Mapping[str, Any]:
+    value = step.get("ci_control", {})
+    if not isinstance(value, Mapping):
+        raise RepositoryCatalogError(f"{source_path}: ci_control must be an object")
+    unknown = set(value) - {"groups", "areas", "selectable"}
+    if unknown:
+        raise RepositoryCatalogError(
+            f"{source_path}: unknown ci_control fields: " + ", ".join(sorted(unknown))
+        )
+    if "selectable" in value and not isinstance(value["selectable"], bool):
+        raise RepositoryCatalogError(
+            f"{source_path}: ci_control.selectable must be boolean"
+        )
+    return value
+
+
+def _load_yaml(path: Path) -> Mapping[str, Any]:
+    if yaml is None:
+        raise RepositoryCatalogError(
+            "PyYAML is required; install the repository-validation extra"
+        )
+    try:
+        value = yaml.safe_load(_read_text(path))
+    except yaml.YAMLError as error:
+        raise RepositoryCatalogError(f"{path}: invalid YAML: {error}") from error
+    if not isinstance(value, Mapping):
+        raise RepositoryCatalogError(f"{path}: root must be an object")
+    return value
+
+
+def _step_list(
+    document: Mapping[str, Any],
+    source_path: Path,
+) -> list[Mapping[str, Any]]:
+    steps = document.get("steps")
+    if not isinstance(steps, list) or not all(
+        isinstance(step, Mapping) for step in steps
+    ):
+        raise RepositoryCatalogError(
+            f"{source_path}: steps must be an array of objects"
+        )
+    return list(steps)
+
+
+def _dependencies(value: Any, source_path: Path) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    values = _string_sequence(value, f"{source_path}: depends_on")
+    if len(values) != len(set(values)):
+        raise RepositoryCatalogError(f"{source_path}: depends_on contains duplicates")
+    return tuple(values)
+
+
+def _normalize_amd_dependencies(dependencies: tuple[str, ...]) -> tuple[str, ...]:
+    """Match the pipeline generator's AMD dependency normalization."""
+
+    normalized = []
+    for dependency in dependencies:
+        value = "image-build-amd" if dependency == "image-build" else dependency
+        if value not in normalized:
+            normalized.append(value)
+    if "image-build-amd" not in normalized:
+        normalized.insert(0, "image-build-amd")
+    return tuple(normalized)
+
+
+def _string_sequence(value: Any, label: str) -> list[str]:
+    if not isinstance(value, (list, tuple)) or not all(
+        isinstance(item, str) and item for item in value
+    ):
+        raise RepositoryCatalogError(f"{label} must be an array of non-empty strings")
+    return list(value)
+
+
+def _parallelism(step: Mapping[str, Any], source_path: Path) -> int:
+    value = step.get("parallelism", 1)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise RepositoryCatalogError(
+            f"{source_path}: parallelism must be a positive integer"
+        )
+    return value
+
+
+def _profile(value: Any, *, prefix: str | None = None) -> str:
+    if value is None:
+        profile = "default"
+    elif isinstance(value, str) and value:
+        profile = value.replace("_", "-")
+    else:
+        raise RepositoryCatalogError("device must be non-empty text")
+    return f"{prefix}-{profile}" if prefix else profile
+
+
+def _direct_execution_definition(
+    step: Mapping[str, Any],
+    dependencies: tuple[str, ...],
+) -> dict[str, Any]:
+    definition = {key: step[key] for key in _DIRECT_EXECUTION_FIELDS if key in step}
+    definition["depends_on"] = sorted(dependencies)
+    return {
+        "kind": ExecutionKind.STEP.value,
+        "schema": _DEFINITION_SCHEMA,
+        "step": definition,
+    }
+
+
+def _opaque_pipeline_definition(
+    steps: list[Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "kind": ExecutionKind.OPAQUE_PIPELINE.value,
+        "schema": _DEFINITION_SCHEMA,
+        "steps": [
+            {
+                key: value
+                for key, value in step.items()
+                if key not in {"ci_control", "key", "label"}
+            }
+            for step in steps
+        ],
+    }
+
+
+def _amd_execution_definition(
+    step: Mapping[str, Any],
+    amd: Mapping[str, Any],
+    dependencies: tuple[str, ...],
+) -> dict[str, Any]:
+    custom_commands = amd.get("commands")
+    source_env = step.get("env")
+    amd_env = amd.get("env")
+    merged_env = {
+        **(source_env if isinstance(source_env, Mapping) else {}),
+        **(amd_env if isinstance(amd_env, Mapping) else {}),
+    }
+    definition = {
+        "agent_tags": amd.get("agent_tags"),
+        "commands": custom_commands or step.get("commands"),
+        "depends_on": sorted(dependencies),
+        "device": amd.get("device"),
+        "dind": amd.get("dind", True),
+        "env": merged_env or None,
+        "no_gpu": amd.get("no_gpu", step.get("no_gpu", False)),
+        "no_plugin": amd.get("no_plugin", False),
+        "num_devices": (
+            amd.get("num_devices") or amd.get("num_gpus") or step.get("num_devices")
+        ),
+        "num_nodes": amd.get("num_nodes", step.get("num_nodes")),
+        "parallelism": step.get("parallelism"),
+        "soft_fail": amd.get("soft_fail", step.get("soft_fail", False)),
+        "timeout_in_minutes": amd.get("timeout_in_minutes"),
+        "working_dir": (
+            amd.get("working_dir", step.get("working_dir"))
+            if custom_commands
+            else step.get("working_dir")
+        ),
+    }
+    return {
+        "kind": "amd-mirror",
+        "schema": _DEFINITION_SCHEMA,
+        "step": definition,
+    }
+
+
+def _definition_digest(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        default=str,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise RepositoryCatalogError(f"cannot read {path}: {error}") from error
+
+
+def main() -> None:
+    """Validate a checkout and print its deterministic catalog summary."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "repository_root",
+        nargs="?",
+        type=Path,
+        default=Path.cwd(),
+    )
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        help="previous repository checkout used for selector compatibility",
+    )
+    arguments = parser.parse_args()
+
+    catalog = compile_repository_catalog(arguments.repository_root)
+    if arguments.baseline is not None:
+        baseline = compile_repository_catalog(arguments.baseline)
+        validate_catalog_evolution(baseline, catalog)
+    if arguments.as_json:
+        print(
+            json.dumps(
+                catalog.to_mapping(),
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        selectable = sum(job.selectable for job in catalog.jobs)
+        print(
+            f"catalog {catalog.version}: {selectable} selectable jobs, "
+            f"{len(catalog.jobs)} total, sha256:{catalog.digest}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/ci-control/src/vllm_ci_control/validation.py
+++ b/services/ci-control/src/vllm_ci_control/validation.py
@@ -1,0 +1,766 @@
+"""Compare an exact PR run with one immutable canonical-main snapshot."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import StrEnum
+
+from .evidence import (
+    GroupId,
+    GroupObservation,
+    MainPosition,
+    Outcome,
+    collapse_distinct_commits,
+)
+from .incidents import Incident, IncidentState
+
+_SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+_MAX_TEXT_LENGTH = 500
+
+
+class Classification(StrEnum):
+    """Advisory relationship between a PR failure and current main evidence."""
+
+    KNOWN_ON_MAIN = "known_on_main"
+    CANDIDATE_ON_MAIN = "candidate_on_main"
+    SEEN_FLAKY_ON_MAIN = "seen_flaky_on_main"
+    RECOVERING_ON_MAIN = "recovering_on_main"
+    RESOLVED_ON_MAIN = "resolved_on_main"
+    DIFFERENT_FAILURE_ON_MAIN = "different_failure_on_main"
+    GROUP_ALSO_RED_ON_MAIN = "group_also_red_on_main"
+    NOT_MATCHED_ON_MAIN = "not_matched_on_main"
+    UNABLE_TO_CLASSIFY = "unable_to_classify"
+
+
+class LaneCompleteness(StrEnum):
+    """Completeness of one provider lane at a frozen scan watermark."""
+
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True, order=True)
+class LaneSnapshot:
+    """One lane's frozen completeness and canonical-main watermark."""
+
+    lane: str
+    completeness: LaneCompleteness
+    watermark: MainPosition | None
+
+    def __post_init__(self) -> None:
+        _validate_text(self.lane, label="lane")
+        if self.completeness is LaneCompleteness.COMPLETE and self.watermark is None:
+            raise ValueError("a complete lane requires a main watermark")
+
+
+@dataclass(frozen=True)
+class SnapshotGroup:
+    """One incident and its evidence captured atomically."""
+
+    incident: Incident
+    history: tuple[GroupObservation, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.incident.latest_attempted_observation is None:
+            raise ValueError("snapshot incidents require attempted evidence")
+        history = tuple(self.history)
+        latest = self.incident.latest_attempted_observation
+        assert latest is not None
+        if latest not in history:
+            history = (*history, latest)
+        for observation in history:
+            if observation.group != self.incident.group:
+                raise ValueError("snapshot history identities must match")
+            if not observation.trusted_main or observation.main_position is None:
+                raise ValueError(
+                    "snapshot history must have trusted canonical-main provenance"
+                )
+        object.__setattr__(
+            self,
+            "history",
+            tuple(sorted(history, key=lambda item: item.main_position)),
+        )
+
+    @property
+    def latest_observation(self) -> GroupObservation:
+        observation = self.incident.latest_attempted_observation
+        assert observation is not None
+        return observation
+
+
+@dataclass(frozen=True)
+class MainSnapshot:
+    """A revisioned, immutable view used for one complete validation."""
+
+    revision: str
+    catalog_version: str
+    catalog_digest: str
+    policy_revision: str
+    algorithm_revision: str
+    generated_at: datetime
+    max_evidence_age: timedelta
+    lanes: tuple[LaneSnapshot, ...]
+    groups: tuple[SnapshotGroup, ...]
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("revision", self.revision),
+            ("catalog version", self.catalog_version),
+            ("catalog digest", self.catalog_digest),
+            ("policy revision", self.policy_revision),
+            ("algorithm revision", self.algorithm_revision),
+        ):
+            _validate_text(value, label=label)
+        if self.generated_at.tzinfo is None:
+            raise ValueError("generated_at must be timezone-aware")
+        if self.max_evidence_age < timedelta(0):
+            raise ValueError("max_evidence_age must not be negative")
+
+        lane_ids = [item.lane for item in self.lanes]
+        if len(lane_ids) != len(set(lane_ids)):
+            raise ValueError("snapshot contains duplicate lanes")
+        identities = [item.incident.group for item in self.groups]
+        if len(identities) != len(set(identities)):
+            raise ValueError("snapshot contains duplicate group identities")
+
+        lanes = self.by_lane
+        for item in self.groups:
+            lane = lanes.get(item.incident.group.pipeline)
+            if lane is None:
+                raise ValueError("snapshot group has no corresponding lane")
+            for observation in item.history:
+                if (
+                    lane.watermark is not None
+                    and observation.main_position > lane.watermark
+                ):
+                    raise ValueError("group evidence is newer than its lane watermark")
+
+    @property
+    def by_group(self) -> dict[GroupId, SnapshotGroup]:
+        return {item.incident.group: item for item in self.groups}
+
+    @property
+    def by_lane(self) -> dict[str, LaneSnapshot]:
+        return {item.lane: item for item in self.lanes}
+
+
+@dataclass(frozen=True)
+class PullRequestRunSubject:
+    """Immutable identity of the PR and provider run being classified."""
+
+    repository: str
+    pull_request_number: int
+    head_sha: str
+    tested_head_sha: str
+    base_sha: str
+    base_ancestor_shas: frozenset[str]
+
+    def __post_init__(self) -> None:
+        _validate_text(self.repository, label="repository")
+        if self.pull_request_number < 1:
+            raise ValueError("pull_request_number must be positive")
+        for label, value in (
+            ("head SHA", self.head_sha),
+            ("tested head SHA", self.tested_head_sha),
+            ("base SHA", self.base_sha),
+        ):
+            _validate_sha(value, label=label)
+        ancestors = frozenset(self.base_ancestor_shas)
+        for value in ancestors:
+            _validate_sha(value, label="base ancestor SHA")
+        if self.base_sha not in ancestors:
+            raise ValueError("base_ancestor_shas must include base_sha")
+        object.__setattr__(self, "base_ancestor_shas", ancestors)
+
+
+@dataclass(frozen=True)
+class PullRequestFailure:
+    """One current failing PR group, optionally with normalized identity."""
+
+    label: str
+    group: GroupId | None
+    build_url: str
+    failure_fingerprint: str | None = None
+    execution_profile: str | None = None
+    definition_digest: str | None = None
+
+    def __post_init__(self) -> None:
+        _validate_text(self.label, label="failure label")
+        _validate_text(self.build_url, label="failure build URL")
+        for label, value in (
+            ("failure fingerprint", self.failure_fingerprint),
+            ("execution profile", self.execution_profile),
+            ("definition digest", self.definition_digest),
+        ):
+            if value is not None:
+                _validate_text(value, label=label)
+
+
+@dataclass(frozen=True)
+class ClassifiedFailure:
+    """Validation result for one PR failure."""
+
+    failure: PullRequestFailure
+    classification: Classification
+    explanation: str
+    main_evidence: GroupObservation | None = None
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    """All classifications produced against exactly one snapshot revision."""
+
+    pull_request_head: str
+    pull_request_base: str
+    snapshot_revision: str
+    evaluated_at: datetime
+    stale_head: bool
+    stale_base: bool
+    results: tuple[ClassifiedFailure, ...]
+
+
+def create_snapshot(
+    *,
+    catalog_version: str,
+    catalog_digest: str,
+    policy_revision: str,
+    algorithm_revision: str,
+    generated_at: datetime,
+    max_evidence_age: timedelta,
+    lanes: Iterable[LaneSnapshot],
+    incidents: Iterable[Incident],
+    observations: Iterable[GroupObservation] = (),
+) -> MainSnapshot:
+    """Create a digest over every frozen field that affects classification."""
+
+    lane_values = tuple(sorted(lanes, key=lambda item: item.lane))
+    history_by_group: dict[GroupId, list[GroupObservation]] = {}
+    for observation in collapse_distinct_commits(observations):
+        history_by_group.setdefault(observation.group, []).append(observation)
+    groups = tuple(
+        SnapshotGroup(
+            incident=incident,
+            history=tuple(history_by_group.get(incident.group, ())),
+        )
+        for incident in sorted(incidents, key=lambda item: item.group)
+        if incident.latest_attempted_observation is not None
+    )
+    payload = {
+        "algorithm_revision": algorithm_revision,
+        "catalog_digest": catalog_digest,
+        "catalog_version": catalog_version,
+        "generated_at": generated_at.isoformat(),
+        "groups": [
+            {
+                "history": [
+                    _serialize_observation(observation) for observation in item.history
+                ],
+                "incident": _serialize_incident(item.incident),
+            }
+            for item in groups
+        ],
+        "lanes": [
+            {
+                "completeness": item.completeness.value,
+                "lane": item.lane,
+                "watermark": _serialize_position(item.watermark),
+            }
+            for item in lane_values
+        ],
+        "max_evidence_age_microseconds": _timedelta_microseconds(max_evidence_age),
+        "policy_revision": policy_revision,
+    }
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    revision = hashlib.sha256(encoded).hexdigest()
+    return MainSnapshot(
+        revision=revision,
+        catalog_version=catalog_version,
+        catalog_digest=catalog_digest,
+        policy_revision=policy_revision,
+        algorithm_revision=algorithm_revision,
+        generated_at=generated_at,
+        max_evidence_age=max_evidence_age,
+        lanes=lane_values,
+        groups=groups,
+    )
+
+
+def validate_pull_request(
+    *,
+    subject: PullRequestRunSubject,
+    current_head: str,
+    current_base: str,
+    pr_catalog_version: str,
+    pr_catalog_digest: str,
+    failures: Iterable[PullRequestFailure],
+    snapshot: MainSnapshot,
+    now: datetime,
+) -> ValidationReport:
+    """Classify failures without mixing heads, bases, lanes, or revisions."""
+
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    _validate_sha(current_head, label="current head SHA")
+    _validate_sha(current_base, label="current base SHA")
+    _validate_text(pr_catalog_version, label="PR catalog version")
+    _validate_text(pr_catalog_digest, label="PR catalog digest")
+    failure_list = tuple(failures)
+
+    if subject.head_sha != current_head:
+        return _unable_report(
+            subject=subject,
+            snapshot=snapshot,
+            failures=failure_list,
+            evaluated_at=now,
+            stale_head=True,
+            stale_base=False,
+            explanation=(
+                "The pull-request head changed during validation; run status "
+                "again for the current commit."
+            ),
+        )
+    if subject.base_sha != current_base:
+        return _unable_report(
+            subject=subject,
+            snapshot=snapshot,
+            failures=failure_list,
+            evaluated_at=now,
+            stale_head=False,
+            stale_base=True,
+            explanation=(
+                "The pull-request base changed during validation; refresh the "
+                "exact-head run subject."
+            ),
+        )
+    if subject.tested_head_sha != subject.head_sha:
+        return _unable_report(
+            subject=subject,
+            snapshot=snapshot,
+            failures=failure_list,
+            evaluated_at=now,
+            stale_head=False,
+            stale_base=False,
+            explanation=(
+                "The provider result was not produced from the exact requested "
+                "pull-request head."
+            ),
+        )
+    if pr_catalog_version != snapshot.catalog_version:
+        return _unable_report(
+            subject=subject,
+            snapshot=snapshot,
+            failures=failure_list,
+            evaluated_at=now,
+            stale_head=False,
+            stale_base=False,
+            explanation=("The PR and main builds use incompatible CI catalog schemas."),
+        )
+
+    snapshot_groups = snapshot.by_group
+    snapshot_lanes = snapshot.by_lane
+    results = []
+    for failure in failure_list:
+        if failure.group is None:
+            results.append(
+                _unable(
+                    failure,
+                    "The failing job has no stable step key.",
+                )
+            )
+            continue
+
+        lane = snapshot_lanes.get(failure.group.pipeline)
+        if lane is None or lane.completeness is not LaneCompleteness.COMPLETE:
+            results.append(
+                _unable(
+                    failure,
+                    "The comparable main lane is partial or unavailable.",
+                )
+            )
+            continue
+
+        main = snapshot_groups.get(failure.group)
+        if main is None:
+            results.append(
+                _unable(
+                    failure,
+                    "The stable group has no comparable main observation.",
+                )
+            )
+            continue
+
+        latest = main.latest_observation
+        age = now - latest.observed_at
+        if age < timedelta(0) or age > snapshot.max_evidence_age:
+            results.append(
+                _unable(
+                    failure,
+                    "The latest comparable main evidence is stale.",
+                    latest,
+                )
+            )
+            continue
+        if latest.outcome is Outcome.INCONCLUSIVE:
+            results.append(
+                _unable(
+                    failure,
+                    "The latest main attempt is incomplete or inconclusive.",
+                    latest,
+                )
+            )
+            continue
+
+        results.append(
+            _classify(
+                failure,
+                main,
+                subject,
+                now=now,
+                max_evidence_age=snapshot.max_evidence_age,
+            )
+        )
+
+    return ValidationReport(
+        pull_request_head=subject.head_sha,
+        pull_request_base=subject.base_sha,
+        snapshot_revision=snapshot.revision,
+        evaluated_at=now,
+        stale_head=False,
+        stale_base=False,
+        results=tuple(results),
+    )
+
+
+class _FingerprintRelation(StrEnum):
+    EXACT = "exact"
+    DIFFERENT = "different"
+    UNVERIFIED = "unverified"
+
+
+def _classify(
+    failure: PullRequestFailure,
+    main: SnapshotGroup,
+    subject: PullRequestRunSubject,
+    *,
+    now: datetime,
+    max_evidence_age: timedelta,
+) -> ClassifiedFailure:
+    incident = main.incident
+    latest = main.latest_observation
+    if not _execution_compatible(failure, latest):
+        return _unable(
+            failure,
+            "Main evidence lacks a compatible execution profile or "
+            "test-definition digest.",
+            latest,
+        )
+    relation = _fingerprint_relation(failure, latest)
+
+    if latest.outcome is Outcome.FAILED:
+        if relation is _FingerprintRelation.EXACT:
+            fingerprint_confirmed = (
+                failure.failure_fingerprint in incident.confirmed_failure_fingerprints
+            )
+            if incident.state is IncidentState.KNOWN and fingerprint_confirmed:
+                return _classified(
+                    failure,
+                    Classification.KNOWN_ON_MAIN,
+                    "The exact compatible failure fingerprint is confirmed "
+                    "and currently failing on main.",
+                    latest,
+                )
+            if incident.state in {
+                IncidentState.CANDIDATE,
+                IncidentState.KNOWN,
+            }:
+                return _classified(
+                    failure,
+                    Classification.CANDIDATE_ON_MAIN,
+                    "The exact compatible failure fingerprint is currently "
+                    "failing on main but is below the confirmation threshold.",
+                    latest,
+                )
+        if relation is _FingerprintRelation.DIFFERENT:
+            return _classified(
+                failure,
+                Classification.DIFFERENT_FAILURE_ON_MAIN,
+                "The compatible group is red on main, but its latest normalized "
+                "failure fingerprint differs from the PR failure.",
+                latest,
+            )
+        return _classified(
+            failure,
+            Classification.GROUP_ALSO_RED_ON_MAIN,
+            "The same job group is also red on main; the underlying failure is "
+            "unverified.",
+            latest,
+        )
+
+    if latest.outcome is Outcome.FLAKY:
+        if relation is _FingerprintRelation.DIFFERENT:
+            return _classified(
+                failure,
+                Classification.DIFFERENT_FAILURE_ON_MAIN,
+                "The main group retried to pass, and its observed failure "
+                "fingerprint differs from the PR failure.",
+                latest,
+            )
+        explanation = (
+            "The exact compatible failure fingerprint was seen on main before "
+            "a later pass on the same SHA."
+            if relation is _FingerprintRelation.EXACT
+            else (
+                "The same group failed and later passed on one main SHA; the "
+                "underlying failure is unverified."
+            )
+        )
+        return _classified(
+            failure,
+            Classification.SEEN_FLAKY_ON_MAIN,
+            explanation,
+            latest,
+        )
+
+    if latest.outcome is Outcome.CLEAN:
+        last_failure = incident.last_failure_observation
+        if (
+            last_failure is not None
+            and _fingerprint_relation(failure, last_failure)
+            is _FingerprintRelation.EXACT
+            and failure.failure_fingerprint in incident.confirmed_failure_fingerprints
+            and _execution_compatible(failure, latest)
+        ):
+            if incident.state is IncidentState.RECOVERING:
+                return _classified(
+                    failure,
+                    Classification.RECOVERING_ON_MAIN,
+                    "The exact compatible main failure is now passing but has "
+                    "not reached the clean-resolution threshold.",
+                    latest,
+                )
+            if incident.state is IncidentState.RESOLVED:
+                return _classified(
+                    failure,
+                    Classification.RESOLVED_ON_MAIN,
+                    "The exact compatible main failure reached the configured "
+                    "clean-resolution threshold.",
+                    latest,
+                )
+
+        if incident.state in {
+            IncidentState.RECOVERING,
+            IncidentState.RESOLVED,
+        }:
+            return _unable(
+                failure,
+                "The main group has recovering or resolved history, but the "
+                "underlying failure identity is unverified.",
+                latest,
+            )
+        control = _latest_base_control(
+            failure=failure,
+            main=main,
+            subject=subject,
+            now=now,
+            max_evidence_age=max_evidence_age,
+        )
+        if control is None:
+            return _unable(
+                failure,
+                "No fresh compatible clean observation is a trusted ancestor "
+                "of the pinned pull-request base.",
+                latest,
+            )
+        return _classified(
+            failure,
+            Classification.NOT_MATCHED_ON_MAIN,
+            "The compatible group ran clean on a trusted ancestor of the "
+            "pinned PR base. This is a possible regression, not proof of "
+            "causation.",
+            control,
+        )
+
+    return _unable(
+        failure,
+        "Current main evidence cannot prove a comparable result.",
+        latest,
+    )
+
+
+def _latest_base_control(
+    *,
+    failure: PullRequestFailure,
+    main: SnapshotGroup,
+    subject: PullRequestRunSubject,
+    now: datetime,
+    max_evidence_age: timedelta,
+) -> GroupObservation | None:
+    candidates = []
+    for observation in main.history:
+        age = now - observation.observed_at
+        if (
+            observation.outcome is Outcome.CLEAN
+            and observation.commit in subject.base_ancestor_shas
+            and timedelta(0) <= age <= max_evidence_age
+            and _execution_compatible(failure, observation)
+        ):
+            candidates.append(observation)
+    return max(candidates, key=lambda item: item.main_position, default=None)
+
+
+def _fingerprint_relation(
+    failure: PullRequestFailure,
+    observation: GroupObservation,
+) -> _FingerprintRelation:
+    if not _execution_compatible(failure, observation):
+        return _FingerprintRelation.UNVERIFIED
+    if failure.failure_fingerprint is None or not observation.failure_fingerprints:
+        return _FingerprintRelation.UNVERIFIED
+    if failure.failure_fingerprint in observation.failure_fingerprints:
+        return _FingerprintRelation.EXACT
+    return _FingerprintRelation.DIFFERENT
+
+
+def _execution_compatible(
+    failure: PullRequestFailure,
+    observation: GroupObservation,
+) -> bool:
+    return (
+        failure.execution_profile is not None
+        and failure.definition_digest is not None
+        and failure.execution_profile == observation.execution_profile
+        and failure.definition_digest == observation.definition_digest
+    )
+
+
+def _classified(
+    failure: PullRequestFailure,
+    classification: Classification,
+    explanation: str,
+    evidence: GroupObservation,
+) -> ClassifiedFailure:
+    return ClassifiedFailure(
+        failure=failure,
+        classification=classification,
+        explanation=explanation,
+        main_evidence=evidence,
+    )
+
+
+def _unable(
+    failure: PullRequestFailure,
+    explanation: str,
+    evidence: GroupObservation | None = None,
+) -> ClassifiedFailure:
+    return ClassifiedFailure(
+        failure=failure,
+        classification=Classification.UNABLE_TO_CLASSIFY,
+        explanation=explanation,
+        main_evidence=evidence,
+    )
+
+
+def _unable_report(
+    *,
+    subject: PullRequestRunSubject,
+    snapshot: MainSnapshot,
+    failures: tuple[PullRequestFailure, ...],
+    evaluated_at: datetime,
+    stale_head: bool,
+    stale_base: bool,
+    explanation: str,
+) -> ValidationReport:
+    return ValidationReport(
+        pull_request_head=subject.head_sha,
+        pull_request_base=subject.base_sha,
+        snapshot_revision=snapshot.revision,
+        evaluated_at=evaluated_at,
+        stale_head=stale_head,
+        stale_base=stale_base,
+        results=tuple(_unable(failure, explanation) for failure in failures),
+    )
+
+
+def _serialize_incident(incident: Incident) -> dict[str, object]:
+    return {
+        "clean_count": incident.clean_count,
+        "ever_known": incident.ever_known,
+        "failure_count": incident.failure_count,
+        "confirmed_failure_fingerprints": sorted(
+            incident.confirmed_failure_fingerprints
+        ),
+        "group": _serialize_group(incident.group),
+        "last_conclusive": _serialize_observation(incident.last_conclusive_observation),
+        "last_failure": _serialize_observation(incident.last_failure_observation),
+        "latest_attempted": _serialize_observation(
+            incident.latest_attempted_observation
+        ),
+        "state": incident.state.value,
+    }
+
+
+def _serialize_observation(
+    observation: GroupObservation | None,
+) -> dict[str, object] | None:
+    if observation is None:
+        return None
+    return {
+        "build_number": observation.build_number,
+        "build_url": observation.build_url,
+        "commit": observation.commit,
+        "definition_digest": observation.definition_digest,
+        "execution_profile": observation.execution_profile,
+        "failure_fingerprints": sorted(observation.failure_fingerprints),
+        "group": _serialize_group(observation.group),
+        "main_position": _serialize_position(observation.main_position),
+        "observed_at": observation.observed_at.isoformat(),
+        "outcome": observation.outcome.value,
+        "trusted_main": observation.trusted_main,
+    }
+
+
+def _serialize_group(group: GroupId) -> list[str]:
+    return [group.pipeline, group.step_key, group.variant]
+
+
+def _serialize_position(
+    position: MainPosition | None,
+) -> list[int] | None:
+    return [position.epoch, position.sequence] if position is not None else None
+
+
+def _timedelta_microseconds(value: timedelta) -> int:
+    return (
+        value.days * 24 * 60 * 60 * 1_000_000
+        + value.seconds * 1_000_000
+        + value.microseconds
+    )
+
+
+def _validate_sha(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or _SHA_PATTERN.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a full lowercase SHA")
+    return value
+
+
+def _validate_text(value: object, *, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > _MAX_TEXT_LENGTH
+        or value.strip() != value
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise ValueError(f"{label} must be bounded normalized printable text")
+    return value

--- a/services/ci-control/tests/test_buildkite_adapter.py
+++ b/services/ci-control/tests/test_buildkite_adapter.py
@@ -1,0 +1,131 @@
+from typing import Any
+
+import pytest
+
+from vllm_ci_control.adapters.buildkite import (
+    BuildkiteClient,
+    BuildkiteProtocolError,
+)
+
+
+class FakeTransport:
+    def __init__(self, *responses: Any) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    def request(self, url: str, **kwargs: Any) -> Any:
+        self.calls.append({"url": url, **kwargs})
+        return self.responses.pop(0)
+
+
+def client(transport: FakeTransport, *, max_pages: int = 100):
+    return BuildkiteClient(
+        token="secret",
+        organization="vllm",
+        pipeline="ci",
+        transport=transport,
+        max_pages=max_pages,
+    )
+
+
+def test_get_build_explicitly_requests_retry_history() -> None:
+    transport = FakeTransport({"number": 42, "jobs": []})
+
+    result = client(transport).get_build(42)
+
+    assert result["number"] == 42
+    assert "include_retried_jobs=true" in transport.calls[0]["url"]
+
+
+def test_list_jobs_follows_cursor_until_complete() -> None:
+    next_url = (
+        "https://api.buildkite.com/v2/organizations/vllm/pipelines/ci/"
+        "builds/42/jobs?after=cursor"
+    )
+    transport = FakeTransport(
+        {
+            "items": [{"id": "first"}],
+            "links": {"next": next_url},
+        },
+        {
+            "items": [{"id": "second"}],
+            "links": {"next": None},
+        },
+    )
+
+    jobs = client(transport).list_jobs(42)
+
+    assert [job["id"] for job in jobs] == ["first", "second"]
+    assert len(transport.calls) == 2
+
+
+@pytest.mark.parametrize(
+    "unsafe_url",
+    [
+        "https://evil.example/jobs?after=secret",
+        "http://api.buildkite.com/v2/organizations/vllm/pipelines/ci/builds/42/jobs",
+        "https://api.buildkite.com/v2/organizations/other/pipelines/ci/builds/42/jobs",
+    ],
+)
+def test_list_jobs_rejects_unsafe_provider_cursor(unsafe_url: str) -> None:
+    transport = FakeTransport(
+        {"items": [], "links": {"next": unsafe_url}},
+    )
+
+    with pytest.raises(BuildkiteProtocolError, match="unsafe"):
+        client(transport).list_jobs(42)
+
+
+def test_list_jobs_rejects_cursor_cycles() -> None:
+    first_url = (
+        "https://api.buildkite.com/v2/organizations/vllm/pipelines/ci/"
+        "builds/42/jobs?after=again"
+    )
+    transport = FakeTransport(
+        {"items": [], "links": {"next": first_url}},
+        {"items": [], "links": {"next": first_url}},
+    )
+
+    with pytest.raises(BuildkiteProtocolError, match="cycle"):
+        client(transport).list_jobs(42)
+
+
+def test_list_builds_encodes_exact_filters() -> None:
+    transport = FakeTransport([])
+
+    client(transport).list_builds(
+        branch="main",
+        commit="a" * 40,
+        states=("passed", "failed"),
+        metadata={"ci-control-request": "request:1"},
+    )
+
+    url = transport.calls[0]["url"]
+    assert "branch=main" in url
+    assert f"commit={'a' * 40}" in url
+    assert "state%5B%5D=passed" in url
+    assert "state%5B%5D=failed" in url
+    assert "meta_data%5Bci-control-request%5D=request%3A1" in url
+
+
+def test_retry_targets_one_validated_job() -> None:
+    transport = FakeTransport({"id": "retry-id", "state": "scheduled"})
+
+    client(transport).retry_job(
+        build_number=42,
+        job_id="b63254c0-3271-4a98-8270-7cfbd6c2f14e",
+    )
+
+    call = transport.calls[0]
+    assert call["method"] == "PUT"
+    assert call["url"].endswith(
+        "/builds/42/jobs/b63254c0-3271-4a98-8270-7cfbd6c2f14e/retry"
+    )
+
+
+def test_pagination_bound_fails_closed() -> None:
+    full_page = [{"number": index} for index in range(100)]
+    transport = FakeTransport(full_page)
+
+    with pytest.raises(BuildkiteProtocolError, match="page bound"):
+        client(transport, max_pages=1).list_builds()

--- a/services/ci-control/tests/test_buildkite_evidence.py
+++ b/services/ci-control/tests/test_buildkite_evidence.py
@@ -1,0 +1,254 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from vllm_ci_control.adapters.buildkite import BuildkiteProtocolError
+from vllm_ci_control.adapters.buildkite_evidence import (
+    normalize_buildkite_jobs,
+    normalize_opaque_buildkite_lane,
+)
+from vllm_ci_control.catalog import Catalog, ExecutionKind, JobDefinition
+from vllm_ci_control.evidence import MainPosition, Outcome, observe_attempts
+
+CATALOG = Catalog(
+    version="v1",
+    jobs=(
+        JobDefinition(
+            job_id="attention",
+            groups=frozenset({"upstream"}),
+            areas=frozenset({"attention"}),
+            execution_profile="h100",
+            shards=2,
+            definition_digest="a" * 64,
+        ),
+    ),
+)
+OPAQUE_CATALOG = Catalog(
+    version="v1",
+    jobs=(
+        JobDefinition(
+            job_id="native-amd-lane",
+            groups=frozenset({"amd"}),
+            areas=frozenset({"native-amd"}),
+            execution_profile="amd-native",
+            execution_kind=ExecutionKind.OPAQUE_PIPELINE,
+            pipeline="amd-ci",
+            shards=2,
+            definition_digest="b" * 64,
+        ),
+    ),
+)
+NOW = datetime(2026, 7, 29, tzinfo=UTC)
+
+
+def raw(job_id: str, shard: int, **overrides):
+    value = {
+        "id": job_id,
+        "type": "script",
+        "step_key": "attention",
+        "state": "passed",
+        "parallel_group_index": shard,
+        "parallel_group_total": 2,
+        "retried_in_job_id": None,
+        # Buildkite represents an initial attempt with an explicit null.
+        "retries_count": None,
+        "soft_failed": False,
+    }
+    value.update(overrides)
+    return value
+
+
+def observe(normalized):
+    return observe_attempts(
+        attempts=normalized.attempts,
+        expectations=normalized.expectations,
+        read_attestation=normalized.read_attestation,
+        build_number=10,
+        build_url="https://buildkite.example/10",
+        commit="a" * 40,
+        observed_at=NOW,
+        trusted_main=True,
+        main_position=MainPosition(1, 1),
+    )[0]
+
+
+def test_complete_expected_shards_can_prove_clean() -> None:
+    normalized = normalize_buildkite_jobs(
+        catalog=CATALOG,
+        pipeline="ci",
+        expected_job_ids=["attention"],
+        jobs=[raw("one", 0), raw("two", 1)],
+        all_pages_fetched=True,
+        retry_history_complete=True,
+    )
+
+    assert observe(normalized).outcome is Outcome.CLEAN
+
+
+def test_missing_retry_counter_is_inconclusive() -> None:
+    one = raw("one", 0)
+    two = raw("two", 1)
+    del one["retries_count"]
+    normalized = normalize_buildkite_jobs(
+        catalog=CATALOG,
+        pipeline="ci",
+        expected_job_ids=["attention"],
+        jobs=[one, two],
+        all_pages_fetched=True,
+        retry_history_complete=True,
+    )
+
+    assert observe(normalized).outcome is Outcome.INCONCLUSIVE
+
+
+def test_real_retry_shape_keeps_the_complete_lineage() -> None:
+    normalized = normalize_buildkite_jobs(
+        catalog=CATALOG,
+        pipeline="ci",
+        expected_job_ids=["attention"],
+        jobs=[
+            raw(
+                "first",
+                0,
+                state="failed",
+                retried_in_job_id="retry",
+                retries_count=None,
+            ),
+            raw("retry", 0, retries_count=1),
+            raw("two", 1),
+        ],
+        all_pages_fetched=True,
+        retry_history_complete=True,
+    )
+
+    assert observe(normalized).outcome is Outcome.FLAKY
+
+
+def test_missing_expected_shard_is_inconclusive() -> None:
+    normalized = normalize_buildkite_jobs(
+        catalog=CATALOG,
+        pipeline="ci",
+        expected_job_ids=["attention"],
+        jobs=[raw("one", 0)],
+        all_pages_fetched=True,
+        retry_history_complete=True,
+    )
+
+    assert observe(normalized).outcome is Outcome.INCONCLUSIVE
+
+
+def test_incomplete_provider_read_is_inconclusive() -> None:
+    normalized = normalize_buildkite_jobs(
+        catalog=CATALOG,
+        pipeline="ci",
+        expected_job_ids=["attention"],
+        jobs=[raw("one", 0), raw("two", 1)],
+        all_pages_fetched=False,
+        retry_history_complete=True,
+    )
+
+    assert observe(normalized).outcome is Outcome.INCONCLUSIVE
+
+
+def test_shard_metadata_must_match_catalog() -> None:
+    with pytest.raises(BuildkiteProtocolError, match="disagrees"):
+        normalize_buildkite_jobs(
+            catalog=CATALOG,
+            pipeline="ci",
+            expected_job_ids=["attention"],
+            jobs=[
+                raw(
+                    "one",
+                    0,
+                    parallel_group_total=3,
+                )
+            ],
+            all_pages_fetched=True,
+            retry_history_complete=True,
+        )
+
+
+def test_finished_state_is_derived_from_exit_status() -> None:
+    normalized = normalize_buildkite_jobs(
+        catalog=CATALOG,
+        pipeline="ci",
+        expected_job_ids=["attention"],
+        jobs=[
+            raw("one", 0, state="finished", exit_status=0),
+            raw(
+                "two",
+                1,
+                state="finished",
+                exit_status=1,
+            ),
+        ],
+        all_pages_fetched=True,
+        retry_history_complete=True,
+        fingerprints_by_job_id={"two": ["pytest:test_failure"]},
+    )
+
+    observation = observe(normalized)
+    assert observation.outcome is Outcome.FAILED
+    assert observation.failure_fingerprints == frozenset({"pytest:test_failure"})
+
+
+def test_opaque_pipeline_uses_a_dedicated_whole_lane_adapter() -> None:
+    jobs = [
+        {
+            "id": "native-one",
+            "type": "script",
+            "state": "passed",
+            "retried_in_job_id": None,
+            "retries_count": None,
+            "soft_failed": False,
+        },
+        {
+            "id": "native-two",
+            "type": "script",
+            "state": "passed",
+            "retried_in_job_id": None,
+            "retries_count": None,
+            "soft_failed": False,
+        },
+    ]
+    normalized = normalize_opaque_buildkite_lane(
+        catalog=OPAQUE_CATALOG,
+        pipeline="amd-ci",
+        lane_job_id="native-amd-lane",
+        jobs=jobs,
+        all_pages_fetched=True,
+        retry_history_complete=True,
+    )
+
+    assert observe(normalized).outcome is Outcome.CLEAN
+    with pytest.raises(ValueError, match="opaque-pipeline normalizer"):
+        normalize_buildkite_jobs(
+            catalog=OPAQUE_CATALOG,
+            pipeline="amd-ci",
+            expected_job_ids=["native-amd-lane"],
+            jobs=jobs,
+            all_pages_fetched=True,
+            retry_history_complete=True,
+        )
+
+
+def test_opaque_pipeline_missing_execution_unit_is_inconclusive() -> None:
+    normalized = normalize_opaque_buildkite_lane(
+        catalog=OPAQUE_CATALOG,
+        pipeline="amd-ci",
+        lane_job_id="native-amd-lane",
+        jobs=[
+            {
+                "id": "native-one",
+                "type": "script",
+                "state": "passed",
+                "retried_in_job_id": None,
+                "retries_count": None,
+                "soft_failed": False,
+            }
+        ],
+        all_pages_fetched=True,
+        retry_history_complete=True,
+    )
+
+    assert observe(normalized).outcome is Outcome.INCONCLUSIVE

--- a/services/ci-control/tests/test_catalog.py
+++ b/services/ci-control/tests/test_catalog.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import pytest
+
+from vllm_ci_control.catalog import (
+    AreaAlias,
+    AreaTombstone,
+    Catalog,
+    CatalogValidationError,
+    EmptySelectionError,
+    JobAlias,
+    JobDefinition,
+    JobTombstone,
+    NonSelectableJobError,
+    RetiredAreaError,
+    RetiredJobError,
+    UnknownSelectorError,
+    validate_catalog_evolution,
+)
+from vllm_ci_control.models import Selector
+
+DIGEST = "a" * 64
+
+
+def _catalog() -> Catalog:
+    return Catalog(
+        version="2026.07",
+        jobs=(
+            JobDefinition(
+                job_id="amd.smoke",
+                groups=frozenset({"amd"}),
+                areas=frozenset({"tests"}),
+                definition_digest=DIGEST,
+                dependencies=("prepare",),
+                pipeline="amd-ci",
+                execution_profile="mi300",
+                shards=2,
+                cost=3,
+            ),
+            JobDefinition(
+                job_id="prepare",
+                groups=frozenset({"upstream"}),
+                areas=frozenset({"infra"}),
+                definition_digest=DIGEST,
+                cost=1,
+                selectable=False,
+            ),
+            JobDefinition(
+                job_id="cpu.smoke",
+                groups=frozenset({"cpu"}),
+                areas=frozenset({"tests"}),
+                definition_digest=DIGEST,
+                dependencies=("prepare",),
+                cost=2,
+            ),
+        ),
+        aliases=(JobAlias("cpu.old", "cpu.smoke"),),
+        tombstones=(
+            JobTombstone(
+                "legacy",
+                "lane was retired",
+                replacement="cpu.smoke",
+            ),
+        ),
+    )
+
+
+def test_plan_intersects_dimensions_and_adds_dependencies() -> None:
+    plan = _catalog().plan(
+        Selector(
+            groups=frozenset({"cpu"}),
+            areas=frozenset({"tests"}),
+        )
+    )
+
+    assert plan.requested_jobs == ("cpu.smoke",)
+    assert plan.jobs == ("prepare", "cpu.smoke")
+    assert plan.dependency_jobs == ("prepare",)
+    assert plan.total_cost == 3
+    assert len(plan.catalog_digest) == 64
+
+
+def test_aliases_resolve_but_tombstones_and_unknowns_fail() -> None:
+    catalog = _catalog()
+
+    assert catalog.plan(Selector(jobs=frozenset({"cpu.old"}))).requested_jobs == (
+        "cpu.smoke",
+    )
+    with pytest.raises(RetiredJobError, match="suggested replacement"):
+        catalog.plan(Selector(jobs=frozenset({"legacy"})))
+    with pytest.raises(UnknownSelectorError, match="unknown groups"):
+        catalog.plan(Selector(groups=frozenset({"gpu"})))
+    with pytest.raises(EmptySelectionError):
+        catalog.plan(
+            Selector(
+                groups=frozenset({"cpu"}),
+                jobs=frozenset({"amd.smoke"}),
+            )
+        )
+    with pytest.raises(NonSelectableJobError, match="internal dependencies"):
+        catalog.plan(Selector(jobs=frozenset({"prepare"})))
+
+
+def test_catalog_order_and_digest_are_deterministic() -> None:
+    catalog = _catalog()
+    reordered = Catalog(
+        version=catalog.version,
+        jobs=tuple(reversed(catalog.jobs)),
+        aliases=tuple(reversed(catalog.aliases)),
+        tombstones=tuple(reversed(catalog.tombstones)),
+    )
+
+    assert reordered.jobs == catalog.jobs
+    assert reordered.digest == catalog.digest
+    assert reordered.plan(Selector.all()) == catalog.plan(Selector.all())
+
+
+def test_plan_cost_includes_parallel_shards_and_route_is_in_digest() -> None:
+    catalog = _catalog()
+    plan = catalog.plan(Selector(groups=frozenset({"amd"})))
+
+    assert plan.total_cost == 7
+    changed_route = Catalog(
+        version=catalog.version,
+        jobs=tuple(
+            JobDefinition(
+                job_id=job.job_id,
+                groups=job.groups,
+                areas=job.areas,
+                dependencies=job.dependencies,
+                pipeline=("different" if job.job_id == "amd.smoke" else job.pipeline),
+                execution_profile=job.execution_profile,
+                shards=job.shards,
+                cost=job.cost,
+                selectable=job.selectable,
+                definition_digest=job.definition_digest,
+            )
+            for job in catalog.jobs
+        ),
+        aliases=catalog.aliases,
+        tombstones=catalog.tombstones,
+    )
+    assert changed_route.digest != catalog.digest
+
+
+def test_catalog_validates_duplicates_namespace_and_dependency_cycles() -> None:
+    duplicate = JobDefinition(
+        "same",
+        frozenset({"cpu"}),
+        frozenset({"tests"}),
+        DIGEST,
+    )
+    with pytest.raises(CatalogValidationError, match="unique"):
+        Catalog(version="v1", jobs=(duplicate, duplicate))
+
+    with pytest.raises(CatalogValidationError, match="share one namespace"):
+        Catalog(
+            version="v1",
+            jobs=(duplicate,),
+            aliases=(JobAlias("same", "same"),),
+        )
+
+    with pytest.raises(CatalogValidationError, match="cycle"):
+        Catalog(
+            version="v1",
+            jobs=(
+                JobDefinition(
+                    "a",
+                    frozenset({"cpu"}),
+                    frozenset({"tests"}),
+                    DIGEST,
+                    dependencies=("b",),
+                ),
+                JobDefinition(
+                    "b",
+                    frozenset({"cpu"}),
+                    frozenset({"tests"}),
+                    DIGEST,
+                    dependencies=("a",),
+                ),
+            ),
+        )
+
+
+def test_strict_mapping_loader() -> None:
+    catalog = Catalog.from_mapping(
+        {
+            "version": "v1",
+            "jobs": [
+                {
+                    "id": "cpu.smoke",
+                    "groups": ["cpu"],
+                    "areas": ["tests"],
+                    "definition_digest": DIGEST,
+                    "dependencies": [],
+                    "pipeline": "ci",
+                    "execution_profile": "cpu-x86",
+                    "shards": 2,
+                    "cost": 2,
+                }
+            ],
+            "aliases": [],
+            "tombstones": [],
+        }
+    )
+
+    assert catalog.job_ids == ("cpu.smoke",)
+    assert catalog.jobs[0].total_cost == 4
+    with pytest.raises(CatalogValidationError, match="unknown fields"):
+        Catalog.from_mapping(
+            {
+                "version": "v1",
+                "jobs": [],
+                "surprise": True,
+            }
+        )
+
+
+def test_area_aliases_and_tombstones_are_first_class_selectors() -> None:
+    base = _catalog()
+    catalog = Catalog(
+        version=base.version,
+        jobs=base.jobs,
+        aliases=base.aliases,
+        tombstones=base.tombstones,
+        area_aliases=(AreaAlias("old-tests", "tests"),),
+        area_tombstones=(
+            AreaTombstone(
+                "retired-tests",
+                "suite was retired",
+                replacement="tests",
+            ),
+        ),
+    )
+
+    assert catalog.plan(Selector(areas=frozenset({"old-tests"}))).requested_jobs == (
+        "amd.smoke",
+        "cpu.smoke",
+    )
+    with pytest.raises(RetiredAreaError, match="suggested replacement"):
+        catalog.plan(Selector(areas=frozenset({"retired-tests"})))
+
+
+def test_catalog_evolution_requires_compatibility_records() -> None:
+    previous = _catalog()
+    remaining = tuple(job for job in previous.jobs if job.job_id != "cpu.smoke")
+    incompatible = Catalog(version="next", jobs=remaining)
+
+    with pytest.raises(CatalogValidationError, match="removed job selector"):
+        validate_catalog_evolution(previous, incompatible)
+
+    compatible = Catalog(
+        version="next",
+        jobs=(
+            *remaining,
+            JobDefinition(
+                job_id="cpu.new",
+                groups=frozenset({"cpu"}),
+                areas=frozenset({"new-tests"}),
+                definition_digest=DIGEST,
+            ),
+        ),
+        aliases=(
+            JobAlias("cpu.old", "cpu.new"),
+            JobAlias("cpu.smoke", "cpu.new"),
+        ),
+        tombstones=(
+            JobTombstone(
+                "legacy",
+                "lane was retired",
+                replacement="cpu.new",
+            ),
+        ),
+    )
+    validate_catalog_evolution(previous, compatible)
+
+
+def test_catalog_evolution_requires_area_compatibility_records() -> None:
+    previous = Catalog(
+        version="old",
+        jobs=(
+            JobDefinition(
+                job_id="cpu.old",
+                groups=frozenset({"cpu"}),
+                areas=frozenset({"old-area"}),
+                definition_digest=DIGEST,
+            ),
+        ),
+    )
+    current_job = JobDefinition(
+        job_id="cpu.old",
+        groups=frozenset({"cpu"}),
+        areas=frozenset({"new-area"}),
+        definition_digest=DIGEST,
+    )
+    with pytest.raises(CatalogValidationError, match="removed area selector"):
+        validate_catalog_evolution(
+            previous,
+            Catalog(version="new", jobs=(current_job,)),
+        )
+
+    validate_catalog_evolution(
+        previous,
+        Catalog(
+            version="new",
+            jobs=(current_job,),
+            area_aliases=(AreaAlias("old-area", "new-area"),),
+        ),
+    )

--- a/services/ci-control/tests/test_commands.py
+++ b/services/ci-control/tests/test_commands.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pytest
+
+from vllm_ci_control.commands import (
+    CommandParseError,
+    CreditsAddCommand,
+    CreditsCommand,
+    HelpCommand,
+    ListCommand,
+    ListTarget,
+    PlanCommand,
+    RetryFailuresCommand,
+    RunCommand,
+    StatusCommand,
+    StatusRefreshCommand,
+    StatusRequestCommand,
+    StatusTarget,
+    UnrelatedComment,
+    parse_command,
+)
+from vllm_ci_control.models import Selector
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        ("/ci help", HelpCommand()),
+        ("/ci status", StatusCommand()),
+        ("/ci status pr", StatusCommand(StatusTarget.PR)),
+        (
+            "/ci status main groups:cpu,amd",
+            StatusCommand(
+                StatusTarget.MAIN,
+                Selector(groups=frozenset({"cpu", "amd"})),
+            ),
+        ),
+        ("/ci status refresh", StatusRefreshCommand()),
+        (
+            "/ci status request:req:123",
+            StatusRequestCommand("req:123"),
+        ),
+        ("/ci list", ListCommand()),
+        ("/ci list jobs", ListCommand(ListTarget.JOBS)),
+        ("/ci plan all", PlanCommand(Selector.all())),
+        (
+            "/ci run groups:amd areas:attention jobs:amd.full",
+            RunCommand(
+                Selector(
+                    groups=frozenset({"amd"}),
+                    areas=frozenset({"attention"}),
+                    jobs=frozenset({"amd.full"}),
+                )
+            ),
+        ),
+        ("/ci retry failures", RetryFailuresCommand()),
+        (
+            "/ci retry failures groups:upstream,cpu",
+            RetryFailuresCommand(Selector(groups=frozenset({"upstream", "cpu"}))),
+        ),
+        ("/ci credits", CreditsCommand()),
+        (
+            "/ci credits add @Example-User 25 incident recovery",
+            CreditsAddCommand(
+                username="example-user",
+                amount=25,
+                reason="incident recovery",
+            ),
+        ),
+    ],
+)
+def test_parse_supported_commands(body: str, expected: object) -> None:
+    assert parse_command(body) == expected
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "/ci",
+        "/ci\nhelp",
+        "/ci help extra",
+        "/ci status summary groups:cpu",
+        "/ci status refresh groups:cpu",
+        "/ci status request:",
+        "/ci retry",
+        "/ci retry failures all groups:cpu",
+        "/ci run",
+        "/ci run groups:cpu groups:amd",
+        "/ci run groups:cpu,cpu",
+        "/ci run unknown:cpu",
+        "/ci credits add @user 0 reason",
+        "/ci credits add user 1 reason",
+        "/ci credits add @user 1",
+        "/ci unknown",
+    ],
+)
+def test_rejects_malformed_ci_commands(body: str) -> None:
+    with pytest.raises(CommandParseError):
+        parse_command(body)
+
+
+@pytest.mark.parametrize("body", ["looks good", "", " /ci help", None])
+def test_unrelated_comments_are_distinct(body: object) -> None:
+    with pytest.raises(UnrelatedComment):
+        parse_command(body)

--- a/services/ci-control/tests/test_credits.py
+++ b/services/ci-control/tests/test_credits.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from vllm_ci_control.credits import (
+    ConcurrentCreditUpdate,
+    CreditAccount,
+    CreditError,
+    IdempotencyConflict,
+    InsufficientCredits,
+    InvalidCreditTransition,
+    ReservationStatus,
+)
+
+
+def test_default_account_reserve_and_partial_settlement() -> None:
+    account = CreditAccount.open(user_id="octocat")
+    assert account.available == 300
+
+    reserved = account.reserve(
+        expected_version=1,
+        idempotency_key="request:1",
+        amount=40,
+    )
+    assert reserved.version == 2
+    assert reserved.reserved == 40
+    assert reserved.available == 260
+
+    settled = reserved.settle(
+        expected_version=2,
+        idempotency_key="settle:1",
+        reservation_key="request:1",
+        charged=25,
+    )
+    assert settled.spent == 25
+    assert settled.reserved == 0
+    assert settled.available == 275
+    assert settled.reservations[0].status is ReservationStatus.SETTLED
+    assert settled.reservations[0].charged == 25
+
+
+def test_exact_replay_is_noop_and_conflicting_replay_fails() -> None:
+    account = CreditAccount.open(user_id="octocat").reserve(
+        expected_version=1,
+        idempotency_key="request:1",
+        amount=10,
+    )
+
+    assert (
+        account.reserve(
+            expected_version=1,
+            idempotency_key="request:1",
+            amount=10,
+        )
+        is account
+    )
+    with pytest.raises(IdempotencyConflict):
+        account.reserve(
+            expected_version=account.version,
+            idempotency_key="request:1",
+            amount=11,
+        )
+
+
+def test_compare_and_swap_version_and_available_balance_are_enforced() -> None:
+    account = CreditAccount.open(user_id="octocat")
+
+    with pytest.raises(ConcurrentCreditUpdate):
+        account.reserve(
+            expected_version=0,
+            idempotency_key="request:1",
+            amount=1,
+        )
+    with pytest.raises(InsufficientCredits):
+        account.reserve(
+            expected_version=1,
+            idempotency_key="request:1",
+            amount=301,
+        )
+
+
+def test_top_up_and_refund_are_audited_transitions() -> None:
+    account = CreditAccount.open(user_id="octocat", initial_credits=0)
+    account = account.grant(
+        expected_version=1,
+        idempotency_key="grant:1",
+        amount=50,
+        actor_id="maintainer",
+        reason="approved incident recovery",
+    )
+    account = account.reserve(
+        expected_version=2,
+        idempotency_key="request:1",
+        amount=50,
+    )
+    account = account.refund(
+        expected_version=3,
+        idempotency_key="refund:1",
+        reservation_key="request:1",
+    )
+
+    assert account.granted == 50
+    assert account.spent == 0
+    assert account.available == 50
+    assert account.reservations[0].status is ReservationStatus.REFUNDED
+    with pytest.raises(InvalidCreditTransition):
+        account.settle(
+            expected_version=account.version,
+            idempotency_key="settle:1",
+            reservation_key="request:1",
+            charged=1,
+        )
+
+
+def test_constructor_rejects_state_not_supported_by_ledger() -> None:
+    account = CreditAccount.open(user_id="octocat").reserve(
+        expected_version=1,
+        idempotency_key="request:1",
+        amount=10,
+    )
+    inconsistent_reservation = replace(
+        account.reservations[0],
+        status=ReservationStatus.SETTLED,
+    )
+
+    with pytest.raises(CreditError, match="terminal operation"):
+        replace(account, reservations=(inconsistent_reservation,))

--- a/services/ci-control/tests/test_evidence.py
+++ b/services/ci-control/tests/test_evidence.py
@@ -1,0 +1,279 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from vllm_ci_control.evidence import (
+    GroupExpectation,
+    GroupId,
+    GroupObservation,
+    JobAttempt,
+    MainPosition,
+    Outcome,
+    ProviderReadAttestation,
+    collapse_distinct_commits,
+    observe_attempts,
+)
+
+GROUP = GroupId("ci", "attention")
+NOW = datetime(2026, 7, 29, tzinfo=UTC)
+POSITION = MainPosition(1, 10)
+COMPLETE_READ = ProviderReadAttestation(
+    all_pages_fetched=True,
+    retry_history_complete=True,
+)
+
+
+def expectation(*shards: str) -> GroupExpectation:
+    return GroupExpectation(
+        group=GROUP,
+        shards=frozenset(shards or {"0"}),
+        execution_profile="cuda-h100",
+        definition_digest="definition-v1",
+    )
+
+
+def observe(
+    *attempts: JobAttempt,
+    expected: GroupExpectation | None = None,
+    read: ProviderReadAttestation = COMPLETE_READ,
+) -> GroupObservation:
+    return observe_attempts(
+        attempts=attempts,
+        expectations=[expected or expectation("0")],
+        read_attestation=read,
+        build_number=10,
+        build_url="https://buildkite.example/10",
+        commit="a" * 40,
+        observed_at=NOW,
+        trusted_main=True,
+        main_position=POSITION,
+    )[0]
+
+
+def attempt(
+    job_id: str,
+    state: str,
+    *,
+    next_id: str | None = None,
+    retries_count: int | None = 0,
+    shard: str = "0",
+    soft_failed: bool = False,
+    fingerprints: frozenset[str] = frozenset(),
+) -> JobAttempt:
+    return JobAttempt(
+        job_id=job_id,
+        group=GROUP,
+        state=state,
+        shard=shard,
+        retried_in_job_id=next_id,
+        retries_count=retries_count,
+        soft_failed=soft_failed,
+        failure_fingerprints=fingerprints,
+    )
+
+
+def test_clean_requires_every_exact_expected_shard_to_pass_first_try() -> None:
+    result = observe(
+        attempt("one", "passed", shard="0"),
+        attempt("two", "passed", shard="1"),
+        expected=expectation("0", "1"),
+    )
+    assert result.outcome is Outcome.CLEAN
+    assert result.execution_profile == "cuda-h100"
+
+
+def test_missing_expected_shard_is_inconclusive() -> None:
+    result = observe(
+        attempt("one", "passed", shard="0"),
+        expected=expectation("0", "1"),
+    )
+    assert result.outcome is Outcome.INCONCLUSIVE
+
+
+@pytest.mark.parametrize(
+    "read",
+    [
+        ProviderReadAttestation(False, True),
+        ProviderReadAttestation(True, False),
+    ],
+)
+def test_incomplete_provider_read_is_inconclusive(
+    read: ProviderReadAttestation,
+) -> None:
+    assert observe(attempt("one", "passed"), read=read).outcome is (
+        Outcome.INCONCLUSIVE
+    )
+
+
+def test_latest_retry_without_predecessor_is_not_clean() -> None:
+    result = observe(attempt("retry", "passed", retries_count=1))
+    assert result.outcome is Outcome.INCONCLUSIVE
+
+
+def test_missing_retries_count_is_inconclusive() -> None:
+    result = observe(attempt("one", "passed", retries_count=None))
+    assert result.outcome is Outcome.INCONCLUSIVE
+
+
+@pytest.mark.parametrize("state", ["failed", "timed_out", "expired"])
+def test_a_current_hard_failure_makes_the_group_failed(state: str) -> None:
+    result = observe(attempt("one", state, fingerprints=frozenset({"test::boom"})))
+    assert result.outcome is Outcome.FAILED
+    assert result.failure_fingerprints == frozenset({"test::boom"})
+
+
+def test_soft_failure_is_failure_evidence() -> None:
+    result = observe(
+        attempt(
+            "one",
+            "passed",
+            soft_failed=True,
+            fingerprints=frozenset({"test::soft"}),
+        )
+    )
+    assert result.outcome is Outcome.FAILED
+
+
+def test_retry_pass_is_flaky_and_keeps_failed_fingerprint() -> None:
+    result = observe(
+        attempt(
+            "first",
+            "failed",
+            next_id="retry",
+            fingerprints=frozenset({"test::boom"}),
+        ),
+        attempt("retry", "passed", retries_count=1),
+    )
+    assert result.outcome is Outcome.FLAKY
+    assert result.failure_fingerprints == frozenset({"test::boom"})
+
+
+def test_retry_after_non_failure_is_never_clean() -> None:
+    result = observe(
+        attempt("first", "canceled", next_id="retry"),
+        attempt("retry", "passed", retries_count=1),
+    )
+    assert result.outcome is Outcome.INCONCLUSIVE
+
+
+@pytest.mark.parametrize(
+    "state", ["blocked", "canceled", "scheduled", "running", "skipped"]
+)
+def test_non_terminal_or_non_executed_state_is_inconclusive(state: str) -> None:
+    assert observe(attempt("one", state)).outcome is Outcome.INCONCLUSIVE
+
+
+def test_duplicate_job_ids_are_rejected() -> None:
+    with pytest.raises(ValueError, match="unique"):
+        observe(attempt("same", "passed"), attempt("same", "passed"))
+
+
+def test_multiple_current_attempts_for_one_shard_are_inconclusive() -> None:
+    result = observe(attempt("one", "passed"), attempt("two", "passed"))
+    assert result.outcome is Outcome.INCONCLUSIVE
+
+
+def test_ambiguous_retry_lineage_is_inconclusive() -> None:
+    result = observe(
+        attempt("first", "failed", next_id="retry"),
+        attempt("also-first", "failed", next_id="retry"),
+        attempt("retry", "passed", retries_count=1),
+    )
+    assert result.outcome is Outcome.INCONCLUSIVE
+
+
+def test_dangling_retry_successor_is_inconclusive() -> None:
+    result = observe(
+        attempt("first", "failed", next_id="missing"),
+        attempt("unrelated", "passed"),
+    )
+    assert result.outcome is Outcome.INCONCLUSIVE
+
+
+def test_expected_but_absent_group_is_inconclusive() -> None:
+    assert observe().outcome is Outcome.INCONCLUSIVE
+
+
+def test_intentionally_unselected_group_produces_no_observation() -> None:
+    assert (
+        observe_attempts(
+            attempts=[],
+            expectations=[],
+            read_attestation=COMPLETE_READ,
+            build_number=10,
+            build_url="https://buildkite.example/10",
+            commit="a" * 40,
+            observed_at=NOW,
+            trusted_main=True,
+            main_position=POSITION,
+        )
+        == ()
+    )
+
+
+def test_rebuilds_of_one_sha_do_not_create_independent_evidence() -> None:
+    failed = observe(
+        attempt(
+            "first",
+            "failed",
+            fingerprints=frozenset({"test::boom"}),
+        )
+    )
+    clean = observe_attempts(
+        attempts=[attempt("second", "passed")],
+        expectations=[expectation("0")],
+        read_attestation=COMPLETE_READ,
+        build_number=11,
+        build_url="https://buildkite.example/11",
+        commit=failed.commit,
+        observed_at=NOW + timedelta(hours=1),
+        trusted_main=True,
+        main_position=POSITION,
+    )[0]
+
+    collapsed = collapse_distinct_commits([failed, clean])
+
+    assert len(collapsed) == 1
+    assert collapsed[0].outcome is Outcome.FLAKY
+    assert collapsed[0].failure_fingerprints == frozenset({"test::boom"})
+
+
+def test_same_sha_in_a_new_main_epoch_is_new_evidence() -> None:
+    first_epoch = observe(attempt("first", "failed"))
+    second_epoch = GroupObservation(
+        group=GROUP,
+        commit=first_epoch.commit,
+        outcome=Outcome.FAILED,
+        build_number=11,
+        observed_at=NOW + timedelta(hours=1),
+        build_url="https://buildkite.example/11",
+        trusted_main=True,
+        main_position=MainPosition(2, 1),
+        execution_profile="cuda-h100",
+        definition_digest="definition-v1",
+    )
+
+    collapsed = collapse_distinct_commits([first_epoch, second_epoch])
+
+    assert len(collapsed) == 2
+    assert [item.main_position for item in collapsed] == [
+        MainPosition(1, 10),
+        MainPosition(2, 1),
+    ]
+
+
+def test_noncanonical_evidence_is_rejected_by_main_collapse() -> None:
+    observation = GroupObservation(
+        group=GROUP,
+        commit="feature-head",
+        outcome=Outcome.CLEAN,
+        build_number=10,
+        observed_at=NOW,
+        build_url="https://buildkite.example/10",
+        trusted_main=False,
+        main_position=None,
+        execution_profile="cuda-h100",
+        definition_digest="definition-v1",
+    )
+    with pytest.raises(ValueError, match="trusted canonical-main"):
+        collapse_distinct_commits([observation])

--- a/services/ci-control/tests/test_github_adapter.py
+++ b/services/ci-control/tests/test_github_adapter.py
@@ -1,0 +1,114 @@
+from typing import Any
+
+import pytest
+
+from vllm_ci_control.adapters.github import (
+    GitHubClient,
+    GitHubProtocolError,
+)
+from vllm_ci_control.adapters.http import HttpError
+from vllm_ci_control.models import RepositoryPermission
+
+
+class FakeTransport:
+    def __init__(self, *responses: Any) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    def request(self, url: str, **kwargs: Any) -> Any:
+        self.calls.append({"url": url, **kwargs})
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def client(transport: FakeTransport, *, max_pages: int = 100):
+    return GitHubClient(
+        token="secret",
+        repository="vllm-project/vllm",
+        transport=transport,
+        max_pages=max_pages,
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ({"permission": "write"}, RepositoryPermission.WRITE),
+        (
+            {"permission": "write", "role_name": "maintain"},
+            RepositoryPermission.MAINTAIN,
+        ),
+        (
+            {"permission": "read", "role_name": "triage"},
+            RepositoryPermission.TRIAGE,
+        ),
+        (
+            {"permission": "write", "role_name": "custom-ci-role"},
+            RepositoryPermission.WRITE,
+        ),
+        ({"permission": "admin"}, RepositoryPermission.ADMIN),
+        ({"permission": "read"}, RepositoryPermission.READ),
+    ],
+)
+def test_repository_permission_uses_live_github_value(
+    raw: dict[str, str],
+    expected: RepositoryPermission,
+) -> None:
+    transport = FakeTransport(raw)
+    assert client(transport).repository_permission("alice") is expected
+
+
+def test_missing_collaborator_has_no_permission() -> None:
+    transport = FakeTransport(HttpError(404, "Not Found"))
+    assert (
+        client(transport).repository_permission("external") is RepositoryPermission.NONE
+    )
+
+
+def test_unknown_permission_fails_closed() -> None:
+    transport = FakeTransport({"permission": "owner"})
+    with pytest.raises(GitHubProtocolError, match="unknown"):
+        client(transport).repository_permission("alice")
+
+
+def test_team_membership_requires_an_active_github_membership() -> None:
+    active = FakeTransport({"state": "active", "role": "member"})
+    pending = FakeTransport({"state": "pending", "role": "member"})
+    missing = FakeTransport(HttpError(404, "Not Found"))
+
+    assert client(active).is_team_member("vllm-committers", "alice")
+    assert not client(pending).is_team_member("vllm-committers", "alice")
+    assert not client(missing).is_team_member("vllm-committers", "alice")
+
+
+def test_reactions_are_completely_paginated() -> None:
+    first = [{"id": index} for index in range(100)]
+    transport = FakeTransport(first, [{"id": 101}])
+
+    result = client(transport).list_comment_reactions(42)
+
+    assert len(result) == 101
+    assert "page=2" in transport.calls[1]["url"]
+
+
+def test_invalid_repository_is_rejected_before_http() -> None:
+    with pytest.raises(ValueError, match="owner/name"):
+        GitHubClient(
+            token="secret",
+            repository="https://github.com/vllm-project/vllm",
+        )
+
+
+def test_reaction_content_is_allowlisted() -> None:
+    transport = FakeTransport({})
+    with pytest.raises(ValueError, match="unsupported"):
+        client(transport).add_reaction(42, "fire")
+    assert transport.calls == []
+
+
+def test_pagination_bound_fails_closed() -> None:
+    transport = FakeTransport([{"id": index} for index in range(100)])
+    with pytest.raises(GitHubProtocolError, match="page bound"):
+        client(transport, max_pages=1).list_comment_reactions(42)

--- a/services/ci-control/tests/test_incidents.py
+++ b/services/ci-control/tests/test_incidents.py
@@ -1,0 +1,286 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from vllm_ci_control.evidence import (
+    GroupId,
+    GroupObservation,
+    MainPosition,
+    Outcome,
+)
+from vllm_ci_control.incidents import (
+    IncidentState,
+    IncidentThresholds,
+    reduce_incident,
+    reduce_registry,
+)
+
+GROUP = GroupId("ci", "attention")
+OTHER = GroupId("ci", "kernels")
+START = datetime(2026, 7, 20, tzinfo=UTC)
+
+
+def observation(
+    index: int,
+    outcome: Outcome,
+    *,
+    group: GroupId = GROUP,
+    commit: str | None = None,
+    observed_at: datetime | None = None,
+    trusted_main: bool = True,
+    position: MainPosition | None = None,
+    fingerprint: str = "test::boom",
+    definition: str = "definition-v1",
+) -> GroupObservation:
+    return GroupObservation(
+        group=group,
+        commit=commit or f"{index:040x}",
+        outcome=outcome,
+        build_number=index + 1,
+        observed_at=observed_at or START + timedelta(hours=index),
+        build_url=f"https://buildkite.example/{index + 1}",
+        trusted_main=trusted_main,
+        main_position=(
+            position
+            if position is not None
+            else (MainPosition(1, index + 1) if trusted_main else None)
+        ),
+        execution_profile="cuda-h100",
+        definition_digest=definition,
+        failure_fingerprints=(
+            frozenset({fingerprint})
+            if outcome in {Outcome.FAILED, Outcome.FLAKY}
+            else frozenset()
+        ),
+    )
+
+
+def states(*outcomes: Outcome):
+    evidence = [observation(index, outcome) for index, outcome in enumerate(outcomes)]
+    return reduce_incident(GROUP, evidence)
+
+
+def test_first_failure_is_candidate_and_second_failed_sha_is_known() -> None:
+    assert states(Outcome.FAILED).state is IncidentState.CANDIDATE
+    known = states(Outcome.FAILED, Outcome.FAILED)
+    assert known.state is IncidentState.KNOWN
+    assert known.ever_known
+
+
+def test_flaky_sha_does_not_confirm_a_current_failure() -> None:
+    incident = states(Outcome.FAILED, Outcome.FLAKY)
+    assert incident.state is IncidentState.CANDIDATE
+    assert incident.failure_count == 1
+
+
+def test_candidate_clears_without_becoming_a_known_incident() -> None:
+    incident = states(Outcome.FAILED, Outcome.CLEAN)
+    assert incident.state is IncidentState.HEALTHY
+    assert not incident.ever_known
+
+
+def test_known_failure_recovers_and_resolves_only_from_clean_first_attempts() -> None:
+    recovering = states(
+        Outcome.FAILED,
+        Outcome.FAILED,
+        Outcome.CLEAN,
+        Outcome.CLEAN,
+    )
+    resolved = states(
+        Outcome.FAILED,
+        Outcome.FAILED,
+        Outcome.CLEAN,
+        Outcome.CLEAN,
+        Outcome.CLEAN,
+    )
+    assert recovering.state is IncidentState.RECOVERING
+    assert resolved.state is IncidentState.RESOLVED
+
+
+def test_latest_inconclusive_is_retained_without_changing_lifecycle() -> None:
+    incident = states(
+        Outcome.FAILED,
+        Outcome.FAILED,
+        Outcome.INCONCLUSIVE,
+    )
+    assert incident.state is IncidentState.KNOWN
+    assert incident.latest_attempted_observation is not None
+    assert incident.latest_attempted_observation.outcome is Outcome.INCONCLUSIVE
+    assert incident.last_conclusive_observation is not None
+    assert incident.last_conclusive_observation.outcome is Outcome.FAILED
+
+
+def test_flaky_and_inconclusive_observations_cannot_resolve_an_incident() -> None:
+    incident = states(
+        Outcome.FAILED,
+        Outcome.FAILED,
+        Outcome.CLEAN,
+        Outcome.INCONCLUSIVE,
+        Outcome.FLAKY,
+    )
+    assert incident.state is IncidentState.KNOWN
+    assert incident.clean_count == 0
+
+
+def test_failure_during_recovery_moves_back_to_known() -> None:
+    incident = states(
+        Outcome.FAILED,
+        Outcome.FAILED,
+        Outcome.CLEAN,
+        Outcome.FAILED,
+    )
+    assert incident.state is IncidentState.KNOWN
+
+
+def test_resolved_recurrence_requires_two_new_hard_failures() -> None:
+    history = [
+        Outcome.FAILED,
+        Outcome.FAILED,
+        Outcome.CLEAN,
+        Outcome.CLEAN,
+        Outcome.CLEAN,
+    ]
+    candidate = states(*history, Outcome.FAILED)
+    reopened = states(*history, Outcome.FAILED, Outcome.FAILED)
+    assert candidate.state is IncidentState.CANDIDATE
+    assert candidate.ever_known
+    assert reopened.state is IncidentState.KNOWN
+
+
+def test_rebuild_of_same_sha_does_not_satisfy_confirmation_threshold() -> None:
+    incident = reduce_incident(
+        GROUP,
+        [
+            observation(
+                0,
+                Outcome.FAILED,
+                commit="a" * 40,
+                position=MainPosition(1, 1),
+            ),
+            observation(
+                1,
+                Outcome.FAILED,
+                commit="a" * 40,
+                position=MainPosition(1, 1),
+            ),
+        ],
+    )
+    assert incident.state is IncidentState.CANDIDATE
+
+
+def test_canonical_position_not_finish_time_drives_transitions() -> None:
+    first_failure_finishes_late = observation(
+        0,
+        Outcome.FAILED,
+        observed_at=START + timedelta(hours=2),
+        position=MainPosition(1, 1),
+    )
+    later_clean_finishes_early = observation(
+        1,
+        Outcome.CLEAN,
+        observed_at=START + timedelta(hours=1),
+        position=MainPosition(1, 2),
+    )
+    incident = reduce_incident(
+        GROUP,
+        [later_clean_finishes_early, first_failure_finishes_late],
+    )
+    assert incident.state is IncidentState.HEALTHY
+    assert incident.latest_attempted_observation == later_clean_finishes_early
+
+
+def test_failure_confirmation_does_not_cross_main_epochs() -> None:
+    incident = reduce_incident(
+        GROUP,
+        [
+            observation(
+                0,
+                Outcome.FAILED,
+                position=MainPosition(1, 1),
+            ),
+            observation(
+                1,
+                Outcome.FAILED,
+                position=MainPosition(2, 1),
+            ),
+        ],
+    )
+    assert incident.state is IncidentState.CANDIDATE
+    assert incident.failure_count == 1
+
+
+def test_failure_confirmation_does_not_cross_definition_revisions() -> None:
+    incident = reduce_incident(
+        GROUP,
+        [
+            observation(0, Outcome.FAILED, definition="definition-v1"),
+            observation(1, Outcome.FAILED, definition="definition-v2"),
+        ],
+    )
+    assert incident.state is IncidentState.CANDIDATE
+    assert incident.failure_count == 1
+    assert not incident.confirmed_failure_fingerprints
+
+
+def test_new_clean_definition_does_not_inherit_old_recovery_state() -> None:
+    incident = reduce_incident(
+        GROUP,
+        [
+            observation(0, Outcome.FAILED, definition="definition-v1"),
+            observation(1, Outcome.FAILED, definition="definition-v1"),
+            observation(2, Outcome.CLEAN, definition="definition-v2"),
+        ],
+    )
+    assert incident.state is IncidentState.HEALTHY
+    assert incident.clean_count == 1
+    assert incident.ever_known
+
+
+def test_recovery_count_restarts_but_known_state_carries_to_new_epoch() -> None:
+    incident = reduce_incident(
+        GROUP,
+        [
+            observation(0, Outcome.FAILED, position=MainPosition(1, 1)),
+            observation(1, Outcome.FAILED, position=MainPosition(1, 2)),
+            observation(2, Outcome.CLEAN, position=MainPosition(1, 3)),
+            observation(3, Outcome.CLEAN, position=MainPosition(2, 1)),
+            observation(4, Outcome.CLEAN, position=MainPosition(2, 2)),
+        ],
+    )
+    assert incident.state is IncidentState.RECOVERING
+    assert incident.clean_count == 2
+    assert incident.ever_known
+
+
+def test_noncanonical_evidence_is_rejected_by_reducer() -> None:
+    value = observation(
+        0,
+        Outcome.FAILED,
+        commit="feature-head",
+        trusted_main=False,
+    )
+    with pytest.raises(ValueError, match="trusted canonical-main"):
+        reduce_incident(GROUP, [value])
+
+
+def test_thresholds_are_configurable() -> None:
+    incident = reduce_incident(
+        GROUP,
+        [observation(0, Outcome.FAILED)],
+        IncidentThresholds(
+            confirm_failures=1,
+            begin_recovery=2,
+            resolve_clean=2,
+        ),
+    )
+    assert incident.state is IncidentState.KNOWN
+
+
+def test_registry_is_sorted_and_group_scoped() -> None:
+    registry = reduce_registry(
+        [
+            observation(0, Outcome.FAILED, group=OTHER),
+            observation(1, Outcome.CLEAN, group=GROUP),
+        ]
+    )
+    assert [item.group for item in registry] == [GROUP, OTHER]

--- a/services/ci-control/tests/test_policy.py
+++ b/services/ci-control/tests/test_policy.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import pytest
+
+from vllm_ci_control.models import RepositoryPermission
+from vllm_ci_control.policy import (
+    Policy,
+    PolicyValidationError,
+    RetryLimit,
+)
+
+OVERLAY = """
+api_version = 1
+
+[catalog]
+groups = ["upstream", "cpu", "amd"]
+aliases = {}
+tombstones = []
+area_aliases = {}
+area_tombstones = []
+native_amd_selection = "whole_lane"
+
+[authorization]
+minimum_compute_permission = "write"
+minimum_refresh_permission = "write"
+minimum_credit_grant_permission = "maintain"
+committer_teams = ["vllm-committers"]
+credit_admin_teams = ["vllm-ci-admins"]
+
+[credits]
+initial_grant = 300
+reset = "none"
+
+[retry]
+failures_limit = "inf"
+include_states = ["failed", "timed_out", "expired"]
+
+[main_status]
+confirmation_distinct_shas = 2
+resolution_clean_distinct_shas = 3
+evidence_max_age_hours = 72
+"""
+
+
+def test_loads_actual_overlay_shape_and_defaults() -> None:
+    policy = Policy.from_toml(OVERLAY)
+
+    assert policy.api_version == 1
+    assert policy.catalog_groups == frozenset({"upstream", "cpu", "amd"})
+    assert policy.initial_credits == 300
+    assert policy.retry_limit.is_infinite
+    assert policy.retry_states == frozenset({"failed", "timed_out", "expired"})
+    assert policy.confirmation_distinct_shas == 2
+    assert policy.resolution_clean_distinct_shas == 3
+    assert policy.evidence_max_age_hours == 72
+
+
+def test_compute_requires_write_or_committer_membership() -> None:
+    policy = Policy.from_toml(OVERLAY)
+
+    assert policy.can_mutate(RepositoryPermission.WRITE)
+    assert policy.can_mutate(RepositoryPermission.ADMIN)
+    assert not policy.can_mutate(RepositoryPermission.READ)
+    assert policy.can_mutate(
+        RepositoryPermission.READ,
+        frozenset({"vllm-committers"}),
+    )
+    assert policy.can_receive_compute_credits(RepositoryPermission.WRITE)
+    assert policy.can_receive_compute_credits(
+        RepositoryPermission.READ,
+        frozenset({"vllm-committers"}),
+    )
+    assert not policy.can_receive_compute_credits(RepositoryPermission.READ)
+
+
+def test_credit_grants_require_elevated_permission_or_admin_team() -> None:
+    policy = Policy.from_toml(OVERLAY)
+
+    assert policy.can_top_up(RepositoryPermission.MAINTAIN)
+    assert policy.can_top_up(RepositoryPermission.ADMIN)
+    assert not policy.can_top_up(RepositoryPermission.WRITE)
+    assert policy.can_top_up(
+        RepositoryPermission.READ,
+        frozenset({"vllm-ci-admins"}),
+    )
+
+
+def test_retry_limit_supports_bounded_and_infinite_values() -> None:
+    assert RetryLimit.parse("inf").allows(1_000_000)
+    bounded = RetryLimit.parse(2)
+    assert bounded.allows(0)
+    assert bounded.allows(1)
+    assert not bounded.allows(2)
+
+
+def test_policy_loader_rejects_unknown_or_unsafe_configuration() -> None:
+    with pytest.raises(PolicyValidationError, match="unknown fields"):
+        Policy.from_mapping(
+            {
+                "api_version": 1,
+                "catalog": {},
+                "authorization": {},
+                "credits": {},
+                "retry": {},
+                "main_status": {},
+                "surprise": True,
+            }
+        )
+    with pytest.raises(PolicyValidationError, match="write or higher"):
+        Policy(minimum_compute_permission=RepositoryPermission.READ)
+    with pytest.raises(PolicyValidationError, match="invalid policy TOML"):
+        Policy.from_toml("not = [valid")

--- a/services/ci-control/tests/test_repository_catalog.py
+++ b/services/ci-control/tests/test_repository_catalog.py
@@ -1,0 +1,285 @@
+from pathlib import Path
+
+import pytest
+
+from vllm_ci_control.models import Selector
+from vllm_ci_control.repository_catalog import (
+    RepositoryCatalogError,
+    compile_repository_catalog,
+)
+
+POLICY = """
+api_version = 1
+
+[catalog]
+groups = ["upstream", "cpu", "amd"]
+aliases = {}
+tombstones = []
+area_aliases = {}
+area_tombstones = []
+native_amd_selection = "whole_lane"
+
+[authorization]
+minimum_compute_permission = "write"
+minimum_refresh_permission = "write"
+minimum_credit_grant_permission = "maintain"
+committer_teams = ["vllm-committers"]
+credit_admin_teams = ["vllm-ci-admins"]
+
+[credits]
+initial_grant = 300
+reset = "none"
+
+[retry]
+failures_limit = "inf"
+include_states = ["failed", "timed_out", "expired"]
+
+[main_status]
+confirmation_distinct_shas = 2
+resolution_clean_distinct_shas = 3
+evidence_max_age_hours = 72
+"""
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def repository(tmp_path: Path) -> Path:
+    write(tmp_path / ".buildkite/ci_control.toml", POLICY)
+    write(
+        tmp_path / ".buildkite/image_build/images.yaml",
+        """
+group: images
+steps:
+- label: primary image
+  key: image-build
+  depends_on: []
+  ci_control:
+    groups: [upstream]
+- label: AMD image
+  key: image-build-amd
+  depends_on: []
+- label: CPU image
+  key: image-build-cpu
+  depends_on: []
+""",
+    )
+    write(
+        tmp_path / ".buildkite/test_areas/models_language.yaml",
+        """
+group: models
+depends_on: [image-build]
+steps:
+- label: language models
+  key: language-models
+  device: h100
+  depends_on:
+  parallelism: 2
+  commands: [pytest models]
+  mirror:
+    amd:
+      device: mi300_1
+""",
+    )
+    write(
+        tmp_path / ".buildkite/hardware_tests/cpu.yaml",
+        """
+group: CPU
+steps:
+- label: CPU models
+  key: cpu-models
+  device: intel_cpu
+  depends_on: [image-build-cpu]
+  ci_control:
+    areas: [models]
+""",
+    )
+    write(
+        tmp_path / ".buildkite/hardware_tests/amd.yaml",
+        """
+group: AMD prerequisites
+steps:
+- label: AMD image alias
+  key: amd-prerequisite
+  depends_on: []
+""",
+    )
+    write(
+        tmp_path / ".buildkite/test-amd.yaml",
+        """
+steps:
+- label: native one
+  parallelism: 2
+- label: native two
+""",
+    )
+    return tmp_path
+
+
+def test_compiles_routes_variants_areas_and_dependency_cost(
+    tmp_path: Path,
+) -> None:
+    catalog = compile_repository_catalog(repository(tmp_path))
+    by_id = {job.job_id: job for job in catalog.jobs}
+
+    assert by_id["language-models"].pipeline == "ci"
+    assert by_id["language-models"].execution_profile == "h100"
+    assert by_id["language-models"].areas == frozenset({"models", "models-language"})
+    assert by_id["language-models"].dependencies == ("image-build",)
+    assert by_id["language-models-amd"].groups == frozenset({"amd"})
+    assert by_id["language-models-amd"].dependencies == ("image-build-amd",)
+    assert by_id["native-amd-lane"].pipeline == "amd-ci"
+    assert by_id["native-amd-lane"].shards == 3
+    assert not by_id["image-build"].selectable
+
+    cpu = catalog.plan(Selector(groups=frozenset({"cpu"})))
+    assert cpu.requested_jobs == ("cpu-models",)
+    assert cpu.jobs == ("image-build-cpu", "cpu-models")
+    assert cpu.total_cost == 2
+
+    amd = catalog.plan(Selector(groups=frozenset({"amd"})))
+    assert amd.requested_jobs == ("language-models-amd", "native-amd-lane")
+    assert amd.jobs == (
+        "image-build-amd",
+        "language-models-amd",
+        "native-amd-lane",
+    )
+
+    amd_models = catalog.plan(
+        Selector(
+            groups=frozenset({"amd"}),
+            areas=frozenset({"models"}),
+        )
+    )
+    assert amd_models.requested_jobs == ("language-models-amd",)
+
+    upstream_and_cpu = catalog.plan(Selector(groups=frozenset({"upstream", "cpu"})))
+    assert upstream_and_cpu.requested_jobs == (
+        "cpu-models",
+        "language-models",
+    )
+
+
+def test_catalog_digest_changes_with_the_executable_definition(
+    tmp_path: Path,
+) -> None:
+    root = repository(tmp_path)
+    before = compile_repository_catalog(root)
+    path = root / ".buildkite/test_areas/models_language.yaml"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            "pytest models",
+            "pytest changed-models",
+        ),
+        encoding="utf-8",
+    )
+
+    after = compile_repository_catalog(root)
+
+    assert before.digest != after.digest
+
+
+def test_variant_definition_digests_exclude_unrelated_metadata(
+    tmp_path: Path,
+) -> None:
+    root = repository(tmp_path)
+    before = compile_repository_catalog(root)
+    path = root / ".buildkite/test_areas/models_language.yaml"
+    path.write_text(
+        path.read_text(encoding="utf-8")
+        .replace(
+            "      device: mi300_1",
+            "      device: mi300_1\n      timeout_in_minutes: 90",
+        )
+        .replace(
+            "  commands: [pytest models]",
+            "  commands: [pytest models]\n  ci_control:\n    areas: [language]",
+        ),
+        encoding="utf-8",
+    )
+
+    after = compile_repository_catalog(root)
+    before_jobs = {job.job_id: job for job in before.jobs}
+    after_jobs = {job.job_id: job for job in after.jobs}
+
+    assert (
+        before_jobs["language-models"].definition_digest
+        == after_jobs["language-models"].definition_digest
+    )
+    assert (
+        before_jobs["language-models-amd"].definition_digest
+        != after_jobs["language-models-amd"].definition_digest
+    )
+
+
+def test_mirror_dependencies_do_not_inherit_source_only_dependencies(
+    tmp_path: Path,
+) -> None:
+    root = repository(tmp_path)
+    path = root / ".buildkite/test_areas/models_language.yaml"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            "depends_on: [image-build]",
+            "depends_on: [image-build, image-build-cpu]",
+        ),
+        encoding="utf-8",
+    )
+
+    catalog = compile_repository_catalog(root)
+    by_id = {job.job_id: job for job in catalog.jobs}
+
+    assert by_id["language-models"].dependencies == (
+        "image-build",
+        "image-build-cpu",
+    )
+    assert by_id["language-models-amd"].dependencies == ("image-build-amd",)
+
+
+def test_groups_outside_protected_policy_fail_closed(tmp_path: Path) -> None:
+    root = repository(tmp_path)
+    path = root / ".buildkite/hardware_tests/cpu.yaml"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            "    areas: [models]",
+            "    areas: [models]\n    groups: [typo-group]",
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RepositoryCatalogError, match="outside protected policy"):
+        compile_repository_catalog(root)
+
+
+def test_explicitly_nonselectable_job_remains_available_to_the_dag(
+    tmp_path: Path,
+) -> None:
+    root = repository(tmp_path)
+    path = root / ".buildkite/hardware_tests/cpu.yaml"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            "    areas: [models]",
+            "    areas: [models]\n    selectable: false",
+        ),
+        encoding="utf-8",
+    )
+
+    catalog = compile_repository_catalog(root)
+    cpu = {job.job_id: job for job in catalog.jobs}["cpu-models"]
+    assert not cpu.selectable
+
+
+def test_missing_explicit_key_fails_closed(tmp_path: Path) -> None:
+    root = repository(tmp_path)
+    path = root / ".buildkite/test_areas/models_language.yaml"
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            "  key: language-models\n",
+            "",
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RepositoryCatalogError, match="explicit key"):
+        compile_repository_catalog(root)

--- a/services/ci-control/tests/test_validation.py
+++ b/services/ci-control/tests/test_validation.py
@@ -1,0 +1,431 @@
+from datetime import UTC, datetime, timedelta
+
+from vllm_ci_control.evidence import (
+    GroupId,
+    GroupObservation,
+    MainPosition,
+    Outcome,
+)
+from vllm_ci_control.incidents import Incident, IncidentState
+from vllm_ci_control.validation import (
+    Classification,
+    LaneCompleteness,
+    LaneSnapshot,
+    PullRequestFailure,
+    PullRequestRunSubject,
+    create_snapshot,
+    validate_pull_request,
+)
+
+NOW = datetime(2026, 7, 29, tzinfo=UTC)
+GROUP = GroupId("ci", "attention")
+PROFILE = "cuda-h100"
+DEFINITION = "definition-v1"
+FINGERPRINT = "test_attention::assertion-a"
+HEAD = "b" * 40
+BASE = "c" * 40
+MAIN_COMMIT = "a" * 40
+WATERMARK = MainPosition(1, 10)
+
+
+def observation(
+    outcome: Outcome,
+    *,
+    group: GroupId = GROUP,
+    commit: str = MAIN_COMMIT,
+    position: MainPosition = WATERMARK,
+    age: timedelta = timedelta(hours=1),
+    fingerprint: str = FINGERPRINT,
+    profile: str | None = PROFILE,
+    definition: str | None = DEFINITION,
+    build_number: int = 10,
+) -> GroupObservation:
+    return GroupObservation(
+        group=group,
+        commit=commit,
+        outcome=outcome,
+        build_number=build_number,
+        observed_at=NOW - age,
+        build_url=f"https://buildkite.example/{build_number}",
+        trusted_main=True,
+        main_position=position,
+        execution_profile=profile,
+        definition_digest=definition,
+        failure_fingerprints=(
+            frozenset({fingerprint})
+            if outcome in {Outcome.FAILED, Outcome.FLAKY}
+            else frozenset()
+        ),
+    )
+
+
+def incident(
+    state: IncidentState,
+    *,
+    outcome: Outcome,
+    group: GroupId = GROUP,
+    age: timedelta = timedelta(hours=1),
+    fingerprint: str = FINGERPRINT,
+    profile: str | None = PROFILE,
+    definition: str | None = DEFINITION,
+) -> Incident:
+    latest = observation(
+        outcome,
+        group=group,
+        age=age,
+        fingerprint=fingerprint,
+        profile=profile,
+        definition=definition,
+    )
+    if outcome is Outcome.INCONCLUSIVE:
+        last_conclusive = observation(
+            Outcome.FAILED,
+            group=group,
+            position=MainPosition(1, 9),
+            fingerprint=fingerprint,
+            profile=profile,
+            definition=definition,
+            build_number=9,
+        )
+    else:
+        last_conclusive = latest
+    if outcome in {Outcome.FAILED, Outcome.FLAKY}:
+        last_failure = latest
+    elif state in {IncidentState.RECOVERING, IncidentState.RESOLVED}:
+        last_failure = observation(
+            Outcome.FAILED,
+            group=group,
+            commit="d" * 40,
+            position=MainPosition(1, 5),
+            fingerprint=fingerprint,
+            profile=profile,
+            definition=definition,
+            build_number=5,
+        )
+    elif outcome is Outcome.INCONCLUSIVE:
+        last_failure = last_conclusive
+    else:
+        last_failure = None
+    return Incident(
+        group=group,
+        state=state,
+        failure_count=2 if state is IncidentState.KNOWN else 0,
+        clean_count=(
+            3
+            if state is IncidentState.RESOLVED
+            else (1 if state is IncidentState.RECOVERING else 0)
+        ),
+        ever_known=state
+        in {
+            IncidentState.KNOWN,
+            IncidentState.RECOVERING,
+            IncidentState.RESOLVED,
+        },
+        latest_attempted_observation=latest,
+        last_conclusive_observation=last_conclusive,
+        last_failure_observation=last_failure,
+        confirmed_failure_fingerprints=(
+            frozenset({fingerprint})
+            if state
+            in {
+                IncidentState.KNOWN,
+                IncidentState.RECOVERING,
+                IncidentState.RESOLVED,
+            }
+            else frozenset()
+        ),
+    )
+
+
+def subject(
+    *,
+    head: str = HEAD,
+    tested_head: str = HEAD,
+    base: str = BASE,
+    ancestors: frozenset[str] = frozenset({MAIN_COMMIT, BASE}),
+) -> PullRequestRunSubject:
+    return PullRequestRunSubject(
+        repository="vllm-project/vllm",
+        pull_request_number=7,
+        head_sha=head,
+        tested_head_sha=tested_head,
+        base_sha=base,
+        base_ancestor_shas=ancestors,
+    )
+
+
+def failure(
+    *,
+    group: GroupId | None = GROUP,
+    fingerprint: str | None = FINGERPRINT,
+    profile: str | None = PROFILE,
+    definition: str | None = DEFINITION,
+) -> PullRequestFailure:
+    return PullRequestFailure(
+        label="attention tests",
+        group=group,
+        build_url="https://buildkite.example/pr",
+        failure_fingerprint=fingerprint,
+        execution_profile=profile,
+        definition_digest=definition,
+    )
+
+
+def snapshot(
+    *incidents: Incident,
+    completeness: LaneCompleteness = LaneCompleteness.COMPLETE,
+    watermark: MainPosition | None = WATERMARK,
+    generated_at: datetime = NOW,
+    policy_revision: str = "policy-v1",
+    algorithm_revision: str = "validation-v1",
+    catalog_version: str = "schema-1",
+    catalog_digest: str = "catalog-v1",
+    observations: tuple[GroupObservation, ...] = (),
+):
+    return create_snapshot(
+        catalog_version=catalog_version,
+        catalog_digest=catalog_digest,
+        policy_revision=policy_revision,
+        algorithm_revision=algorithm_revision,
+        generated_at=generated_at,
+        max_evidence_age=timedelta(days=2),
+        lanes=[LaneSnapshot("ci", completeness, watermark)],
+        incidents=incidents,
+        observations=observations,
+    )
+
+
+def validate(
+    main_incident: Incident,
+    *,
+    pr_failure: PullRequestFailure | None = None,
+    run_subject: PullRequestRunSubject | None = None,
+    current_head: str = HEAD,
+    current_base: str = BASE,
+    pr_version: str = "schema-1",
+    pr_digest: str = "catalog-v1",
+    completeness: LaneCompleteness = LaneCompleteness.COMPLETE,
+):
+    return validate_pull_request(
+        subject=run_subject or subject(),
+        current_head=current_head,
+        current_base=current_base,
+        pr_catalog_version=pr_version,
+        pr_catalog_digest=pr_digest,
+        failures=[pr_failure or failure()],
+        snapshot=snapshot(main_incident, completeness=completeness),
+        now=NOW,
+    )
+
+
+def test_exact_known_and_candidate_fingerprints_are_distinct() -> None:
+    known = validate(incident(IncidentState.KNOWN, outcome=Outcome.FAILED))
+    candidate = validate(incident(IncidentState.CANDIDATE, outcome=Outcome.FAILED))
+    assert known.results[0].classification is Classification.KNOWN_ON_MAIN
+    assert candidate.results[0].classification is Classification.CANDIDATE_ON_MAIN
+
+
+def test_group_only_red_match_is_explicitly_unverified() -> None:
+    report = validate(
+        incident(IncidentState.KNOWN, outcome=Outcome.FAILED),
+        pr_failure=failure(fingerprint=None),
+    )
+    assert report.results[0].classification is Classification.GROUP_ALSO_RED_ON_MAIN
+    assert "underlying failure is unverified" in report.results[0].explanation
+
+
+def test_different_normalized_fingerprints_are_not_called_known() -> None:
+    report = validate(
+        incident(
+            IncidentState.KNOWN,
+            outcome=Outcome.FAILED,
+            fingerprint="test_attention::different",
+        )
+    )
+    assert report.results[0].classification is Classification.DIFFERENT_FAILURE_ON_MAIN
+
+
+def test_flaky_latest_is_distinct_and_never_currently_failing() -> None:
+    report = validate(incident(IncidentState.KNOWN, outcome=Outcome.FLAKY))
+    result = report.results[0]
+    assert result.classification is Classification.SEEN_FLAKY_ON_MAIN
+    assert "later pass" in result.explanation
+    assert "currently failing" not in result.explanation
+
+
+def test_exact_recovering_and_resolved_incidents_are_distinct() -> None:
+    recovering = validate(incident(IncidentState.RECOVERING, outcome=Outcome.CLEAN))
+    resolved = validate(incident(IncidentState.RESOLVED, outcome=Outcome.CLEAN))
+    assert recovering.results[0].classification is Classification.RECOVERING_ON_MAIN
+    assert resolved.results[0].classification is Classification.RESOLVED_ON_MAIN
+
+
+def test_clean_regression_candidate_requires_compatible_base_control() -> None:
+    report = validate(incident(IncidentState.HEALTHY, outcome=Outcome.CLEAN))
+    assert report.results[0].classification is Classification.NOT_MATCHED_ON_MAIN
+    assert "possible regression" in report.results[0].explanation
+
+
+def test_clean_evidence_without_compatible_metadata_is_unable() -> None:
+    report = validate(
+        incident(
+            IncidentState.HEALTHY,
+            outcome=Outcome.CLEAN,
+            profile=None,
+            definition=None,
+        )
+    )
+    assert report.results[0].classification is Classification.UNABLE_TO_CLASSIFY
+    assert "execution profile" in report.results[0].explanation
+
+
+def test_clean_commit_newer_than_pinned_base_is_not_a_regression_control() -> None:
+    report = validate(
+        incident(IncidentState.HEALTHY, outcome=Outcome.CLEAN),
+        run_subject=subject(ancestors=frozenset({BASE})),
+    )
+    assert report.results[0].classification is Classification.UNABLE_TO_CLASSIFY
+    assert "trusted ancestor" in report.results[0].explanation
+
+
+def test_latest_inconclusive_attempt_overrides_older_known_context() -> None:
+    report = validate(incident(IncidentState.KNOWN, outcome=Outcome.INCONCLUSIVE))
+    assert report.results[0].classification is Classification.UNABLE_TO_CLASSIFY
+    assert "latest main attempt" in report.results[0].explanation
+    assert report.results[0].main_evidence is not None
+    assert report.results[0].main_evidence.outcome is Outcome.INCONCLUSIVE
+
+
+def test_partial_lane_is_unable_even_with_conclusive_group_evidence() -> None:
+    report = validate(
+        incident(IncidentState.KNOWN, outcome=Outcome.FAILED),
+        completeness=LaneCompleteness.PARTIAL,
+    )
+    assert report.results[0].classification is Classification.UNABLE_TO_CLASSIFY
+    assert "partial or unavailable" in report.results[0].explanation
+
+
+def test_missing_group_and_unkeyed_failure_are_unable() -> None:
+    main = incident(IncidentState.HEALTHY, outcome=Outcome.CLEAN)
+    missing = validate(
+        main,
+        pr_failure=failure(group=GroupId("ci", "not-on-main")),
+    )
+    unkeyed = validate(main, pr_failure=failure(group=None))
+    assert missing.results[0].classification is Classification.UNABLE_TO_CLASSIFY
+    assert unkeyed.results[0].classification is Classification.UNABLE_TO_CLASSIFY
+
+
+def test_stale_evidence_is_unable() -> None:
+    report = validate(
+        incident(
+            IncidentState.HEALTHY,
+            outcome=Outcome.CLEAN,
+            age=timedelta(days=3),
+        )
+    )
+    assert "stale" in report.results[0].explanation
+
+
+def test_global_catalog_digest_change_does_not_hide_compatible_job() -> None:
+    report = validate(
+        incident(IncidentState.KNOWN, outcome=Outcome.FAILED),
+        pr_digest="different",
+    )
+    assert report.results[0].classification is Classification.KNOWN_ON_MAIN
+
+
+def test_catalog_schema_mismatch_makes_the_whole_validation_unable() -> None:
+    report = validate(
+        incident(IncidentState.KNOWN, outcome=Outcome.FAILED),
+        pr_version="schema-2",
+    )
+    assert "catalog schemas" in report.results[0].explanation
+
+
+def test_head_base_and_tested_checkout_are_pinned_independently() -> None:
+    main = incident(IncidentState.KNOWN, outcome=Outcome.FAILED)
+
+    stale_head = validate(main, current_head="e" * 40)
+    assert stale_head.stale_head
+
+    stale_base = validate(main, current_base="f" * 40)
+    assert stale_base.stale_base
+
+    wrong_checkout = validate(
+        main,
+        run_subject=subject(tested_head="e" * 40),
+    )
+    assert "not produced from the exact" in wrong_checkout.results[0].explanation
+
+
+def test_snapshot_revision_changes_with_every_classification_input() -> None:
+    stale = snapshot(
+        incident(
+            IncidentState.KNOWN,
+            outcome=Outcome.FAILED,
+            age=timedelta(days=3),
+        )
+    )
+    fresh = snapshot(incident(IncidentState.KNOWN, outcome=Outcome.FAILED))
+    new_generation_time = snapshot(
+        incident(IncidentState.KNOWN, outcome=Outcome.FAILED),
+        generated_at=NOW + timedelta(minutes=1),
+    )
+    new_policy = snapshot(
+        incident(IncidentState.KNOWN, outcome=Outcome.FAILED),
+        policy_revision="policy-v2",
+    )
+    new_algorithm = snapshot(
+        incident(IncidentState.KNOWN, outcome=Outcome.FAILED),
+        algorithm_revision="validation-v2",
+    )
+    partial = snapshot(
+        incident(IncidentState.KNOWN, outcome=Outcome.FAILED),
+        completeness=LaneCompleteness.PARTIAL,
+    )
+
+    revisions = {
+        stale.revision,
+        fresh.revision,
+        new_generation_time.revision,
+        new_policy.revision,
+        new_algorithm.revision,
+        partial.revision,
+    }
+    assert len(revisions) == 6
+
+
+def test_snapshot_revision_is_deterministic_for_identical_content() -> None:
+    main = incident(IncidentState.KNOWN, outcome=Outcome.FAILED)
+    assert snapshot(main).revision == snapshot(main).revision
+
+
+def test_clean_control_uses_newest_fresh_observation_in_base_ancestry() -> None:
+    older = observation(
+        Outcome.CLEAN,
+        commit="d" * 40,
+        position=MainPosition(1, 8),
+        build_number=8,
+    )
+    latest = observation(
+        Outcome.CLEAN,
+        commit=MAIN_COMMIT,
+        position=WATERMARK,
+    )
+    main = incident(IncidentState.HEALTHY, outcome=Outcome.CLEAN)
+    frozen = snapshot(main, observations=(older, latest))
+    report = validate_pull_request(
+        subject=subject(ancestors=frozenset({BASE, older.commit})),
+        current_head=HEAD,
+        current_base=BASE,
+        pr_catalog_version="schema-1",
+        pr_catalog_digest="different-but-compatible",
+        failures=[failure()],
+        snapshot=frozen,
+        now=NOW,
+    )
+
+    result = report.results[0]
+    assert result.classification is Classification.NOT_MATCHED_ON_MAIN
+    assert result.main_evidence == older

--- a/services/ci-control/uv.lock
+++ b/services/ci-control/uv.lock
@@ -1,0 +1,388 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/e3/85ec501f206fb049259288c1f3506e53876937fb00edb47009348e66756b/charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e94703ec9684807f20cfb5eed95c70f67f2a8f21ad620146d7b5a13677b93e5", size = 317075, upload-time = "2026-07-07T14:32:56.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/69/2a5385192e67175f7d8bd5ce4f57c24bc956439adeae5c13a99aa28a53d1/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a441ea71902098ffe78c5abe6c494f44160b4af614ed16c3d9a3b1d17fd8ee2", size = 213837, upload-time = "2026-07-07T14:32:57.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/46/03ddc7da576d814fe0a36dd1f0fd3258e95404b4b2e3c026b7923d7e133f/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:304b13570067b2547562e308af560b3963857b1fa90bd6afd978130130fe2d6a", size = 235503, upload-time = "2026-07-07T14:32:59.205Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/6e/de0229a7ef40f6f9d28a837eebf4ec47bdca5dab4e900c84f22919af636a/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4773092f8019072343a7447203308b176e10199920eb02d6195e81bbb3274c29", size = 229944, upload-time = "2026-07-07T14:33:00.803Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/34/49b9060e8418b14fb5cba9cf6bfb383111e2538a03a1fb18e66a95aeb3d5/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c", size = 221276, upload-time = "2026-07-07T14:33:02.199Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/80282cce0fae9c3061203d723ee87da996aed79679e65d8935050ee7ca1f/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:c0323c9daef75ef2e5083624b4585018a0c9d5e3b40f607eed81a311270b934b", size = 205260, upload-time = "2026-07-07T14:33:03.698Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/74/2f62c8821b969ea3bd67cc2e6976834f48ca5d12664d2559ebcd9bcfbed7/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:871ff67ea1aad4dfd91736464934d56b32dac49f9fbe16cddba36198a7b3a0db", size = 217786, upload-time = "2026-07-07T14:33:05.12Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8d/feabb82cb49fcad14515b1d7d1ca4787b0da7fc723a212bf89bc9e0fac52/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67830fc78e67501f47bb950471b2dcb9b35b140084429318e862895a8e89c993", size = 216798, upload-time = "2026-07-07T14:33:06.629Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ff/c946d63bc3786d5b84d960b0f7ab7e25b828486a946b5aa997625bcaf6a6/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3d92613ec25e43b05f042302531ec0f00b8445190e43325880cbd6ab7c2581da", size = 206429, upload-time = "2026-07-07T14:33:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ba/5e5007c370702f85d2ef75791fac7943ed41e080364a673b20142e430e3e/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:280081916dc341820640489a66e4696049401ef1cf6dd672f672e70ad915aca3", size = 223066, upload-time = "2026-07-07T14:33:09.783Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d5/9096aa3cf532dfad237861544eb47a0f20d5adbf1039760fed8eaae935d9/charset_normalizer-3.4.9-cp311-cp311-win32.whl", hash = "sha256:ac351b3b8014eead140e77e9717e2992c6bbe30b63bc3422422eb84865412e3d", size = 150456, upload-time = "2026-07-07T14:33:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a1/e29995109e455dc8eff8d0fac6ae509be39561318a7cfeac5d33ad029213/charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:6366a16e1a25018694d6a5d784d09b046edc9eac40ea2b54065c3052672516a1", size = 161410, upload-time = "2026-07-07T14:33:12.743Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8d/1569f4d0032d6ba2a4fe4591c35bf87868c600c41a71eb5c2e1ffa8464c2/charset_normalizer-3.4.9-cp311-cp311-win_arm64.whl", hash = "sha256:1d22856ffbe153a602df38e4a5464f0b748a54002e0d69ac6d2ad0a197cc99ec", size = 152649, upload-time = "2026-07-07T14:33:14.173Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.1.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121, upload-time = "2023-08-17T17:29:11.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28", size = 97941, upload-time = "2023-08-17T17:29:10.08Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/b7/d9e3f12af310e1120c21603644a1cd86f59060e040ec5c3a80b8f05fae30/pydantic-2.9.2.tar.gz", hash = "sha256:d155cef71265d1e9807ed1c32b4c8deec042a44a50a4188b25ac67ecd81a9c0f", size = 769917, upload-time = "2024-09-17T15:59:54.273Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/e4/ba44652d562cbf0bf320e0f3810206149c8a4e99cdbf66da82e97ab53a15/pydantic-2.9.2-py3-none-any.whl", hash = "sha256:f048cec7b26778210e28a0459867920654d48e5e62db0958433636cde4254f12", size = 434928, upload-time = "2024-09-17T15:59:51.827Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.23.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/aa/6b6a9b9f8537b872f552ddd46dd3da230367754b6f707b8e1e963f515ea3/pydantic_core-2.23.4.tar.gz", hash = "sha256:2584f7cf844ac4d970fba483a717dbe10c1c1c96a969bf65d61ffe94df1b2863", size = 402156, upload-time = "2024-09-16T16:06:44.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/30/890a583cd3f2be27ecf32b479d5d615710bb926d92da03e3f7838ff3e58b/pydantic_core-2.23.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:77733e3892bb0a7fa797826361ce8a9184d25c8dffaec60b7ffe928153680ba8", size = 1865160, upload-time = "2024-09-16T16:04:18.628Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/9a/b634442e1253bc6889c87afe8bb59447f106ee042140bd57680b3b113ec7/pydantic_core-2.23.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b84d168f6c48fabd1f2027a3d1bdfe62f92cade1fb273a5d68e621da0e44e6d", size = 1776777, upload-time = "2024-09-16T16:04:20.038Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9a/7816295124a6b08c24c96f9ce73085032d8bcbaf7e5a781cd41aa910c891/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df49e7a0861a8c36d089c1ed57d308623d60416dab2647a4a17fe050ba85de0e", size = 1799244, upload-time = "2024-09-16T16:04:21.799Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8f/89c1405176903e567c5f99ec53387449e62f1121894aa9fc2c4fdc51a59b/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ff02b6d461a6de369f07ec15e465a88895f3223eb75073ffea56b84d9331f607", size = 1805307, upload-time = "2024-09-16T16:04:23.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a5/1a194447d0da1ef492e3470680c66048fef56fc1f1a25cafbea4bc1d1c48/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:996a38a83508c54c78a5f41456b0103c30508fed9abcad0a59b876d7398f25fd", size = 2000663, upload-time = "2024-09-16T16:04:25.203Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a5/1df8541651de4455e7d587cf556201b4f7997191e110bca3b589218745a5/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d97683ddee4723ae8c95d1eddac7c192e8c552da0c73a925a89fa8649bf13eea", size = 2655941, upload-time = "2024-09-16T16:04:27.211Z" },
+    { url = "https://files.pythonhosted.org/packages/44/31/a3899b5ce02c4316865e390107f145089876dff7e1dfc770a231d836aed8/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:216f9b2d7713eb98cb83c80b9c794de1f6b7e3145eef40400c62e86cee5f4e1e", size = 2052105, upload-time = "2024-09-16T16:04:28.611Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/aa/98e190f8745d5ec831f6d5449344c48c0627ac5fed4e5340a44b74878f8e/pydantic_core-2.23.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6f783e0ec4803c787bcea93e13e9932edab72068f68ecffdf86a99fd5918878b", size = 1919967, upload-time = "2024-09-16T16:04:30.045Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/35/b6e00b6abb2acfee3e8f85558c02a0822e9a8b2f2d812ea8b9079b118ba0/pydantic_core-2.23.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d0776dea117cf5272382634bd2a5c1b6eb16767c223c6a5317cd3e2a757c61a0", size = 1964291, upload-time = "2024-09-16T16:04:32.376Z" },
+    { url = "https://files.pythonhosted.org/packages/13/46/7bee6d32b69191cd649bbbd2361af79c472d72cb29bb2024f0b6e350ba06/pydantic_core-2.23.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d5f7a395a8cf1621939692dba2a6b6a830efa6b3cee787d82c7de1ad2930de64", size = 2109666, upload-time = "2024-09-16T16:04:33.923Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ef/7b34f1b122a81b68ed0a7d0e564da9ccdc9a2924c8d6c6b5b11fa3a56970/pydantic_core-2.23.4-cp311-none-win32.whl", hash = "sha256:74b9127ffea03643e998e0c5ad9bd3811d3dac8c676e47db17b0ee7c3c3bf35f", size = 1732940, upload-time = "2024-09-16T16:04:35.467Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/76/37b7e76c645843ff46c1d73e046207311ef298d3f7b2f7d8f6ac60113071/pydantic_core-2.23.4-cp311-none-win_amd64.whl", hash = "sha256:98d134c954828488b153d88ba1f34e14259284f256180ce659e8d83e9c05eaa3", size = 1916804, upload-time = "2024-09-16T16:04:37.06Z" },
+    { url = "https://files.pythonhosted.org/packages/74/7b/8e315f80666194b354966ec84b7d567da77ad927ed6323db4006cf915f3f/pydantic_core-2.23.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f3e0da4ebaef65158d4dfd7d3678aad692f7666877df0002b8a522cdf088f231", size = 1856459, upload-time = "2024-09-16T16:04:38.438Z" },
+    { url = "https://files.pythonhosted.org/packages/14/de/866bdce10ed808323d437612aca1ec9971b981e1c52e5e42ad9b8e17a6f6/pydantic_core-2.23.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f69a8e0b033b747bb3e36a44e7732f0c99f7edd5cea723d45bc0d6e95377ffee", size = 1770007, upload-time = "2024-09-16T16:04:40.229Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/69/8edd5c3cd48bb833a3f7ef9b81d7666ccddd3c9a635225214e044b6e8281/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:723314c1d51722ab28bfcd5240d858512ffd3116449c557a1336cbe3919beb87", size = 1790245, upload-time = "2024-09-16T16:04:41.794Z" },
+    { url = "https://files.pythonhosted.org/packages/80/33/9c24334e3af796ce80d2274940aae38dd4e5676298b4398eff103a79e02d/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bb2802e667b7051a1bebbfe93684841cc9351004e2badbd6411bf357ab8d5ac8", size = 1801260, upload-time = "2024-09-16T16:04:43.991Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6f/e9567fd90104b79b101ca9d120219644d3314962caa7948dd8b965e9f83e/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d18ca8148bebe1b0a382a27a8ee60350091a6ddaf475fa05ef50dc35b5df6327", size = 1996872, upload-time = "2024-09-16T16:04:45.593Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/ad/b5f0fe9e6cfee915dd144edbd10b6e9c9c9c9d7a56b69256d124b8ac682e/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33e3d65a85a2a4a0dc3b092b938a4062b1a05f3a9abde65ea93b233bca0e03f2", size = 2661617, upload-time = "2024-09-16T16:04:47.3Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c8/7d4b708f8d05a5cbfda3243aad468052c6e99de7d0937c9146c24d9f12e9/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:128585782e5bfa515c590ccee4b727fb76925dd04a98864182b22e89a4e6ed36", size = 2071831, upload-time = "2024-09-16T16:04:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/89/4d/3079d00c47f22c9a9a8220db088b309ad6e600a73d7a69473e3a8e5e3ea3/pydantic_core-2.23.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:68665f4c17edcceecc112dfed5dbe6f92261fb9d6054b47d01bf6371a6196126", size = 1917453, upload-time = "2024-09-16T16:04:51.099Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/88/9df5b7ce880a4703fcc2d76c8c2d8eb9f861f79d0c56f4b8f5f2607ccec8/pydantic_core-2.23.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:20152074317d9bed6b7a95ade3b7d6054845d70584216160860425f4fbd5ee9e", size = 1968793, upload-time = "2024-09-16T16:04:52.604Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/b9/41f7efe80f6ce2ed3ee3c2dcfe10ab7adc1172f778cc9659509a79518c43/pydantic_core-2.23.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:9261d3ce84fa1d38ed649c3638feefeae23d32ba9182963e465d58d62203bd24", size = 2116872, upload-time = "2024-09-16T16:04:54.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/08/b59b7a92e03dd25554b0436554bf23e7c29abae7cce4b1c459cd92746811/pydantic_core-2.23.4-cp312-none-win32.whl", hash = "sha256:4ba762ed58e8d68657fc1281e9bb72e1c3e79cc5d464be146e260c541ec12d84", size = 1738535, upload-time = "2024-09-16T16:04:55.828Z" },
+    { url = "https://files.pythonhosted.org/packages/88/8d/479293e4d39ab409747926eec4329de5b7129beaedc3786eca070605d07f/pydantic_core-2.23.4-cp312-none-win_amd64.whl", hash = "sha256:97df63000f4fea395b2824da80e169731088656d1818a11b95f3b173747b6cd9", size = 1917992, upload-time = "2024-09-16T16:04:57.395Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ef/16ee2df472bf0e419b6bc68c05bf0145c49247a1095e85cee1463c6a44a1/pydantic_core-2.23.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7530e201d10d7d14abce4fb54cfe5b94a0aefc87da539d0346a484ead376c3cc", size = 1856143, upload-time = "2024-09-16T16:04:59.062Z" },
+    { url = "https://files.pythonhosted.org/packages/da/fa/bc3dbb83605669a34a93308e297ab22be82dfb9dcf88c6cf4b4f264e0a42/pydantic_core-2.23.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df933278128ea1cd77772673c73954e53a1c95a4fdf41eef97c2b779271bd0bd", size = 1770063, upload-time = "2024-09-16T16:05:00.522Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/e813f3bbd257a712303ebdf55c8dc46f9589ec74b384c9f652597df3288d/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cb3da3fd1b6a5d0279a01877713dbda118a2a4fc6f0d821a57da2e464793f05", size = 1790013, upload-time = "2024-09-16T16:05:02.619Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/56eda3a37929a1d297fcab1966db8c339023bcca0b64c5a84896db3fcc5c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42c6dcb030aefb668a2b7009c85b27f90e51e6a3b4d5c9bc4c57631292015b0d", size = 1801077, upload-time = "2024-09-16T16:05:04.154Z" },
+    { url = "https://files.pythonhosted.org/packages/04/be/5e49376769bfbf82486da6c5c1683b891809365c20d7c7e52792ce4c71f3/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:696dd8d674d6ce621ab9d45b205df149399e4bb9aa34102c970b721554828510", size = 1996782, upload-time = "2024-09-16T16:05:06.931Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/24/e3ee6c04f1d58cc15f37bcc62f32c7478ff55142b7b3e6d42ea374ea427c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2971bb5ffe72cc0f555c13e19b23c85b654dd2a8f7ab493c262071377bfce9f6", size = 2661375, upload-time = "2024-09-16T16:05:08.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f8/11a9006de4e89d016b8de74ebb1db727dc100608bb1e6bbe9d56a3cbbcce/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8394d940e5d400d04cad4f75c0598665cbb81aecefaca82ca85bd28264af7f9b", size = 2071635, upload-time = "2024-09-16T16:05:10.456Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/45/bdce5779b59f468bdf262a5bc9eecbae87f271c51aef628d8c073b4b4b4c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0dff76e0602ca7d4cdaacc1ac4c005e0ce0dcfe095d5b5259163a80d3a10d327", size = 1916994, upload-time = "2024-09-16T16:05:12.051Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/fa/c648308fe711ee1f88192cad6026ab4f925396d1293e8356de7e55be89b5/pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7d32706badfe136888bdea71c0def994644e09fff0bfe47441deaed8e96fdbc6", size = 1968877, upload-time = "2024-09-16T16:05:14.021Z" },
+    { url = "https://files.pythonhosted.org/packages/16/16/b805c74b35607d24d37103007f899abc4880923b04929547ae68d478b7f4/pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed541d70698978a20eb63d8c5d72f2cc6d7079d9d90f6b50bad07826f1320f5f", size = 2116814, upload-time = "2024-09-16T16:05:15.684Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/58/5305e723d9fcdf1c5a655e6a4cc2a07128bf644ff4b1d98daf7a9dbf57da/pydantic_core-2.23.4-cp313-none-win32.whl", hash = "sha256:3d5639516376dce1940ea36edf408c554475369f5da2abd45d44621cb616f769", size = 1738360, upload-time = "2024-09-16T16:05:17.258Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ae/e14b0ff8b3f48e02394d8acd911376b7b66e164535687ef7dc24ea03072f/pydantic_core-2.23.4-cp313-none-win_amd64.whl", hash = "sha256:5a1504ad17ba4210df3a045132a7baeeba5a200e930f57512ee02909fc5c4cb5", size = 1919411, upload-time = "2024-09-16T16:05:18.934Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/b9/9bd84453ed6dd04688de9b3f3a4146a1698e8faae2ceeccce4e14c67ae17/ruff-0.14.0.tar.gz", hash = "sha256:62ec8969b7510f77945df916de15da55311fade8d6050995ff7f680afe582c57", size = 5452071, upload-time = "2025-10-07T18:21:55.763Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/4e/79d463a5f80654e93fa653ebfb98e0becc3f0e7cf6219c9ddedf1e197072/ruff-0.14.0-py3-none-linux_armv6l.whl", hash = "sha256:58e15bffa7054299becf4bab8a1187062c6f8cafbe9f6e39e0d5aface455d6b3", size = 12494532, upload-time = "2025-10-07T18:21:00.373Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/40/e2392f445ed8e02aa6105d49db4bfff01957379064c30f4811c3bf38aece/ruff-0.14.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:838d1b065f4df676b7c9957992f2304e41ead7a50a568185efd404297d5701e8", size = 13160768, upload-time = "2025-10-07T18:21:04.73Z" },
+    { url = "https://files.pythonhosted.org/packages/75/da/2a656ea7c6b9bd14c7209918268dd40e1e6cea65f4bb9880eaaa43b055cd/ruff-0.14.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:703799d059ba50f745605b04638fa7e9682cc3da084b2092feee63500ff3d9b8", size = 12363376, upload-time = "2025-10-07T18:21:07.833Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e2/1ffef5a1875add82416ff388fcb7ea8b22a53be67a638487937aea81af27/ruff-0.14.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ba9a8925e90f861502f7d974cc60e18ca29c72bb0ee8bfeabb6ade35a3abde7", size = 12608055, upload-time = "2025-10-07T18:21:10.72Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/32/986725199d7cee510d9f1dfdf95bf1efc5fa9dd714d0d85c1fb1f6be3bc3/ruff-0.14.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e41f785498bd200ffc276eb9e1570c019c1d907b07cfb081092c8ad51975bbe7", size = 12318544, upload-time = "2025-10-07T18:21:13.741Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/ed/4969cefd53315164c94eaf4da7cfba1f267dc275b0abdd593d11c90829a3/ruff-0.14.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30a58c087aef4584c193aebf2700f0fbcfc1e77b89c7385e3139956fa90434e2", size = 14001280, upload-time = "2025-10-07T18:21:16.411Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ad/96c1fc9f8854c37681c9613d825925c7f24ca1acfc62a4eb3896b50bacd2/ruff-0.14.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f8d07350bc7af0a5ce8812b7d5c1a7293cf02476752f23fdfc500d24b79b783c", size = 15027286, upload-time = "2025-10-07T18:21:19.577Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/00/1426978f97df4fe331074baf69615f579dc4e7c37bb4c6f57c2aad80c87f/ruff-0.14.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eec3bbbf3a7d5482b5c1f42d5fc972774d71d107d447919fca620b0be3e3b75e", size = 14451506, upload-time = "2025-10-07T18:21:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/9c1cea6e493c0cf0647674cca26b579ea9d2a213b74b5c195fbeb9678e15/ruff-0.14.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:16b68e183a0e28e5c176d51004aaa40559e8f90065a10a559176713fcf435206", size = 13437384, upload-time = "2025-10-07T18:21:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b4/4cd6a4331e999fc05d9d77729c95503f99eae3ba1160469f2b64866964e3/ruff-0.14.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb732d17db2e945cfcbbc52af0143eda1da36ca8ae25083dd4f66f1542fdf82e", size = 13447976, upload-time = "2025-10-07T18:21:28.83Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c0/ac42f546d07e4f49f62332576cb845d45c67cf5610d1851254e341d563b6/ruff-0.14.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:c958f66ab884b7873e72df38dcabee03d556a8f2ee1b8538ee1c2bbd619883dd", size = 13682850, upload-time = "2025-10-07T18:21:31.842Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c4/4b0c9bcadd45b4c29fe1af9c5d1dc0ca87b4021665dfbe1c4688d407aa20/ruff-0.14.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7eb0499a2e01f6e0c285afc5bac43ab380cbfc17cd43a2e1dd10ec97d6f2c42d", size = 12449825, upload-time = "2025-10-07T18:21:35.074Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a8/e2e76288e6c16540fa820d148d83e55f15e994d852485f221b9524514730/ruff-0.14.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:4c63b2d99fafa05efca0ab198fd48fa6030d57e4423df3f18e03aa62518c565f", size = 12272599, upload-time = "2025-10-07T18:21:38.08Z" },
+    { url = "https://files.pythonhosted.org/packages/18/14/e2815d8eff847391af632b22422b8207704222ff575dec8d044f9ab779b2/ruff-0.14.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:668fce701b7a222f3f5327f86909db2bbe99c30877c8001ff934c5413812ac02", size = 13193828, upload-time = "2025-10-07T18:21:41.216Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c6/61ccc2987cf0aecc588ff8f3212dea64840770e60d78f5606cd7dc34de32/ruff-0.14.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a86bf575e05cb68dcb34e4c7dfe1064d44d3f0c04bbc0491949092192b515296", size = 13628617, upload-time = "2025-10-07T18:21:44.04Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e6/03b882225a1b0627e75339b420883dc3c90707a8917d2284abef7a58d317/ruff-0.14.0-py3-none-win32.whl", hash = "sha256:7450a243d7125d1c032cb4b93d9625dea46c8c42b4f06c6b709baac168e10543", size = 12367872, upload-time = "2025-10-07T18:21:46.67Z" },
+    { url = "https://files.pythonhosted.org/packages/41/77/56cf9cf01ea0bfcc662de72540812e5ba8e9563f33ef3d37ab2174892c47/ruff-0.14.0-py3-none-win_amd64.whl", hash = "sha256:ea95da28cd874c4d9c922b39381cbd69cb7e7b49c21b8152b014bd4f52acddc2", size = 13464628, upload-time = "2025-10-07T18:21:50.318Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2a/65880dfd0e13f7f13a775998f34703674a4554906167dce02daf7865b954/ruff-0.14.0-py3-none-win_arm64.whl", hash = "sha256:f42c9495f5c13ff841b1da4cb3c2a42075409592825dada7c5885c2c844ac730", size = 12565142, upload-time = "2025-10-07T18:21:53.577Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "vllm-ci-control"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.optional-dependencies]
+repository-validation = [
+    { name = "pyyaml" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "click" },
+    { name = "pydantic" },
+    { name = "pytest" },
+    { name = "requests" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pyyaml", marker = "extra == 'repository-validation'", specifier = ">=6.0.2,<7" }]
+provides-extras = ["repository-validation"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "click", specifier = "==8.1.7" },
+    { name = "pydantic", specifier = "==2.9.2" },
+    { name = "pytest", specifier = ">=8.3,<10" },
+    { name = "requests", specifier = ">=2.32,<3" },
+    { name = "ruff", specifier = "==0.14.0" },
+]


### PR DESCRIPTION
## Purpose

This rebuilds the existing PR from current `main` as a single, modular foundation for the new `/ci` control plane. The public contract and rollout design live in `services/ci-control/README.md`.

- Parse a strict, one-line API for help, status/refresh, planning, targeted runs, failure retries, credit inspection, and administrative top-ups.
- Enforce repository policy: 300 initial job credits, write/committer access for execution, maintain/admin access for grants, and configurable retry limits including `inf`.
- Compile stable job, area, group, and lane selectors with dependency closure, costs, aliases, tombstones, and definition revisions.
- Normalize Buildkite/GitHub evidence and reduce main failures into versioned incident snapshots with confirmation, recovery, force-push epoch, and freshness rules.
- Compare each PR failure with compatible main evidence as known, candidate, flaky, recovering, resolved, different, group-red, unmatched, or unable-to-classify.
- Keep domain logic behind explicit ports for authorization, CI providers, persistence, and clocks; add bounded GitHub and Buildkite adapters.
- Validate vLLM catalog changes against the exact base catalog through a reusable, secretless, SHA-pinnable action.

The native AMD pipeline is modeled honestly as an opaque whole lane until it exposes direct job-level dispatch/evidence. Stateful logic stays here; vLLM owns only trusted policy and catalog metadata.

## Deployment boundary

This foundation intentionally does **not** deploy a gateway, database, webhook receiver, or reconciliation worker. Mutation commands remain disabled until a durable transactional runtime is added. That prevents the new and legacy mutation paths from operating concurrently.

## Test plan and result

- `cd services/ci-control && uv run --frozen --group dev --extra repository-validation pytest -q` — 152 passed.
- `uv run --project services/ci-control --frozen --group dev --extra repository-validation pytest -q buildkite/tests` — 51 passed.
- Service Ruff check and format check — passed.
- `actionlint` and relevant repository pre-commit checks — passed.
- Compiled the rebuilt vLLM catalog — 267 selectable jobs, 276 total jobs.

This is not a duplicate: it replaces the earlier contents of this same PR after checking for overlapping open work. AI assistance (OpenAI Codex) was used to design, implement, test, and review the change; the human submitter must review and understand every changed line before merge.