### PR TITLE
[CI] Retry jobs that lose their agent

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 from typing import Dict, List, Optional, Any, Union, Literal
+from copy import deepcopy
 import os
 
 from amd import (
@@ -29,6 +30,7 @@ PRECOMMIT_MAX_WAIT = 3600  # 30 minutes
 PRECOMMIT_WAIT_INTERVAL = 60
 
 SKIP_TIMEOUT_ENV_VAR = "SKIP_TIMEOUT"
+EXIT_STATUS_NEGATIVE_ONE_RETRY = {"exit_status": -1, "limit": 1}
 
 
 # Self-contained poll of the pre-commit GitHub Actions check run. Baked with the
@@ -442,6 +444,41 @@ def _matches_source_dependency(source_file: str, diff_file: str) -> bool:
     return diff_file == normalized or diff_file.startswith(f"{normalized}/")
 
 
+def ensure_exit_status_negative_one_retry(
+    retry: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Add a one-time retry for jobs that lose their agent."""
+    retry_policy = deepcopy(retry or {})
+    automatic = retry_policy.get("automatic")
+
+    if automatic is True:
+        return retry_policy
+
+    if automatic is None or automatic is False:
+        automatic_conditions = []
+    elif isinstance(automatic, dict):
+        if automatic.get("exit_status") == -1:
+            return retry_policy
+        automatic_conditions = [automatic]
+    elif isinstance(automatic, list):
+        automatic_conditions = automatic
+        if any(
+            isinstance(condition, dict) and condition.get("exit_status") == -1
+            for condition in automatic_conditions
+        ):
+            return retry_policy
+    else:
+        raise ValueError(
+            "retry.automatic must be a boolean, mapping, or list."
+        )
+
+    retry_policy["automatic"] = [
+        dict(EXIT_STATUS_NEGATIVE_ONE_RETRY),
+        *automatic_conditions,
+    ]
+    return retry_policy
+
+
 def convert_group_step_to_buildkite_step(
     group_steps: Dict[str, List[Step]],
 ) -> List[BuildkiteGroupStep]:
@@ -512,6 +549,9 @@ def convert_group_step_to_buildkite_step(
                 buildkite_step.env = step.env
             if step.retry:
                 buildkite_step.retry = step.retry
+            buildkite_step.retry = ensure_exit_status_negative_one_retry(
+                buildkite_step.retry
+            )
             if step.key:
                 buildkite_step.key = step.key
             if step.parallelism:

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -84,6 +84,42 @@ def test_continue_on_failure_exits_nonzero_after_command_failure(monkeypatch):
     assert result.returncode == 1
 
 
+def test_generated_steps_retry_when_the_agent_is_lost():
+    step = Step(
+        label="Agent retry",
+        group="Failure handling",
+        key="image-build-agent-retry",
+        device="h100",
+        commands=["pytest tests/basic.py"],
+    )
+
+    command_step = _render_single_step(step).steps[0]
+
+    assert command_step.retry == {
+        "automatic": [{"exit_status": -1, "limit": 1}],
+    }
+
+
+def test_agent_lost_retry_preserves_step_retry_conditions():
+    step = Step(
+        label="Agent retry with policy",
+        group="Failure handling",
+        key="image-build-agent-retry-with-policy",
+        device="h100",
+        commands=["pytest tests/basic.py"],
+        retry={"automatic": {"exit_status": 143, "limit": 2}},
+    )
+
+    command_step = _render_single_step(step).steps[0]
+
+    assert command_step.retry == {
+        "automatic": [
+            {"exit_status": -1, "limit": 1},
+            {"exit_status": 143, "limit": 2},
+        ],
+    }
+
+
 def test_multi_gpu_step_dumps_nvidia_topology():
     step = Step(
         label="Distributed Comm Ops Test",


### PR DESCRIPTION
## Summary

- retry generated command jobs once when Buildkite reports `exit_status: -1`
- preserve explicit per-step retry conditions and avoid duplicating the lost-agent rule
- cover the default and existing-policy cases with generator tests

## Why

`-1` represents a job that lost its agent, so it should receive one clean retry instead of failing the build immediately. AMD GPU jobs already had this handling, but the shared generator and AMD CPU-generated steps did not.

## Duplicate check

Open PRs #435 and #429 are AMD-only Hugging Face retry policies; neither adds the shared lost-agent retry policy.

## Validation

`uv run --project /Users/khluu/ci-infra/buildkite/pipeline_generator --with pytest pytest /Users/khluu/ci-infra/buildkite/tests/pipeline_generator/test_step.py /Users/khluu/ci-infra/buildkite/tests/pipeline_generator/test_amd.py -v`

Result: 40 passed.
