### PR TITLE
[CI] Modernize and harden Agent Stack Kubernetes installer

### DIFF
--- a/infra-k8s/agent-stack-values.yaml
+++ b/infra-k8s/agent-stack-values.yaml
@@ -1,0 +1,15 @@
+annotations:
+  prometheus.io/path: /metrics
+  prometheus.io/port: "9216"
+  prometheus.io/scrape: "true"
+
+config:
+  enable-completion-watcher: true
+  pod-pending-timeout: 15m
+  prometheus-port: 9216
+  reservation-expiry-seconds: 900
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 100Mi

--- a/infra-k8s/install-buildkite-k8s.sh
+++ b/infra-k8s/install-buildkite-k8s.sh
@@ -1,10 +1,17 @@
-set -ex
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+agentStackVersion=${AGENT_STACK_K8S_VERSION:-0.46.3}
+scriptDir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 
 # gcloud container clusters get-credentials vllm-ci-test-cluster --region us-central1 --project vllm-405802
 
 # ensure current K8s cluster is vllm-ci-test-cluster
-kubectl config current-context | grep vllm-ci-test-cluster || (echo "Current K8s cluster is not vllm-ci-test-cluster" && exit 1)
-
+if ! kubectl config current-context | grep -q vllm-ci-test-cluster; then
+    echo "Current K8s cluster is not vllm-ci-test-cluster"
+    exit 1
+fi
 
 agentToken=${TF_VAR_buildkite_agent_token:-}
 if [ -z "$agentToken" ]; then
@@ -12,16 +19,19 @@ if [ -z "$agentToken" ]; then
     exit 1
 fi
 
-graphqlToken=${BUILDKITE_GRAPHQL_TOKEN:-}
-if [ -z "$graphqlToken" ]; then
-    echo "BUILDKITE_GRAPHQL_TOKEN is not set"
+agentQueue=${BUILDKITE_AGENT_QUEUE:-}
+if [ -z "$agentQueue" ]; then
+    echo "BUILDKITE_AGENT_QUEUE is not set"
     exit 1
 fi
 
-
 helm upgrade --install agent-stack-k8s oci://ghcr.io/buildkite/helm/agent-stack-k8s \
+    --version "$agentStackVersion" \
     --create-namespace \
     --namespace buildkite \
-    --set config.org=vllm \
-    --set agentToken=$agentToken \
-    --set graphqlToken=$graphqlToken
+    --values "$scriptDir/agent-stack-values.yaml" \
+    --set-string agentToken="$agentToken" \
+    --set-string config.queue="$agentQueue" \
+    --atomic \
+    --wait \
+    --timeout 10m


### PR DESCRIPTION
## Summary

Source review found that the Kubernetes installer was stale. Against the tested Buildkite Agent Stack chart, it passes invalid `config.org`, does not select a queue (and therefore targets the default queue), floats the chart version, and still requires obsolete GraphQL configuration.

This change:

- pins the tested `agent-stack-k8s` chart default to `0.46.3`;
- requires an explicit `BUILDKITE_AGENT_QUEUE` (`b200-k8s` for the B200 queue);
- removes invalid `config.org` and obsolete GraphQL settings;
- makes Helm upgrades atomic, waited, and bounded by a 10-minute timeout; and
- adds a checked-in values baseline for controller requests, completion/reservation timeouts, and Prometheus scrape annotations.

## Validation

- `bash -n infra-k8s/install-buildkite-k8s.sh`
- ShellCheck using `koalaman/shellcheck:stable`
- `git diff --check`
- Helm render using `alpine/helm:3.19.0`, chart `0.46.3`, a dummy token, and `BUILDKITE_AGENT_QUEUE=b200-k8s`; verified the queue, metrics annotations, controller image, and resource requests
- Parsed the rendered ConfigMap with the official `0.46.3` controller image; configuration loading succeeded and stopped only at the expected missing in-cluster Kubernetes environment

## ⚠️ Pre-merge checklist for Kevin/operators

- [ ] Capture live `helm get values` and `helm get manifest`, then compare them with this render so existing deployment-specific settings are preserved.
- [ ] Confirm the target cluster satisfies the chart's Kubernetes `>=1.29.0-0` requirement and confirm the cluster agent token is correct.
- [ ] Confirm the exact queue name; use `b200-k8s` for B200.
- [ ] Exercise upgrade and rollback in an appropriate nonproduction or otherwise controlled deployment before touching production.

## Non-goals

No live cluster was accessed. This does not provide or claim control-plane HA. It does not add storage limits without measurements.

No overlapping open PR was found for the installer/Agent Stack/B200 reliability searches.