### PR TITLE
[CI] Add explicit step-key filtering to pipeline generator

### DIFF
--- a/buildkite/pipeline_generator/README.md
+++ b/buildkite/pipeline_generator/README.md
@@ -78,3 +78,6 @@ The generator relies on several environment variables, typically provided by Bui
 *   `SKIP_TIMEOUT`: Set to "1" at pipeline generation time to omit all configured step timeouts.
 *   `DOCS_ONLY_DISABLE`: Set to "0" to enable skipping CI for doc-only changes.
 *   `VLLM_USE_PRECOMPILED`: Set to "1" to force use of precompiled wheels.
+*   `VLLM_CI_ONLY_STEP_KEYS`: A non-empty JSON array of stable step keys. When
+    set, the generator emits those steps and their transitive dependencies,
+    ignoring normal source-file selection. Unknown keys fail generation.

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -17,7 +17,11 @@ from amd import (
     is_amd_gpu_device,
 )
 from step import Step
-from utils_lib.docker_utils import get_image, get_ecr_cache_registry, get_torch_nightly_image
+from utils_lib.docker_utils import (
+    get_image,
+    get_ecr_cache_registry,
+    get_torch_nightly_image,
+)
 from global_config import get_global_config
 from plugin.k8s_plugin import get_k8s_plugin
 from plugin.docker_plugin import get_docker_plugin
@@ -101,9 +105,7 @@ def create_precommit_group_step(repo_name: str, commit: str) -> "BuildkiteGroupS
         agents={"queue": AgentQueue.SMALL_CPU_PREMERGE},
         priority=1000 if os.getenv("PRIORITY", "") == "HIGH" else 0,
     )
-    return BuildkiteGroupStep(
-        group="GitHub pre-commit check", steps=[precommit_step]
-    )
+    return BuildkiteGroupStep(group="GitHub pre-commit check", steps=[precommit_step])
 
 
 def add_precommit_dependency(
@@ -197,7 +199,11 @@ class BuildkiteGroupStep(BaseModel):
 
 def _get_step_plugin(step: Step):
     # Use K8s plugin
-    use_cpu = step.device in (DeviceType.CPU, DeviceType.CPU_SMALL, DeviceType.CPU_MEDIUM)
+    use_cpu = step.device in (
+        DeviceType.CPU,
+        DeviceType.CPU_SMALL,
+        DeviceType.CPU_MEDIUM,
+    )
     use_arm64 = step.device == DeviceType.DGX_SPARK
     if step.device in [
         DeviceType.H100.value,
@@ -285,7 +291,11 @@ def _get_variables_to_inject() -> Dict[str, str]:
     cache_from_tag, cache_to_tag = get_ecr_cache_registry()
     registries = global_config["registries"]
     repositories = global_config["repositories"]
-    repo = repositories["main"] if global_config["branch"] == "main" else repositories["premerge"]
+    repo = (
+        repositories["main"]
+        if global_config["branch"] == "main"
+        else repositories["premerge"]
+    )
 
     # Build target ($IMAGE_TAG) must match what the test steps pull (get_image()).
     # get_image() already switches to the dedicated -torch-nightly tag when
@@ -370,8 +380,10 @@ def _prepare_commands(
     if step.commands:
         for i, cmd in enumerate(step.commands):
             # Sanitize command preview for use in echo (remove quotes and special chars)
-            preview = cmd[:80].replace("'", "").replace('"', '').replace('$', '')
-            commands.append(f"echo '+++ :test_tube: Command ({i+1}/{len(step.commands)}): {preview}'")
+            preview = cmd[:80].replace("'", "").replace('"', "").replace("$", "")
+            commands.append(
+                f"echo '+++ :test_tube: Command ({i + 1}/{len(step.commands)}): {preview}'"
+            )
             if continue_on_failure:
                 # Note: We don't use a subshell here to preserve environment changes between commands
                 # (export, cd, etc).
@@ -391,9 +403,10 @@ def _prepare_commands(
                 continue
             # Use regex to only replace whole variable matches (not substrings)
             import re
+
             # Escape variable (may have $ or special characters)
             pattern = re.escape(variable)
-            command = re.sub(pattern + r'\b', value, command)
+            command = re.sub(pattern + r"\b", value, command)
         final_commands.append(command)
 
     if step.working_dir and not (
@@ -468,9 +481,7 @@ def ensure_exit_status_negative_one_retry(
         ):
             return retry_policy
     else:
-        raise ValueError(
-            "retry.automatic must be a boolean, mapping, or list."
-        )
+        raise ValueError("retry.automatic must be a boolean, mapping, or list.")
 
     retry_policy["automatic"] = [
         dict(EXIT_STATUS_NEGATIVE_ONE_RETRY),
@@ -602,7 +613,11 @@ def convert_group_step_to_buildkite_step(
             group_steps_list.append(buildkite_step)
 
             # Create AMD mirror step and its block step if specified/applicable
-            if step.mirror and step.mirror.get("amd"):
+            if (
+                step.mirror
+                and step.mirror.get("amd")
+                and global_config["only_step_keys"] is None
+            ):
                 amd = step.mirror["amd"]
                 amd_no_plugin = amd.get("no_plugin", False)
                 amd_no_gpu = amd.get("no_gpu", step.no_gpu or False)
@@ -693,6 +708,8 @@ def _step_should_run(step: Step, list_file_diff: List[str]) -> bool:
     if os.getenv("NOAUTO") == "1":
         return False
     global_config = get_global_config()
+    if global_config["only_step_keys"] is not None:
+        return step.key in global_config["only_step_keys"]
     if step.key and (
         step.key.startswith("image-build") or step.key in AMD_ALWAYS_RUN_STEP_KEYS
     ):

--- a/buildkite/pipeline_generator/global_config.py
+++ b/buildkite/pipeline_generator/global_config.py
@@ -1,8 +1,15 @@
-from typing import TypedDict, List, Dict, Optional
-import yaml
+import json
 import os
 import re
+from typing import Dict, FrozenSet, List, Optional, TypedDict
+
+import yaml
+
 from utils_lib.git_utils import get_merge_base_commit, get_list_file_diff, get_pr_labels
+
+
+ONLY_STEP_KEYS_ENV_VAR = "VLLM_CI_ONLY_STEP_KEYS"
+STEP_KEY_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 class GlobalConfig(TypedDict):
@@ -22,6 +29,7 @@ class GlobalConfig(TypedDict):
     docs_only_disable: Optional[str] = "0"
     merge_base_commit: Optional[str] = None
     fail_fast: bool = False
+    only_step_keys: Optional[FrozenSet[str]] = None
 
 
 config = None
@@ -74,6 +82,7 @@ def init_global_config(pipeline_config_path: str):
         merge_base_commit=merge_base_commit,
         list_file_diff=list_file_diff,
         fail_fast=_should_fail_fast(pr_labels),
+        only_step_keys=_parse_only_step_keys(os.getenv(ONLY_STEP_KEYS_ENV_VAR)),
     )
     if "ready-run-all-tests" in pr_labels:
         config["run_all"] = True
@@ -88,6 +97,27 @@ def get_global_config():
     if not config:
         raise ValueError("Global config not initialized")
     return config
+
+
+def _parse_only_step_keys(value: Optional[str]) -> Optional[FrozenSet[str]]:
+    if value is None:
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise ValueError(
+            f"{ONLY_STEP_KEYS_ENV_VAR} must be a JSON array of step keys."
+        ) from error
+    if not isinstance(parsed, list) or not parsed:
+        raise ValueError(f"{ONLY_STEP_KEYS_ENV_VAR} must be a non-empty JSON array.")
+    if any(
+        not isinstance(key, str) or not STEP_KEY_PATTERN.fullmatch(key)
+        for key in parsed
+    ):
+        raise ValueError(f"{ONLY_STEP_KEYS_ENV_VAR} contains an invalid step key.")
+    if len(set(parsed)) != len(parsed):
+        raise ValueError(f"{ONLY_STEP_KEYS_ENV_VAR} contains duplicate step keys.")
+    return frozenset(parsed)
 
 
 def _validate_pipeline_config(pipeline_config: Dict):

--- a/buildkite/pipeline_generator/pipeline_generator.py
+++ b/buildkite/pipeline_generator/pipeline_generator.py
@@ -1,14 +1,16 @@
-from typing import List
-import yaml
-import subprocess
 import os
-from step import read_steps_from_job_dir, group_steps
+import subprocess
+from typing import FrozenSet, List, Optional, Tuple
+
+import yaml
+
 from buildkite_step import (
-    convert_group_step_to_buildkite_step,
     add_precommit_dependency,
+    convert_group_step_to_buildkite_step,
     create_precommit_group_step,
 )
-from global_config import init_global_config, get_global_config
+from global_config import get_global_config, init_global_config
+from step import Step, group_steps, read_steps_from_job_dir
 
 
 class PipelineGenerator:
@@ -25,7 +27,11 @@ class PipelineGenerator:
         global_config = get_global_config()
 
         # Skip if changes are doc-only (unless RUN_ALL is set)
-        if global_config["docs_only_disable"] == "0" and not global_config["run_all"]:
+        if (
+            global_config["docs_only_disable"] == "0"
+            and not global_config["run_all"]
+            and global_config["only_step_keys"] is None
+        ):
             if is_docs_only_change(global_config["list_file_diff"]):
                 print("List file diff: ", global_config["list_file_diff"])
                 print("All changes are doc-only, skipping CI.")
@@ -45,6 +51,10 @@ class PipelineGenerator:
         steps = []
         for job_dir in global_config["job_dirs"]:
             steps.extend(read_steps_from_job_dir(job_dir))
+        steps, selected_step_keys = select_steps_and_dependencies(
+            steps, global_config["only_step_keys"]
+        )
+        global_config["only_step_keys"] = selected_step_keys
         grouped_steps = group_steps(steps)
 
         buildkite_group_steps = convert_group_step_to_buildkite_step(grouped_steps)
@@ -62,7 +72,6 @@ class PipelineGenerator:
                 ),
             )
 
-
         buildkite_steps_dict = {"steps": []}
         for buildkite_group_step in buildkite_group_steps:
             buildkite_steps_dict["steps"].append(
@@ -73,6 +82,42 @@ class PipelineGenerator:
                 buildkite_steps_dict, f, sort_keys=False, default_flow_style=False
             )
         return
+
+
+def select_steps_and_dependencies(
+    steps: List[Step],
+    requested_step_keys: Optional[FrozenSet[str]],
+) -> Tuple[List[Step], Optional[FrozenSet[str]]]:
+    if requested_step_keys is None:
+        return steps, None
+
+    steps_by_key = {}
+    for step in steps:
+        if not step.key:
+            continue
+        if step.key in steps_by_key:
+            raise ValueError(f"Duplicate CI step key: {step.key}")
+        steps_by_key[step.key] = step
+
+    missing = requested_step_keys - steps_by_key.keys()
+    if missing:
+        raise ValueError("Unknown CI step key(s): " + ", ".join(sorted(missing)))
+
+    selected_step_keys = set(requested_step_keys)
+    pending = list(requested_step_keys)
+    while pending:
+        step_key = pending.pop()
+        for dependency in steps_by_key[step_key].depends_on or []:
+            if dependency not in steps_by_key:
+                raise ValueError(
+                    f"CI step {step_key} depends on unknown step {dependency}."
+                )
+            if dependency not in selected_step_keys:
+                selected_step_keys.add(dependency)
+                pending.append(dependency)
+
+    selected = [step for step in steps if step.key in selected_step_keys]
+    return selected, frozenset(selected_step_keys)
 
 
 def is_docs_only_change(list_file_diff: List[str]) -> bool:

--- a/buildkite/tests/pipeline_generator/conftest.py
+++ b/buildkite/tests/pipeline_generator/conftest.py
@@ -25,6 +25,7 @@ def fake_global_config(monkeypatch):
         "run_all": False,
         "list_file_diff": [],
         "fail_fast": False,
+        "only_step_keys": None,
     }
     monkeypatch.setattr(step_module, "get_global_config", lambda: config)
     monkeypatch.setattr(buildkite_step, "get_global_config", lambda: config)

--- a/buildkite/tests/pipeline_generator/test_global_config.py
+++ b/buildkite/tests/pipeline_generator/test_global_config.py
@@ -1,7 +1,14 @@
-import pytest
-from unittest.mock import patch, mock_open
 import os
-from buildkite.pipeline_generator.global_config import init_global_config
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from buildkite.pipeline_generator.global_config import (
+    ONLY_STEP_KEYS_ENV_VAR,
+    _parse_only_step_keys,
+    _validate_pipeline_config,
+    init_global_config,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -19,9 +26,7 @@ def reset_config():
     "buildkite.pipeline_generator.global_config.get_list_file_diff",
     return_value=[],
 )
-@patch(
-    "buildkite.pipeline_generator.global_config.get_pr_labels", return_value=[]
-)
+@patch("buildkite.pipeline_generator.global_config.get_pr_labels", return_value=[])
 @patch(
     "builtins.open",
     new_callable=mock_open,
@@ -31,9 +36,7 @@ def reset_config():
 def test_init_global_config_valid_branch(
     mock_exists, mock_open, mock_pr_labels, mock_diff, mock_mb
 ):
-    with patch.dict(
-        os.environ, {"BUILDKITE_BRANCH": "valid-branch-name_123/pkg"}
-    ):
+    with patch.dict(os.environ, {"BUILDKITE_BRANCH": "valid-branch-name_123/pkg"}):
         init_global_config("dummy_path")
         # Should succeed
 
@@ -46,9 +49,7 @@ def test_init_global_config_valid_branch(
     "buildkite.pipeline_generator.global_config.get_list_file_diff",
     return_value=[],
 )
-@patch(
-    "buildkite.pipeline_generator.global_config.get_pr_labels", return_value=[]
-)
+@patch("buildkite.pipeline_generator.global_config.get_pr_labels", return_value=[])
 @patch(
     "builtins.open",
     new_callable=mock_open,
@@ -71,9 +72,7 @@ def test_init_global_config_invalid_branch(
     "buildkite.pipeline_generator.global_config.get_list_file_diff",
     return_value=[],
 )
-@patch(
-    "buildkite.pipeline_generator.global_config.get_pr_labels", return_value=[]
-)
+@patch("buildkite.pipeline_generator.global_config.get_pr_labels", return_value=[])
 @patch(
     "builtins.open",
     new_callable=mock_open,
@@ -84,13 +83,66 @@ def test_init_global_config_fork_branch(
     mock_exists, mock_open, mock_pr_labels, mock_diff, mock_mb
 ):
     # Fork PRs arrive as "owner:branch"; the colon must be accepted.
-    with patch.dict(
-        os.environ, {"BUILDKITE_BRANCH": "octocat:update-pytorch-2.13.0"}
-    ):
+    with patch.dict(os.environ, {"BUILDKITE_BRANCH": "octocat:update-pytorch-2.13.0"}):
         init_global_config("dummy_path")
         # Should succeed
-from unittest.mock import patch
-from global_config import _validate_pipeline_config
+
+
+def test_parse_only_step_keys():
+    assert _parse_only_step_keys(
+        '["basic-models-test-other-cpu", "image-build-cpu"]'
+    ) == frozenset(
+        {
+            "basic-models-test-other-cpu",
+            "image-build-cpu",
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "value, message",
+    [
+        ("not-json", "must be a JSON array"),
+        ("[]", "must be a non-empty JSON array"),
+        ('["bad key"]', "contains an invalid step key"),
+        ('["same", "same"]', "contains duplicate step keys"),
+    ],
+)
+def test_parse_only_step_keys_rejects_invalid_values(value, message):
+    with pytest.raises(ValueError, match=message):
+        _parse_only_step_keys(value)
+
+
+@patch(
+    "buildkite.pipeline_generator.global_config.get_merge_base_commit",
+    return_value="sha",
+)
+@patch(
+    "buildkite.pipeline_generator.global_config.get_list_file_diff",
+    return_value=[],
+)
+@patch("buildkite.pipeline_generator.global_config.get_pr_labels", return_value=[])
+@patch(
+    "builtins.open",
+    new_callable=mock_open,
+    read_data="name: test\njob_dirs: [/tmp]\nregistries: reg\nrepositories: {main: repo}",
+)
+@patch("os.path.exists", return_value=True)
+def test_init_global_config_reads_only_step_keys(
+    mock_exists, mock_open, mock_pr_labels, mock_diff, mock_mb
+):
+    import buildkite.pipeline_generator.global_config as global_config
+
+    with patch.dict(
+        os.environ,
+        {
+            "BUILDKITE_BRANCH": "test-branch",
+            ONLY_STEP_KEYS_ENV_VAR: '["selected-step"]',
+        },
+    ):
+        init_global_config("dummy_path")
+
+    assert global_config.config["only_step_keys"] == frozenset({"selected-step"})
 
 
 def test_validate_pipeline_config_valid_repo():

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 import buildkite_step
+from pipeline_generator import select_steps_and_dependencies
 from step import Step, group_steps, read_steps_from_job_dir
 
 pytestmark = pytest.mark.usefixtures("fake_global_config")
@@ -13,9 +14,11 @@ TEST_JOB_DIR = Path(__file__).resolve().parent / "test_files" / "test_jobs"
 
 
 def _render_single_step(step):
-    return buildkite_step.convert_group_step_to_buildkite_step({
-        step.group: [step],
-    })[0]
+    return buildkite_step.convert_group_step_to_buildkite_step(
+        {
+            step.group: [step],
+        }
+    )[0]
 
 
 def test_read_steps_from_job_dir():
@@ -50,6 +53,68 @@ def test_group_steps_sorts_steps_within_each_group():
         "Test C",
         "Test D",
     ]
+
+
+def test_selected_steps_include_transitive_dependencies():
+    steps = [
+        Step(label="Image", key="image-build", commands=["build"]),
+        Step(
+            label="Prepare",
+            key="prepare",
+            depends_on=["image-build"],
+            commands=["prepare"],
+        ),
+        Step(
+            label="Test",
+            key="test",
+            depends_on=["prepare"],
+            commands=["test"],
+        ),
+        Step(label="Other", key="other", commands=["other"]),
+    ]
+
+    selected, selected_keys = select_steps_and_dependencies(steps, frozenset({"test"}))
+
+    assert [step.key for step in selected] == [
+        "image-build",
+        "prepare",
+        "test",
+    ]
+    assert selected_keys == frozenset({"image-build", "prepare", "test"})
+
+
+def test_selected_steps_reject_unknown_key():
+    with pytest.raises(ValueError, match="Unknown CI step key.*missing"):
+        select_steps_and_dependencies(
+            [Step(label="Test", key="test", commands=["test"])],
+            frozenset({"missing"}),
+        )
+
+
+def test_selected_steps_reject_unknown_dependency():
+    step = Step(
+        label="Test",
+        key="test",
+        depends_on=["missing"],
+        commands=["test"],
+    )
+
+    with pytest.raises(
+        ValueError, match="CI step test depends on unknown step missing"
+    ):
+        select_steps_and_dependencies([step], frozenset({"test"}))
+
+
+def test_selected_step_runs_without_source_match(fake_global_config):
+    fake_global_config["only_step_keys"] = frozenset({"selected"})
+    step = Step(
+        label="Selected",
+        key="selected",
+        source_file_dependencies=["unrelated.py"],
+        commands=["test"],
+    )
+
+    assert buildkite_step._step_should_run(step, ["changed.py"])
 
 
 def test_continue_on_failure_exits_nonzero_after_command_failure(monkeypatch):
@@ -134,10 +199,10 @@ def test_multi_gpu_step_dumps_nvidia_topology():
 
     commands = buildkite_step._prepare_commands(step, variables_to_inject={})
 
-    assert '(command nvidia-smi topo -m || true)' in commands
+    assert "(command nvidia-smi topo -m || true)" in commands
     # Topology dump comes after the base GPU info and before coredump setup.
-    topo_index = commands.index('(command nvidia-smi topo -m || true)')
-    smi_index = commands.index('(command nvidia-smi || true)')
+    topo_index = commands.index("(command nvidia-smi topo -m || true)")
+    smi_index = commands.index("(command nvidia-smi || true)")
     assert smi_index < topo_index
 
 
@@ -156,7 +221,7 @@ def test_multi_node_step_dumps_nvidia_topology():
 
     commands = buildkite_step._prepare_commands(step, variables_to_inject={})
 
-    assert '(command nvidia-smi topo -m || true)' in commands
+    assert "(command nvidia-smi topo -m || true)" in commands
 
 
 def test_single_gpu_step_skips_nvidia_topology():
@@ -174,8 +239,8 @@ def test_single_gpu_step_skips_nvidia_topology():
     commands = buildkite_step._prepare_commands(step, variables_to_inject={})
 
     # Base GPU info is still emitted, but the topology dump is multi-GPU only.
-    assert '(command nvidia-smi || true)' in commands
-    assert '(command nvidia-smi topo -m || true)' not in commands
+    assert "(command nvidia-smi || true)" in commands
+    assert "(command nvidia-smi topo -m || true)" not in commands
 
 
 def test_torch_nightly_flag_no_separate_group(fake_global_config):
@@ -194,31 +259,36 @@ def test_torch_nightly_flag_no_separate_group(fake_global_config):
         device="h200_18gb",
     )
 
-    group_steps = buildkite_step.convert_group_step_to_buildkite_step({
-        step.group: [step],
-    })
+    group_steps = buildkite_step.convert_group_step_to_buildkite_step(
+        {
+            step.group: [step],
+        }
+    )
 
     # No dedicated torch-nightly group is synthesized anymore.
-    assert not any(
-        g.group == "vLLM Against PyTorch Nightly" for g in group_steps
-    )
+    assert not any(g.group == "vLLM Against PyTorch Nightly" for g in group_steps)
 
     # The step stays in its normal group and is built once (no nightly duplicate).
     normal_group = next(g for g in group_steps if g.group == "Some Group")
     labels = [
-        s.label for s in normal_group.steps
+        s.label
+        for s in normal_group.steps
         if isinstance(s, buildkite_step.BuildkiteCommandStep)
     ]
     assert "Untagged test" in labels
     assert not any(lbl.startswith("Torch Nightly ") for lbl in labels)
 
 
-def test_image_tag_matches_get_image_and_latest_suppressed_on_nightly(fake_global_config):
+def test_image_tag_matches_get_image_and_latest_suppressed_on_nightly(
+    fake_global_config,
+):
     fake_global_config["branch"] = "main"
     # Build target ($IMAGE_TAG) mirrors what test steps pull (get_image()).
     vars_ = buildkite_step._get_variables_to_inject()
     assert vars_["$IMAGE_TAG"] == buildkite_step.get_image()
-    assert vars_["$IMAGE_TAG_LATEST"] == "example.com/vllm/vllm-ci-postmerge-repo:latest"
+    assert (
+        vars_["$IMAGE_TAG_LATEST"] == "example.com/vllm/vllm-ci-postmerge-repo:latest"
+    )
 
     # A nightly run must not publish :latest (and still mirrors get_image()).
     fake_global_config["torch_nightly"] = "1"
@@ -241,7 +311,8 @@ def test_timeout_in_minutes_propagates_to_command_step():
 
     group_step = _render_single_step(step)
     command_step = next(
-        s for s in group_step.steps
+        s
+        for s in group_step.steps
         if isinstance(s, buildkite_step.BuildkiteCommandStep)
     )
 
@@ -260,7 +331,8 @@ def test_skip_timeout_omits_timeout_from_command_step(monkeypatch):
 
     group_step = _render_single_step(step)
     command_step = next(
-        s for s in group_step.steps
+        s
+        for s in group_step.steps
         if isinstance(s, buildkite_step.BuildkiteCommandStep)
     )
 
@@ -281,7 +353,8 @@ def test_missing_timeout_in_minutes_is_omitted_from_pipeline():
 
     group_step = _render_single_step(step)
     command_step = next(
-        s for s in group_step.steps
+        s
+        for s in group_step.steps
         if isinstance(s, buildkite_step.BuildkiteCommandStep)
     )
 


### PR DESCRIPTION
## Purpose

Add a narrow filtered-generation mode for the existing vLLM Buildkite pipeline. When `VLLM_CI_ONLY_STEP_KEYS` contains a non-empty JSON array, the generator now:

- validates every requested stable step key;
- includes the requested steps and their transitive `depends_on` closure;
- bypasses normal source-file and docs-only selection for the explicit request;
- omits unrelated steps and AMD mirror variants; and
- fails closed when a key or dependency is unknown.

This is the pipeline-side prerequisite for making `/ci retry` carry failed Buildkite steps onto a newer PR commit. The paired handler change is vllm-project/vllm#50318.

## Duplicate-work check

Searched open ci-infra PRs for selected-step, step-key, and retry filtering work. PR #437 is materially different: it builds a broader modular CI control-plane foundation whose mutation commands remain intentionally disabled. This PR is a small bridge for the currently deployed legacy `/ci retry` workflow and does not add a service, policy engine, credits, persistence, or a new command API.

## Validation

- `uv run --with pytest --with pyyaml --with pydantic==2.9.2 --with click==8.1.7 --with requests pytest -q buildkite/tests/pipeline_generator` — 58 passed.
- `uv tool run pre-commit run --files ...` on all changed files — passed.
- Rendered the generator against the current vLLM `.buildkite/ci_config.yaml` with `VLLM_CI_ONLY_STEP_KEYS=["basic-models-test-other-cpu"]`. The output contained only `basic-models-test-other-cpu` and its `image-build-cpu` dependency.

## Rollout

Merge this PR before vllm-project/vllm#50318 so the selector environment variable cannot be ignored by the deployed generator.

## AI assistance

AI assistance was used to implement, test, and prepare this PR. The human submitter must review and understand every changed line before merge.