### PR TITLE
[CI][AMD] Retry ROCm GPU hang aborts

### DIFF
--- a/buildkite/pipeline_generator/amd.py
+++ b/buildkite/pipeline_generator/amd.py
@@ -38,6 +38,8 @@ AMD_RETRY = {
         {"exit_status": -1, "limit": 1},
         {"exit_status": 1, "limit": 1},
         {"exit_status": 128, "limit": 1},
+        # ROCm/KFD reports GPU hangs by aborting the process (SIGABRT).
+        {"exit_status": 134, "limit": 1},
         {"signal_reason": "agent_stop", "limit": 1},
         {"signal_reason": "agent_refused", "limit": 1},
     ],

--- a/buildkite/test-template-amd.j2
+++ b/buildkite/test-template-amd.j2
@@ -24,6 +24,8 @@
 {{ indent }}    - exit_status: -1  # Lost contact with the running agent
 {{ indent }}      signal_reason: none
 {{ indent }}      limit: 1
+{{ indent }}    - exit_status: 134  # ROCm/KFD GPU hang (SIGABRT)
+{{ indent }}      limit: 1
 {%- endmacro %}
 
 {% macro amd_step_slug(step) -%}

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 import amd
@@ -6,6 +8,17 @@ from constants import AgentQueue
 from step import Step
 
 pytestmark = pytest.mark.usefixtures("fake_global_config")
+
+
+def test_legacy_amd_template_retries_gpu_hang_abort():
+    template = (
+        Path(__file__).parents[2] / "test-template-amd.j2"
+    ).read_text()
+
+    assert (
+        "{{ indent }}    - exit_status: 134  # ROCm/KFD GPU hang (SIGABRT)\n"
+        "{{ indent }}      limit: 1"
+    ) in template
 
 
 def _render_single_step(step):
@@ -121,11 +134,12 @@ def test_direct_amd_gpu_steps_use_dind_flag(
         assert command_step.env["DOCKER_IMAGE_NAME"] == amd.AMD_STABLE_CI_BASE_IMAGE
 
     assert command_step.retry == amd.AMD_RETRY
-    assert len(command_step.retry["automatic"]) == 6
+    assert len(command_step.retry["automatic"]) == 7
     assert command_step.retry["automatic"][0] == {
         "signal_reason": "stack_error",
         "limit": 1,
     }
+    assert {"exit_status": 134, "limit": 1} in command_step.retry["automatic"]
 
     test_commands = command_step.env["VLLM_TEST_COMMANDS"]
     assert test_commands.startswith(f"export VLLM_TEST_GROUP_NAME={step.key}")


### PR DESCRIPTION
- Retry an AMD job once when ROCm reports a GPU hang as `SIGABRT`/exit status 134, as seen in the [V1 speculative-decoding failure](https://buildkite.com/vllm/ci/builds/81118/summary?jid=019faf31-29cd-41e7-9599-7eb7fc2aae06&tab=output).
- The failing log reports an explicit KFD `GPU Hang`, and a fresh run of the same job and commit passed, identifying this as a transient runner/driver failure rather than a reproducible vLLM segfault.
- Add the retry condition to both the current AMD pipeline generator and the legacy Jinja template.