### PR TITLE
Provision the agent environment hook on tpu-inference v7x and v6e machines

### DIFF
--- a/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
@@ -136,6 +136,18 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       echo 'BUILDKITE_ANALYTICS_TOKEN=${var.buildkite_analytics_token_value}' | sudo tee -a /etc/environment
       echo 'TPU_VERSION=tpu6e' | sudo tee -a /etc/environment
 
+      # Also provide HF_TOKEN and BUILDKITE_ANALYTICS_TOKEN through the agent's
+      # own environment hook, matching how the newer machines are provisioned.
+      # The agent only knows about variables set in its hooks; /etc/environment
+      # is opaque to it.
+      sudo mkdir -p /etc/buildkite-agent/hooks
+      sudo touch /etc/buildkite-agent/hooks/environment
+      sudo chown root:buildkite-agent /etc/buildkite-agent/hooks/environment
+      sudo chmod 750 /etc/buildkite-agent/hooks/environment
+      printf '#!/bin/bash\nexport HF_TOKEN=%q\nexport BUILDKITE_ANALYTICS_TOKEN=%q\n' \
+        '${var.huggingface_token_value}' '${var.buildkite_analytics_token_value}' \
+        | sudo tee /etc/buildkite-agent/hooks/environment > /dev/null
+
       sudo mkdir -p /mnt/disks/persist
 
       # Format if not already formatted

--- a/terraform/gcp_old/tpu-inference/modules/ci_v7x/startup-script.sh.tftpl
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v7x/startup-script.sh.tftpl
@@ -132,6 +132,17 @@ echo 'HF_TOKEN=${huggingface_token_value}' | sudo tee -a /etc/environment
 echo 'BUILDKITE_ANALYTICS_TOKEN=${buildkite_analytics_token_value}' | sudo tee -a /etc/environment
 echo 'TPU_VERSION=tpu7x' | sudo tee -a /etc/environment
 
+# Also provide HF_TOKEN and BUILDKITE_ANALYTICS_TOKEN through the agent's own
+# environment hook, matching how the newer machines are provisioned. The agent
+# only knows about variables set in its hooks; /etc/environment is opaque to it.
+sudo mkdir -p /etc/buildkite-agent/hooks
+sudo touch /etc/buildkite-agent/hooks/environment
+sudo chown root:buildkite-agent /etc/buildkite-agent/hooks/environment
+sudo chmod 750 /etc/buildkite-agent/hooks/environment
+printf '#!/bin/bash\nexport HF_TOKEN=%q\nexport BUILDKITE_ANALYTICS_TOKEN=%q\n' \
+  '${huggingface_token_value}' '${buildkite_analytics_token_value}' \
+  | sudo tee /etc/buildkite-agent/hooks/environment > /dev/null
+
 %{ if has_attached_disk ~}
 sudo mkdir -p /mnt/disks/persist
 


### PR DESCRIPTION
The newer TPU CI machines provide HF_TOKEN and BUILDKITE_ANALYTICS_TOKEN to the buildkite agent via /etc/buildkite-agent/hooks/environment. The v7x and v6e modules only write them to /etc/environment, which the agent itself does not read. This aligns the older modules with the newer provisioning.

The /etc/environment entries stay: setup_docker_env.sh reads HF_TOKEN from there and re-fetches it from Secret Manager when absent.

Takes effect on re-provision only; running machines are unaffected until recreated.