### PR TITLE
[AMD][CI] Increase native shared-memory capacity

### DIFF
--- a/buildkite/pipeline_generator/amd.py
+++ b/buildkite/pipeline_generator/amd.py
@@ -16,7 +16,7 @@ AMD_RESULTS_ROOT = "/home/buildkite-agent/huggingface/amd-ci-results"
 AMD_HF_HOME = "/home/buildkite-agent/huggingface"
 AMD_NATIVE_WORKSPACE = "/vllm-workspace"
 AMD_NATIVE_WORKSPACE_VOLUME = "vllm-workspace"
-AMD_NATIVE_SHM_SIZE = "16Gi"
+AMD_NATIVE_SHM_SIZE = "32Gi"
 AMD_NATIVE_RUNTIME_SOURCE_DEPENDENCIES = (
     ".buildkite/scripts/hardware_ci/run-amd-test.sh",
 )

--- a/buildkite/test-template-amd.j2
+++ b/buildkite/test-template-amd.j2
@@ -94,7 +94,7 @@ rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT
                   - name: devshm
                     emptyDir:
                       medium: Memory
-                      sizeLimit: 16Gi
+                      sizeLimit: 32Gi
                   - name: vllm-workspace
                     emptyDir: {}
 {%- endmacro %}

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -21,12 +21,6 @@ def test_legacy_amd_template_retries_gpu_hang_abort():
     ) in template
 
 
-def test_legacy_amd_template_uses_32_gib_shared_memory():
-    template = (Path(__file__).parents[2] / "test-template-amd.j2").read_text()
-
-    assert "                      sizeLimit: 32Gi" in template
-
-
 def _render_single_step(step):
     return buildkite_step.convert_group_step_to_buildkite_step(
         {
@@ -129,15 +123,8 @@ def test_direct_amd_gpu_steps_use_dind_flag(
         assert command_step.plugins is not None
         pod_patch = command_step.plugins[0]["kubernetes"]["podSpecPatch"]
         container = pod_patch["containers"][0]
-        devshm = next(
-            volume for volume in pod_patch["volumes"] if volume["name"] == "devshm"
-        )
         assert container["resources"]["limits"]["amd.com/gpu"] == expected_gpu_count
         assert container["resources"]["requests"]["amd.com/gpu"] == expected_gpu_count
-        assert devshm["emptyDir"] == {
-            "medium": "Memory",
-            "sizeLimit": "32Gi",
-        }
         assert command_step.env["AMD_CI_RUNTIME"] == "native"
         assert command_step.env["VLLM_CI_EXPECTED_GPU_COUNT"] == expected_gpu_count
         assert "DOCKER_IMAGE_NAME" not in command_step.env

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -21,6 +21,12 @@ def test_legacy_amd_template_retries_gpu_hang_abort():
     ) in template
 
 
+def test_legacy_amd_template_uses_32_gib_shared_memory():
+    template = (Path(__file__).parents[2] / "test-template-amd.j2").read_text()
+
+    assert "                      sizeLimit: 32Gi" in template
+
+
 def _render_single_step(step):
     return buildkite_step.convert_group_step_to_buildkite_step(
         {
@@ -123,8 +129,15 @@ def test_direct_amd_gpu_steps_use_dind_flag(
         assert command_step.plugins is not None
         pod_patch = command_step.plugins[0]["kubernetes"]["podSpecPatch"]
         container = pod_patch["containers"][0]
+        devshm = next(
+            volume for volume in pod_patch["volumes"] if volume["name"] == "devshm"
+        )
         assert container["resources"]["limits"]["amd.com/gpu"] == expected_gpu_count
         assert container["resources"]["requests"]["amd.com/gpu"] == expected_gpu_count
+        assert devshm["emptyDir"] == {
+            "medium": "Memory",
+            "sizeLimit": "32Gi",
+        }
         assert command_step.env["AMD_CI_RUNTIME"] == "native"
         assert command_step.env["VLLM_CI_EXPECTED_GPU_COUNT"] == expected_gpu_count
         assert "DOCKER_IMAGE_NAME" not in command_step.env


### PR DESCRIPTION
- Increase the native AMD test pod's memory-backed `/dev/shm` size limit from 16 GiB to 32 GiB.
- Preserve the existing `emptyDir` mount and IPC locking configuration while giving large multi-GPU tests usable allocation headroom.

PR #46893 configured the DeepSeek KV-offload correctness test with a 16 GiB host cache, PR #37206 made the shared region populate its pages eagerly, and ci-infra PR #402 introduced the exact 16 GiB AMD pod limit. CUDA H100 CI can run that configuration because its memory-backed `/dev/shm` has no explicit 16 GiB cap, while AMD native CI currently caps the entire mount at exactly the requested allocation size. Build 11570 first exposes the job's missing AITER setting in the [KV-offload step](https://buildkite.com/vllm/amd-ci/builds/11570/list?sid=019fc12a-ba06-4b1d-bd34-32a2f7dcfbfd&tab=output); after enabling AITER, the exact local reproduction reaches this shared-memory limit. Raising the infrastructure limit preserves the original test coverage instead of reducing its cache size only for AMD.