### PR TITLE
Fix nightly throughput report data source

### DIFF
--- a/claude-skills/vllm-nightly-perf/scripts/test_vllm_perf_eval.py
+++ b/claude-skills/vllm-nightly-perf/scripts/test_vllm_perf_eval.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import datetime, timedelta, timezone
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -13,6 +14,7 @@ from vllm_perf_eval import (
     build_slack_payload,
     calculate_statistic,
     run_adopt,
+    run_report,
     run_trigger,
 )
 
@@ -119,6 +121,107 @@ def test_adopt_records_only_the_latest_reportable_build(monkeypatch, tmp_path):
 
     with pytest.raises(RuntimeError, match="not the latest reportable build"):
         run_adopt(tmp_path, build_number=308)
+
+
+def test_report_uses_full_comparison_when_nightly_perf_preview_omits_throughput(
+    monkeypatch, tmp_path
+):
+    commit = "c" * 40
+    previous_commit = "b" * 40
+    model = "org/model"
+    image = f"public.ecr.aws/vllm-release-repo:{commit}-x86_64"
+    previous_image = f"public.ecr.aws/vllm-release-repo:{previous_commit}-x86_64"
+    current = {
+        "commit": commit,
+        "date": "2026-08-03T06:00:00Z",
+        "sourceImage": image,
+        "perfEval": {
+            "build": {
+                "number": "361",
+                "state": "failed",
+                "web_url": "https://buildkite.com/vllm/perf-eval/builds/361",
+            }
+        },
+        "deltaVsPrev": {
+            "prevSourceImage": previous_image,
+            "perfDeltas": [
+                {
+                    "model": model,
+                    "metric": "p99_ttft",
+                    "key": f"{model}|h200|8|128|8192|1024|fp8|p99_ttft",
+                }
+            ],
+            "evalDeltas": [],
+        },
+    }
+    previous = {
+        "commit": previous_commit,
+        "sourceImage": previous_image,
+        "perfEval": {"build": {"number": "360", "state": "failed"}},
+    }
+    throughput_delta = {
+        "model": model,
+        "metric": "tput_per_gpu",
+        "key": f"{model}|h200|8|128|8192|1024|fp8|tput_per_gpu",
+        "dimension": "h200 - TP 8 - conc 128 - ISL 8192 - OSL 1024 - fp8",
+        "candidateRun": "2026-08-03 09:34:32",
+        "candidateValue": 105.0,
+        "higherIsBetter": True,
+    }
+
+    def fake_request(url, **_kwargs):
+        if url.endswith("/nightly?limit=30"):
+            return {"nightlies": [current, previous]}
+        if "/compare?" in url:
+            query = parse_qs(urlparse(url).query)
+            assert query == {
+                "baseline": [previous_image],
+                "candidate": [image],
+                "device": ["h200"],
+            }
+            return {"perf": {"deltas": [throughput_delta]}}
+        raise AssertionError(f"Unexpected dashboard URL: {url}")
+
+    history = [
+        {
+            "model": model,
+            "device": "h200",
+            "tp": "8",
+            "conc": "128",
+            "isl": "8192",
+            "osl": "1024",
+            "precision": "fp8",
+            "date": "2026-08-02 09:34:32",
+            "image": previous_image,
+            "tput_per_gpu": 100.0,
+        },
+        {
+            "model": model,
+            "device": "h200",
+            "tp": "8",
+            "conc": "128",
+            "isl": "8192",
+            "osl": "1024",
+            "precision": "fp8",
+            "date": "2026-08-03 09:34:32",
+            "image": image,
+            "tput_per_gpu": 105.0,
+        },
+    ]
+
+    monkeypatch.setattr("vllm_perf_eval._request", fake_request)
+    monkeypatch.setattr(
+        "vllm_perf_eval._load_histories",
+        lambda models: {model: (history, [])} if models == {model} else {},
+    )
+
+    assert run_report(tmp_path, dry_run=True) == 0
+
+    rows = json.loads((tmp_path / "vllm_perf_eval_report_rows.json").read_text())
+    assert rows["build_number"] == 361
+    assert len(rows["perf"]) == 1
+    assert rows["perf"][0]["model"] == model
+    assert rows["perf"][0]["current"] == 105.0
 
 
 def test_trigger_accepts_failed_release_when_cuda_image_job_passed(

--- a/claude-skills/vllm-nightly-perf/scripts/vllm_perf_eval.py
+++ b/claude-skills/vllm-nightly-perf/scripts/vllm_perf_eval.py
@@ -297,6 +297,27 @@ def _load_histories(models: set[str]) -> dict[str, HistoryRows]:
     return histories
 
 
+def _load_full_perf_deltas(current: dict[str, Any]) -> list[dict[str, Any]]:
+    """Load complete H200 deltas; the nightly endpoint contains an 8-row UI preview."""
+    source_image = str(current.get("sourceImage", ""))
+    previous_image = str(current.get("deltaVsPrev", {}).get("prevSourceImage", ""))
+    if not source_image or not previous_image:
+        raise RuntimeError("Nightly data is missing perf comparison image references")
+
+    query = urllib.parse.urlencode(
+        {
+            "baseline": previous_image,
+            "candidate": source_image,
+            "device": "h200",
+        }
+    )
+    comparison = _request(f"{DASHBOARD_API}/compare?{query}")
+    deltas = comparison.get("perf", {}).get("deltas")
+    if not isinstance(deltas, list):
+        raise RuntimeError("Dashboard comparison is missing full perf deltas")
+    return deltas
+
+
 def _current_observation(delta: dict[str, Any], commit: str) -> Observation:
     return Observation(
         commit=commit,
@@ -306,13 +327,18 @@ def _current_observation(delta: dict[str, Any], commit: str) -> Observation:
 
 
 def _make_rows(
-    current: dict[str, Any], histories: dict[str, HistoryRows]
+    current: dict[str, Any],
+    histories: dict[str, HistoryRows],
+    *,
+    perf_deltas: list[dict[str, Any]] | None = None,
 ) -> tuple[list[ReportRow], list[ReportRow]]:
     commit = str(current["commit"]).lower()
     deltas = current["deltaVsPrev"]
     perf_deltas = [
         item
-        for item in deltas.get("perfDeltas", [])
+        for item in (
+            perf_deltas if perf_deltas is not None else deltas.get("perfDeltas", [])
+        )
         if item.get("metric") == "tput_per_gpu" and "|h200|" in str(item.get("key"))
     ]
     eval_deltas = list(deltas.get("evalDeltas", []))
@@ -621,13 +647,16 @@ def run_report(state_dir: Path, *, dry_run: bool) -> int:
         print(f"SKIP: perf-eval build #{build_number} was already reported")
         return 0
 
-    all_deltas = [
-        *current["deltaVsPrev"].get("perfDeltas", []),
-        *current["deltaVsPrev"].get("evalDeltas", []),
-    ]
+    perf_deltas = _load_full_perf_deltas(current)
+    eval_deltas = current["deltaVsPrev"].get("evalDeltas", [])
+    all_deltas = [*perf_deltas, *eval_deltas]
     models = {str(item["model"]) for item in all_deltas}
     histories = _load_histories(models)
-    perf_rows, eval_rows = _make_rows(current, histories)
+    perf_rows, eval_rows = _make_rows(
+        current,
+        histories,
+        perf_deltas=perf_deltas,
+    )
     if not perf_rows and not eval_rows:
         raise RuntimeError(f"No rolling statistics available for build #{build_number}")
 


### PR DESCRIPTION
## Summary

- fetch the complete H200 performance comparison instead of relying on the eight-row nightly UI preview
- keep the concise nightly preview for eval rows
- add regression coverage for a preview that contains latency metrics but omits throughput

## Root cause

The dashboard nightly endpoint now returns only its top eight performance deltas for the UI. The host reporter filtered that preview for H200 `tput_per_gpu`, so a preview filled with latency metrics produced an empty Throughput section even though the full comparison and Buildkite run contained throughput results.

## Validation

- `uv run pytest` (7 passed)
- `uv run ruff check scripts`
- `uv run ruff format --check scripts`
- `bash -n scripts/install.sh`
- live dashboard dry run for perf-eval build #361 produced 7 perf and 8 eval rows
- deployed-path dry run on `dev` produced 7 perf and 8 eval rows; `vllm-ci-report.service` remains active
