### PR TITLE
Support "!" exclusions in source_file_dependencies

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -755,11 +755,19 @@ def _get_amd_mirror_effective_step(step: Step, amd: Dict[str, Any]) -> Step:
 def _source_file_dependencies_match(
     source_file_dependencies: Optional[List[str]], list_file_diff: List[str]
 ) -> bool:
-    if source_file_dependencies:
-        for source_file in source_file_dependencies:
-            for diff_file in list_file_diff:
-                if _matches_source_dependency(source_file, diff_file):
-                    return True
+    if not source_file_dependencies:
+        return False
+    # A "!"-prefixed entry is an exclusion: a changed file that matches an
+    # exclusion does not count as a match, even if it also matches an include.
+    # This lets a broad include like "vllm/" skip a self-contained subtree that
+    # has its own dedicated CI, e.g. "!vllm/distributed/kv_transfer/".
+    includes = [d for d in source_file_dependencies if not d.startswith("!")]
+    excludes = [d[1:] for d in source_file_dependencies if d.startswith("!")]
+    for diff_file in list_file_diff:
+        if any(
+            _matches_source_dependency(inc, diff_file) for inc in includes
+        ) and not any(_matches_source_dependency(exc, diff_file) for exc in excludes):
+            return True
     return False
 
 

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -364,5 +364,50 @@ def test_missing_timeout_in_minutes_is_omitted_from_pipeline():
     assert "timeout_in_minutes" not in command_step.model_dump(exclude_none=True)
 
 
+def test_source_file_dependencies_match_without_exclusions():
+    deps = ["vllm/", "tests/models/multimodal"]
+    assert buildkite_step._source_file_dependencies_match(
+        deps, ["vllm/model_executor/models/llama.py"]
+    )
+    assert not buildkite_step._source_file_dependencies_match(deps, ["docs/foo.md"])
+
+
+def test_exclusion_carves_out_subtree_from_broad_include():
+    deps = ["vllm/", "!vllm/distributed/kv_transfer/"]
+    # A change confined to the excluded subtree does not select the step.
+    assert not buildkite_step._source_file_dependencies_match(
+        deps, ["vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py"]
+    )
+    # A change elsewhere under the broad include still selects it.
+    assert buildkite_step._source_file_dependencies_match(
+        deps, ["vllm/model_executor/models/llama.py"]
+    )
+    # Sibling distributed code (not under the exclusion) still selects it.
+    assert buildkite_step._source_file_dependencies_match(
+        deps, ["vllm/distributed/parallel_state.py"]
+    )
+
+
+def test_exclusion_only_applies_per_file():
+    # A diff touching both an excluded file and an included file still matches:
+    # the included file is enough on its own.
+    deps = ["vllm/", "!vllm/distributed/kv_transfer/"]
+    assert buildkite_step._source_file_dependencies_match(
+        deps,
+        [
+            "vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py",
+            "vllm/config/__init__.py",
+        ],
+    )
+
+
+def test_step_explicitly_listing_excluded_subtree_still_matches():
+    # A dedicated step that includes the subtree directly is unaffected.
+    deps = ["vllm/distributed/kv_transfer/kv_connector/v1/nixl/"]
+    assert buildkite_step._source_file_dependencies_match(
+        deps, ["vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py"]
+    )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Summary

The pipeline generator selects a step when any changed file is a **path prefix** of any `source_file_dependencies` entry (`buildkite_step.py`, `_matches_source_dependency` / `_source_file_dependencies_match`), and there is no way to carve a subtree out of a broad include.

As a result, a change confined to a self-contained subtree that already has its own dedicated CI — e.g. `vllm/distributed/kv_transfer/` (the KV connectors, covered by the Disaggregated jobs) — fans out to **every** step declaring the broad `vllm/` or `vllm/distributed/` catch-alls (all model/multimodal/entrypoint suites, basic correctness, etc.). Concretely, the small nixl-connector fix in vllm-project/vllm#49221 triggered ~70 CUDA steps.

This PR adds an **exclusion operator** so a broad include can opt a subtree out.

## What changed

`_source_file_dependencies_match`: a `"!"`-prefixed entry is an exclusion. Matching stays **per changed file** — a file selects the step if it matches an include **and** matches no exclusion. So a diff touching both an excluded and an included path still runs the step. When no `"!"` entries are present, behavior is byte-for-byte unchanged.

```yaml
source_file_dependencies:
- vllm/
- "!vllm/distributed/kv_transfer/"   # KV connectors have dedicated CI
```

A step that lists the subtree directly (the dedicated connector jobs) is unaffected and still matches.

## Tests

Added 4 unit tests in `tests/pipeline_generator/test_step.py` (carve-out, per-file semantics, dedicated-step opt-in, no-exclusion baseline).

```
$ python3 -m pytest tests/pipeline_generator/ -q
63 passed
```

`ruff check` / `ruff format` clean.

## Follow-up

A companion PR in `vllm-project/vllm` adds `- "!vllm/distributed/kv_transfer/"` to the broad steps. The `"!"` syntax is inert until this PR merges, so this one lands first.
