### PR TITLE
Add TTFT latency to nightly report

### DIFF
--- a/claude-skills/AUTOMATIONS.md
+++ b/claude-skills/AUTOMATIONS.md
@@ -14,7 +14,7 @@ timer enabled.
 | Automation | Purpose | Schedule | External action | systemd unit |
 | --- | --- | --- | --- | --- |
 | Nightly perf trigger | Start `vllm/perf-eval` from the newest scheduled `release-v2` build whose x86_64 CUDA 13.0 image job passed | Daily at 23:00 America/Los_Angeles | Create a Buildkite `perf-eval` build | `vllm-nightly-perf-trigger.{service,timer}` |
-| Nightly perf report | Compare the latest completed perf/eval nightly against rolling history | Daily at 09:00 and 19:00 America/Los_Angeles | Post to `#ci-notifications` (`C0ABTNM9L5U`) | `vllm-nightly-perf-report.{service,timer}` |
+| Nightly perf report | Compare H200 throughput/GPU, p99 TTFT latency, and eval accuracy against rolling history | Daily at 09:00 and 19:00 America/Los_Angeles | Post to `#ci-notifications` (`C0ABTNM9L5U`) | `vllm-nightly-perf-report.{service,timer}` |
 | Fast CI failure alert | Find Databricks-ingested CI script jobs that failed in 30 seconds or less during the previous 30 minutes | Every 15 minutes at `:03`, `:18`, `:33`, and `:48` | Post to `#ci-alert` (`C0ANHBE642Y`) | `vllm-fast-ci-failure-alert.{service,timer}` |
 
 ### Nightly perf trigger and report

--- a/claude-skills/vllm-nightly-perf/scripts/test_vllm_perf_eval.py
+++ b/claude-skills/vllm-nightly-perf/scripts/test_vllm_perf_eval.py
@@ -78,6 +78,17 @@ def test_canvas_shaped_slack_payload_stays_within_block_limits():
         )
         for index in range(8)
     ]
+    latency_rows = [
+        ReportRow(
+            "latency",
+            f"org/model-{index}",
+            "H200 · TP8",
+            "p99 TTFT",
+            120.0,
+            Statistic(90.0, 100.0, 5.0, 0.20, 0.33, "regression", 6),
+        )
+        for index in range(8)
+    ]
     eval_rows = [
         ReportRow(
             "eval",
@@ -90,16 +101,18 @@ def test_canvas_shaped_slack_payload_stays_within_block_limits():
         for index in range(16)
     ]
 
-    payload = build_slack_payload(current, previous, perf_rows, eval_rows)
+    payload = build_slack_payload(current, previous, perf_rows, latency_rows, eval_rows)
 
     _validate_payload_limits(payload)
     rendered = "\n".join(
         block.get("text", {}).get("text", "") for block in payload["blocks"]
     )
     assert "Throughput / GPU" in rendered
+    assert "Latency — p99 TTFT" in rendered
+    assert "ms · lower is better" in rendered
     assert "Eval accuracy" in rendered
     assert "7d avg" in rendered
-    assert "Δ peak" in rendered
+    assert "Δ best" in rendered
 
 
 def test_adopt_records_only_the_latest_reportable_build(monkeypatch, tmp_path):
@@ -123,9 +136,7 @@ def test_adopt_records_only_the_latest_reportable_build(monkeypatch, tmp_path):
         run_adopt(tmp_path, build_number=308)
 
 
-def test_report_uses_full_comparison_when_nightly_perf_preview_omits_throughput(
-    monkeypatch, tmp_path
-):
+def test_report_uses_full_comparison_for_throughput_and_latency(monkeypatch, tmp_path):
     commit = "c" * 40
     previous_commit = "b" * 40
     model = "org/model"
@@ -168,6 +179,15 @@ def test_report_uses_full_comparison_when_nightly_perf_preview_omits_throughput(
         "candidateValue": 105.0,
         "higherIsBetter": True,
     }
+    latency_delta = {
+        "model": model,
+        "metric": "p99_ttft",
+        "key": f"{model}|h200|8|128|8192|1024|fp8|p99_ttft",
+        "dimension": "h200 - TP 8 - conc 128 - ISL 8192 - OSL 1024 - fp8",
+        "candidateRun": "2026-08-03 09:34:32",
+        "candidateValue": 0.12,
+        "higherIsBetter": False,
+    }
 
     def fake_request(url, **_kwargs):
         if url.endswith("/nightly?limit=30"):
@@ -179,7 +199,7 @@ def test_report_uses_full_comparison_when_nightly_perf_preview_omits_throughput(
                 "candidate": [image],
                 "device": ["h200"],
             }
-            return {"perf": {"deltas": [throughput_delta]}}
+            return {"perf": {"deltas": [throughput_delta, latency_delta]}}
         raise AssertionError(f"Unexpected dashboard URL: {url}")
 
     history = [
@@ -194,6 +214,7 @@ def test_report_uses_full_comparison_when_nightly_perf_preview_omits_throughput(
             "date": "2026-08-02 09:34:32",
             "image": previous_image,
             "tput_per_gpu": 100.0,
+            "p99_ttft": 0.10,
         },
         {
             "model": model,
@@ -206,6 +227,7 @@ def test_report_uses_full_comparison_when_nightly_perf_preview_omits_throughput(
             "date": "2026-08-03 09:34:32",
             "image": image,
             "tput_per_gpu": 105.0,
+            "p99_ttft": 0.12,
         },
     ]
 
@@ -222,6 +244,11 @@ def test_report_uses_full_comparison_when_nightly_perf_preview_omits_throughput(
     assert len(rows["perf"]) == 1
     assert rows["perf"][0]["model"] == model
     assert rows["perf"][0]["current"] == 105.0
+    assert len(rows["latency"]) == 1
+    assert rows["latency"][0]["model"] == model
+    assert rows["latency"][0]["metric"] == "p99 TTFT"
+    assert rows["latency"][0]["current"] == pytest.approx(120.0)
+    assert rows["latency"][0]["statistic"]["status"] == "regression"
 
 
 def test_trigger_accepts_failed_release_when_cuda_image_job_passed(

--- a/claude-skills/vllm-nightly-perf/scripts/vllm_perf_eval.py
+++ b/claude-skills/vllm-nightly-perf/scripts/vllm_perf_eval.py
@@ -29,6 +29,7 @@ REGRESSION_SIGMA = 2.0
 REGRESSION_RELATIVE = 0.01
 HTTP_ATTEMPTS = 3
 HTTP_TIMEOUT = 90
+LATENCY_METRICS = {"p99_ttft": ("p99 TTFT", 1000.0)}
 HistoryRows = tuple[list[dict[str, Any]], list[dict[str, Any]]]
 
 
@@ -326,26 +327,45 @@ def _current_observation(delta: dict[str, Any], commit: str) -> Observation:
     )
 
 
+def _scale_statistic(statistic: Statistic, factor: float) -> Statistic:
+    return Statistic(
+        peak=statistic.peak * factor,
+        average=statistic.average * factor,
+        sigma=statistic.sigma * factor,
+        delta_average=statistic.delta_average,
+        delta_peak=statistic.delta_peak,
+        status=statistic.status,
+        baseline_count=statistic.baseline_count,
+    )
+
+
 def _make_rows(
     current: dict[str, Any],
     histories: dict[str, HistoryRows],
     *,
     perf_deltas: list[dict[str, Any]] | None = None,
-) -> tuple[list[ReportRow], list[ReportRow]]:
+) -> tuple[list[ReportRow], list[ReportRow], list[ReportRow]]:
     commit = str(current["commit"]).lower()
     deltas = current["deltaVsPrev"]
-    perf_deltas = [
+    all_perf_deltas = (
+        perf_deltas if perf_deltas is not None else deltas.get("perfDeltas", [])
+    )
+    throughput_deltas = [
         item
-        for item in (
-            perf_deltas if perf_deltas is not None else deltas.get("perfDeltas", [])
-        )
+        for item in all_perf_deltas
         if item.get("metric") == "tput_per_gpu" and "|h200|" in str(item.get("key"))
     ]
+    latency_deltas = [
+        item
+        for item in all_perf_deltas
+        if item.get("metric") in LATENCY_METRICS and "|h200|" in str(item.get("key"))
+    ]
     eval_deltas = list(deltas.get("evalDeltas", []))
-    perf_rows: list[ReportRow] = []
+    throughput_rows: list[ReportRow] = []
+    latency_rows: list[ReportRow] = []
     eval_rows: list[ReportRow] = []
 
-    for delta in perf_deltas:
+    for delta in throughput_deltas:
         model = str(delta["model"])
         raw_perf = histories.get(model, ([], []))[0]
         current_value = _current_observation(delta, commit)
@@ -358,9 +378,39 @@ def _make_rows(
             continue
         dimension_parts = str(delta["dimension"]).split(" - ")
         config = " · ".join(dimension_parts[:2]).upper()
-        perf_rows.append(
+        throughput_rows.append(
             ReportRow(
-                "perf", model, config, "token/s/gpu", current_value.value, statistic
+                "throughput",
+                model,
+                config,
+                "token/s/gpu",
+                current_value.value,
+                statistic,
+            )
+        )
+
+    for delta in latency_deltas:
+        model = str(delta["model"])
+        raw_perf = histories.get(model, ([], []))[0]
+        current_value = _current_observation(delta, commit)
+        statistic = calculate_statistic(
+            _perf_observations(delta, raw_perf),
+            current=current_value,
+            higher_is_better=bool(delta.get("higherIsBetter", False)),
+        )
+        if statistic is None:
+            continue
+        metric_label, scale = LATENCY_METRICS[str(delta["metric"])]
+        dimension_parts = str(delta["dimension"]).split(" - ")
+        config = " · ".join(dimension_parts[:2]).upper()
+        latency_rows.append(
+            ReportRow(
+                "latency",
+                model,
+                config,
+                metric_label,
+                current_value.value * scale,
+                _scale_statistic(statistic, scale),
             )
         )
 
@@ -383,11 +433,16 @@ def _make_rows(
         )
 
     status_order = {"regression": 0, "improvement": 1, "steady": 2}
-    perf_rows.sort(key=lambda row: (status_order[row.statistic.status], row.model))
+    throughput_rows.sort(
+        key=lambda row: (status_order[row.statistic.status], row.model)
+    )
+    latency_rows.sort(
+        key=lambda row: (status_order[row.statistic.status], row.model, row.metric)
+    )
     eval_rows.sort(
         key=lambda row: (status_order[row.statistic.status], row.model, row.metric)
     )
-    return perf_rows, eval_rows
+    return throughput_rows, latency_rows, eval_rows
 
 
 def _short_model(model: str, width: int) -> str:
@@ -415,8 +470,28 @@ def _format_percent(value: float) -> str:
 
 def _perf_table(rows: list[ReportRow]) -> list[str]:
     lines = [
-        "●  Model                        Config     Peak    7d avg ±σ       "
-        "Current  Δ avg   Δ peak",
+        "●  Model                        Config     Best    7d avg ±σ       "
+        "Current  Δ avg   Δ best",
+        "-- ---------------------------- ---------- ------- --------------- "
+        "-------- ------- --------",
+    ]
+    for row in rows:
+        stat = row.statistic
+        average = f"{_format_number(stat.average)} ±{_format_number(stat.sigma)}"
+        lines.append(
+            f"{_icon(stat.status)} {_short_model(row.model, 28):<28} "
+            f"{row.dimension:<10} {_format_number(stat.peak):>7} "
+            f"{average:>15} {_format_number(row.current):>8} "
+            f"{_format_percent(stat.delta_average):>7} "
+            f"{_format_percent(stat.delta_peak):>8}"
+        )
+    return lines
+
+
+def _latency_table(rows: list[ReportRow]) -> list[str]:
+    lines = [
+        "●  Model                        Config       Best    7d avg ±σ       "
+        "Current  Δ avg   Δ best",
         "-- ---------------------------- ---------- ------- --------------- "
         "-------- ------- --------",
     ]
@@ -435,8 +510,8 @@ def _perf_table(rows: list[ReportRow]) -> list[str]:
 
 def _eval_table(rows: list[ReportRow]) -> list[str]:
     lines = [
-        "●  Model                    Task · Metric                    Peak  "
-        "7d avg ±σ     Now  Δ avg  Δ peak",
+        "●  Model                    Task · Metric                    Best  "
+        "7d avg ±σ     Now  Δ avg  Δ best",
         "-- ------------------------ -------------------------------- ------- "
         "------------- ------- ------ -------",
     ]
@@ -482,7 +557,8 @@ def _counts(rows: list[ReportRow]) -> dict[str, int]:
 def build_slack_payload(
     current: dict[str, Any],
     previous: dict[str, Any],
-    perf_rows: list[ReportRow],
+    throughput_rows: list[ReportRow],
+    latency_rows: list[ReportRow],
     eval_rows: list[ReportRow],
 ) -> dict[str, Any]:
     """Build a webhook-compatible Block Kit rendering of the Canvas template."""
@@ -494,11 +570,15 @@ def build_slack_payload(
     commit = str(current["commit"])
     previous_commit = str(previous["commit"])
     build = current["perfEval"]["build"]
-    perf_counts = _counts(perf_rows)
+    throughput_counts = _counts(throughput_rows)
+    latency_counts = _counts(latency_rows)
     eval_counts = _counts(eval_rows)
     summary = (
-        f"> *Perf:* 🔴 {perf_counts['regression']} · 🟢 "
-        f"{perf_counts['improvement']} improved · {perf_counts['steady']} steady · "
+        f"> *Throughput:* 🔴 {throughput_counts['regression']} · 🟢 "
+        f"{throughput_counts['improvement']} improved · "
+        f"{throughput_counts['steady']} steady · "
+        f"*Latency:* 🔴 {latency_counts['regression']} · 🟢 "
+        f"{latency_counts['improvement']} improved · {latency_counts['steady']} steady · "
         f"*Eval:* 🔴 {eval_counts['regression']} · 🟢 "
         f"{eval_counts['improvement']} improved · {eval_counts['steady']} steady"
     )
@@ -512,7 +592,7 @@ def build_slack_payload(
     )
     legend = (
         "🔴 = regression vs 7-day avg (≥2σ & ≥1%), 🟢 = otherwise. "
-        "Δ vs avg and Δ vs peak are relative %. Peak over 30d; avg ±σ over "
+        "Δ vs avg and Δ vs best are relative %. Best over 30d; avg ±σ over "
         "the prior 7 days."
     )
     blocks: list[dict[str, Any]] = [
@@ -536,7 +616,20 @@ def build_slack_payload(
             },
         },
     ]
-    blocks.extend(_table_blocks(_perf_table(perf_rows)))
+    blocks.extend(_table_blocks(_perf_table(throughput_rows)))
+    blocks.extend(
+        [
+            {"type": "divider"},
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*Latency — p99 TTFT*\n_ms · lower is better_",
+                },
+            },
+        ]
+    )
+    blocks.extend(_table_blocks(_latency_table(latency_rows)))
     blocks.extend(
         [
             {"type": "divider"},
@@ -553,7 +646,10 @@ def build_slack_payload(
         ]
     )
     blocks.extend(_table_blocks(_eval_table(eval_rows)))
-    min_perf = min((row.statistic.baseline_count for row in perf_rows), default=0)
+    min_throughput = min(
+        (row.statistic.baseline_count for row in throughput_rows), default=0
+    )
+    min_latency = min((row.statistic.baseline_count for row in latency_rows), default=0)
     min_eval = min((row.statistic.baseline_count for row in eval_rows), default=0)
     blocks.append(
         {
@@ -563,7 +659,8 @@ def build_slack_payload(
                     "type": "mrkdwn",
                     "text": (
                         f"Source: <https://ci.vllm.ai/nightly|vLLM CI dashboard> · "
-                        f"minimum 7d samples: perf {min_perf}, eval {min_eval}"
+                        f"minimum 7d samples: throughput {min_throughput}, "
+                        f"latency {min_latency}, eval {min_eval}"
                     ),
                 }
             ],
@@ -652,15 +749,21 @@ def run_report(state_dir: Path, *, dry_run: bool) -> int:
     all_deltas = [*perf_deltas, *eval_deltas]
     models = {str(item["model"]) for item in all_deltas}
     histories = _load_histories(models)
-    perf_rows, eval_rows = _make_rows(
+    throughput_rows, latency_rows, eval_rows = _make_rows(
         current,
         histories,
         perf_deltas=perf_deltas,
     )
-    if not perf_rows and not eval_rows:
+    if not throughput_rows and not latency_rows and not eval_rows:
         raise RuntimeError(f"No rolling statistics available for build #{build_number}")
 
-    payload = build_slack_payload(current, previous, perf_rows, eval_rows)
+    payload = build_slack_payload(
+        current,
+        previous,
+        throughput_rows,
+        latency_rows,
+        eval_rows,
+    )
     report_path = state_dir / "vllm_perf_eval_report_payload.json"
     details_path = state_dir / "vllm_perf_eval_report_rows.json"
     _write_json(report_path, payload)
@@ -669,7 +772,8 @@ def run_report(state_dir: Path, *, dry_run: bool) -> int:
         {
             "build_number": build_number,
             "commit": current["commit"],
-            "perf": [asdict(row) for row in perf_rows],
+            "perf": [asdict(row) for row in throughput_rows],
+            "latency": [asdict(row) for row in latency_rows],
             "eval": [asdict(row) for row in eval_rows],
         },
     )
@@ -677,7 +781,8 @@ def run_report(state_dir: Path, *, dry_run: bool) -> int:
     if dry_run:
         print(
             f"DRY RUN: generated build #{build_number} report with "
-            f"{len(perf_rows)} perf and {len(eval_rows)} eval rows"
+            f"{len(throughput_rows)} throughput, {len(latency_rows)} latency, "
+            f"and {len(eval_rows)} eval rows"
         )
         return 0
 


### PR DESCRIPTION
## Summary

- add a dedicated H200 p99 TTFT latency table to the nightly Slack report
- convert dashboard values from seconds to milliseconds and evaluate them as lower-is-better
- split summary counts into Throughput, Latency, and Eval and use consistent 30-day `Best` labels
- document the report's throughput, latency, and accuracy coverage

## Why

The reporter fetched the full performance comparison but selected only `tput_per_gpu`, so dashboard latency data such as `p99_ttft` was silently omitted from Slack.

## Validation

- `uv run pytest` (7 passed)
- `uv run ruff check scripts`
- `uv run ruff format --check scripts`
- `bash -n scripts/install.sh`
- live dashboard dry run for build #363 produced 7 throughput, 7 latency, and 8 eval rows in 14 Slack blocks
- deployed-path dry run on `dev` produced the same row counts; `vllm-ci-report.service` remains active

No Slack message was posted during validation.