### PR TITLE
Cap Buildkite retries at three

### DIFF
--- a/.buildkite/pipelines/rebuild-cpu-ami.yml
+++ b/.buildkite/pipelines/rebuild-cpu-ami.yml
@@ -208,7 +208,7 @@ steps:
     retry:
       automatic:
         - exit_status: -1  # Agent/infrastructure failures only
-          limit: 1
+          limit: 3
 
   - label: ":aws: Update SSM Parameter"
     key: update-ssm

--- a/buildkite/pipeline_generator/README.md
+++ b/buildkite/pipeline_generator/README.md
@@ -81,3 +81,9 @@ The generator relies on several environment variables, typically provided by Bui
 *   `VLLM_CI_ONLY_STEP_KEYS`: A non-empty JSON array of stable step keys. When
     set, the generator emits those steps and their transitive dependencies,
     ignoring normal source-file selection. Unknown keys fail generation.
+
+## Retry policy
+
+Generated jobs retry a lost Buildkite agent (`exit_status: -1`) up to three
+times. Step-specific automatic retry rules are preserved, but any explicit
+limit above three is capped at three; lower limits remain unchanged.

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -34,7 +34,11 @@ PRECOMMIT_MAX_WAIT = 3600  # 30 minutes
 PRECOMMIT_WAIT_INTERVAL = 60
 
 SKIP_TIMEOUT_ENV_VAR = "SKIP_TIMEOUT"
-EXIT_STATUS_NEGATIVE_ONE_RETRY = {"exit_status": -1, "limit": 1}
+MAX_AUTOMATIC_RETRIES_PER_RULE = 3
+EXIT_STATUS_NEGATIVE_ONE_RETRY = {
+    "exit_status": -1,
+    "limit": MAX_AUTOMATIC_RETRIES_PER_RULE,
+}
 
 
 # Self-contained poll of the pre-commit GitHub Actions check run. Baked with the
@@ -460,7 +464,7 @@ def _matches_source_dependency(source_file: str, diff_file: str) -> bool:
 def ensure_exit_status_negative_one_retry(
     retry: Optional[Dict[str, Any]],
 ) -> Dict[str, Any]:
-    """Add a one-time retry for jobs that lose their agent."""
+    """Retry jobs that lose their agent, up to the global retry ceiling."""
     retry_policy = deepcopy(retry or {})
     automatic = retry_policy.get("automatic")
 
@@ -487,6 +491,45 @@ def ensure_exit_status_negative_one_retry(
         dict(EXIT_STATUS_NEGATIVE_ONE_RETRY),
         *automatic_conditions,
     ]
+    return retry_policy
+
+
+def cap_automatic_retry_limits(
+    retry: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Cap every explicit automatic retry rule at three retries.
+
+    Buildkite tracks the limit of each automatic retry rule independently. This
+    preserves narrower per-rule limits while preventing a job definition from
+    requesting more than the repository-wide ceiling for any one rule.
+    """
+    if retry is None:
+        return None
+
+    retry_policy = deepcopy(retry)
+    automatic = retry_policy.get("automatic")
+    if automatic is None or isinstance(automatic, bool):
+        # Buildkite's `automatic: true` default is two retries.
+        return retry_policy
+
+    if isinstance(automatic, dict):
+        conditions = [automatic]
+    elif isinstance(automatic, list):
+        conditions = automatic
+    else:
+        raise ValueError("retry.automatic must be a boolean, mapping, or list.")
+
+    for condition in conditions:
+        if not isinstance(condition, dict):
+            raise ValueError("retry.automatic conditions must be mappings.")
+        limit = condition.get("limit")
+        if limit is None:
+            # Buildkite defaults an omitted rule limit to two retries.
+            continue
+        if isinstance(limit, bool) or not isinstance(limit, int) or limit < 0:
+            raise ValueError("retry.automatic limit must be a non-negative integer.")
+        condition["limit"] = min(limit, MAX_AUTOMATIC_RETRIES_PER_RULE)
+
     return retry_policy
 
 
@@ -574,6 +617,7 @@ def convert_group_step_to_buildkite_step(
                 buildkite_step.retry = ensure_amd_stack_error_retry(
                     buildkite_step.retry
                 )
+            buildkite_step.retry = cap_automatic_retry_limits(buildkite_step.retry)
             if step.key == AMD_ROCM_BASE_REFRESH_STEP_KEY:
                 refresh_env = dict(buildkite_step.env or {})
                 refresh_env.update(get_rocm_base_refresh_env())
@@ -810,6 +854,7 @@ def _create_amd_step(
         num_nodes=num_nodes,
         agent_tags=agent_tags,
     )
+    options["retry"] = cap_automatic_retry_limits(options["retry"])
     return BuildkiteCommandStep(
         **options,
         key=key,

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -161,7 +161,7 @@ def test_generated_steps_retry_when_the_agent_is_lost():
     command_step = _render_single_step(step).steps[0]
 
     assert command_step.retry == {
-        "automatic": [{"exit_status": -1, "limit": 1}],
+        "automatic": [{"exit_status": -1, "limit": 3}],
     }
 
 
@@ -179,10 +179,60 @@ def test_agent_lost_retry_preserves_step_retry_conditions():
 
     assert command_step.retry == {
         "automatic": [
-            {"exit_status": -1, "limit": 1},
+            {"exit_status": -1, "limit": 3},
             {"exit_status": 143, "limit": 2},
         ],
     }
+
+
+def test_generated_steps_cap_custom_retry_limits_at_three():
+    step = Step(
+        label="Capped retry policy",
+        group="Failure handling",
+        key="capped-retry-policy",
+        device="h100",
+        commands=["pytest tests/basic.py"],
+        retry={
+            "automatic": [
+                {"exit_status": 143, "limit": 10},
+                {"exit_status": 255, "limit": 2},
+            ],
+            "manual": {"allowed": False},
+        },
+    )
+
+    command_step = next(
+        generated_step
+        for generated_step in _render_single_step(step).steps
+        if isinstance(generated_step, buildkite_step.BuildkiteCommandStep)
+    )
+
+    assert command_step.retry == {
+        "automatic": [
+            {"exit_status": -1, "limit": 3},
+            {"exit_status": 143, "limit": 3},
+            {"exit_status": 255, "limit": 2},
+        ],
+        "manual": {"allowed": False},
+    }
+
+
+@pytest.mark.parametrize("limit", [-1, 1.5, True])
+def test_generated_steps_reject_invalid_retry_limits(limit):
+    step = Step(
+        label="Invalid retry policy",
+        group="Failure handling",
+        key="invalid-retry-policy",
+        device="h100",
+        commands=["pytest tests/basic.py"],
+        retry={"automatic": {"exit_status": 143, "limit": limit}},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="retry.automatic limit must be a non-negative integer",
+    ):
+        _render_single_step(step)
 
 
 def test_multi_gpu_step_dumps_nvidia_topology():


### PR DESCRIPTION
## Summary

- retry generated jobs that lose their Buildkite agent up to three times
- cap explicit automatic retry rules at three while preserving lower limits and manual retry settings
- align the standalone CPU AMI pipeline and document the retry policy

## Why

Buildkite accepts automatic retry limits up to ten, and the pipeline generator previously passed custom limits through without a repository-wide ceiling. The injected agent-loss policy and standalone AMI pipeline also allowed only one retry.

This change centralizes a three-retry ceiling in the shared generator. Buildkite tracks limits independently for each automatic retry rule, so targeted failure conditions remain intact without introducing a wildcard retry for genuine test failures.

## Impact

Transient agent-loss failures can recover up to three times. Custom per-rule limits above three are reduced to three, lower limits remain unchanged, and malformed limits fail pipeline generation with a clear error.

## Validation

- `python3 -m pytest -q buildkite/tests/pipeline_generator` — 63 passed
- `python3 -m pre_commit run --files .buildkite/pipelines/rebuild-cpu-ami.yml buildkite/pipeline_generator/README.md buildkite/pipeline_generator/buildkite_step.py buildkite/tests/pipeline_generator/test_step.py` — passed
- `bk pipeline validate --file .buildkite/pipelines/rebuild-cpu-ami.yml` — passed against the current online schema
