### PR TITLE
Keep five GitHub Actions runners warm

### DIFF
--- a/terraform/github-runners/README.md
+++ b/terraform/github-runners/README.md
@@ -8,15 +8,16 @@ autoscaling:
 ```
 workflow_job (queued)  ->  API Gateway  ->  scale-up Lambda
    ->  one EC2 instance per job (JIT, ephemeral)  ->  runs a single job  ->  terminated
+
+pool scheduler (every minute)  ->  keep 5 idle JIT runners ready
 ```
 
 This is the recommended pattern over a CPU-metric Auto Scaling Group: scaling
 tracks the job queue, and one job per throwaway instance is required for safely
 running public-repo PR code.
 
-> **Status: not yet applied.** This is a reviewed scaffold. It has not been
-> `terraform apply`-ed (it needs the GitHub App + SSM secrets below). Run
-> `terraform plan` and review before applying.
+> **Status: deployed in `us-west-2`.** Review `terraform plan` against the
+> remote state before applying changes.
 
 ## What it creates
 
@@ -117,6 +118,9 @@ jobs:
 
 ## Cost / scaling
 
+- `runners_minimum_idle_count = 5` keeps five idle runners ready 24/7. The pool
+  scheduler replenishes consumed ephemeral runners every minute, and the idle
+  configuration prevents scale-down from reaping the warm capacity.
 - `runners_maximum_count` caps concurrent instances.
 - `instance_target_capacity_type = "on-demand"` for gating-check reliability;
   switch to `"spot"` for cost (set `create_service_linked_role_spot = true`).

--- a/terraform/github-runners/main.tf
+++ b/terraform/github-runners/main.tf
@@ -81,6 +81,20 @@ module "runners" {
   enable_job_queued_check  = true
   runners_maximum_count    = var.runners_maximum_count
 
+  # Keep a 24/7 pool of ready runners. The pool reconciler replaces ephemeral
+  # runners after jobs consume them, while idle_config prevents scale-down from
+  # reaping the ready capacity between jobs.
+  pool_runner_owner = var.runner_pool_owner
+  pool_config = [{
+    size                = var.runners_minimum_idle_count
+    schedule_expression = "cron(* * * * ? *)"
+  }]
+  idle_config = [{
+    cron      = "* * * * * *"
+    timeZone  = "UTC"
+    idleCount = var.runners_minimum_idle_count
+  }]
+
   # Reap stuck/idle instances; keep brief minimum lifetime to avoid churn.
   minimum_running_time_in_minutes = 5
   scale_down_schedule_expression  = "cron(* * * * ? *)"

--- a/terraform/github-runners/variables.tf
+++ b/terraform/github-runners/variables.tf
@@ -52,6 +52,23 @@ variable "runners_maximum_count" {
   default     = 50
 }
 
+variable "runners_minimum_idle_count" {
+  description = "Minimum number of idle runners kept ready at all times."
+  type        = number
+  default     = 5
+
+  validation {
+    condition     = var.runners_minimum_idle_count >= 0
+    error_message = "runners_minimum_idle_count must be zero or greater."
+  }
+}
+
+variable "runner_pool_owner" {
+  description = "GitHub organization that owns the pre-provisioned runner pool."
+  type        = string
+  default     = "vllm-project"
+}
+
 # SSM SecureString/String parameters holding the GitHub App credentials.
 # Create these manually before the first apply (see README.md).
 variable "github_app_id_ssm_name" {


### PR DESCRIPTION
## Summary

- add a 24/7 pool reconciler targeting five idle `vllm-runners`
- retain five runners during scale-down so the warm pool is not churned
- document the deployed stack and warm-capacity behavior

## Why

The event-driven ephemeral runner path starts an EC2 instance only after a job queues, so jobs can wait several minutes for boot and registration. Keeping five idle runners ready lets normal bursts start immediately; the scheduler reconciles the pool every minute after runners are consumed.

## Validation

- `terraform fmt -check -recursive`
- `terraform validate`
- live remote-state plan: 9 creates, 3 in-place updates, 0 destroys

The warm-pool change adds the pool Lambda, scheduler, IAM, and log resources and updates the scale-down Lambda configuration. The full plan also observes the module's existing dynamic Ubuntu AMI refresh and a generated S3 trigger source-path change; those should be reviewed explicitly before apply.