### PR TITLE
[CI] Use blobless checkout for image builds

### DIFF
--- a/packer/cpu/buildkite-cpu-ami.pkr.hcl
+++ b/packer/cpu/buildkite-cpu-ami.pkr.hcl
@@ -122,6 +122,14 @@ build {
     script = "scripts/install-build-tools.sh"
   }
 
+  # Use a blobless checkout for the vLLM image build without changing checkout
+  # behavior for other jobs on the shared CPU queues.
+  provisioner "shell" {
+    inline = [
+      "sudo install -D -o buildkite-agent -g buildkite-agent -m 0755 /tmp/scripts/pre-checkout /etc/buildkite-agent/hooks/pre-checkout"
+    ]
+  }
+
   # Warm the cache by building vLLM image (runs as buildkite-agent)
   provisioner "shell" {
     environment_vars = [

--- a/packer/cpu/scripts/pre-checkout
+++ b/packer/cpu/scripts/pre-checkout
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eu -o pipefail
+
+if [[ "${BUILDKITE_STEP_KEY:-}" == "image-build" ]]; then
+  echo "--- :git: Configuring blobless checkout"
+  export BUILDKITE_GIT_CLONE_FLAGS="-v --filter=blob:none --no-checkout"
+  export BUILDKITE_GIT_FETCH_FLAGS="-v --prune --filter=blob:none"
+fi


### PR DESCRIPTION
## Summary

- install a Buildkite `pre-checkout` hook in the custom CPU build AMI
- use a blobless clone with no initial branch checkout only for the `image-build` step
- preserve the existing checkout behavior for all other jobs on the shared CPU queues

## Why

The recent vLLM Build image job spent 3m55s cloning the full repository and received 244.6 MiB of Git objects. Reproducing the same PR checkout with `--filter=blob:none --no-checkout` completed the clone/fetch/checkout flow in about 9 seconds while preserving tags, full commit history, `HEAD~1`, and the exact `setuptools_scm` version.

The current Buildkite agent is v3.73.1, where clone/fetch flags are protected from pipeline YAML. Installing a scoped agent hook in the CPU AMI is therefore the smallest effective change without upgrading the agent or changing checkout behavior globally.

No matching open pull request was found for the Buildkite checkout optimization.

## Validation

- `packer fmt -check packer/cpu/buildkite-cpu-ami.pkr.hcl`
- `packer validate -syntax-only packer/cpu/buildkite-cpu-ami.pkr.hcl`
- `bash -n packer/cpu/scripts/pre-checkout`
- verified the hook exports both Git flags for `BUILDKITE_STEP_KEY=image-build`
- verified the hook exports neither flag for an unrelated step key
- `uvx pre-commit run --files packer/cpu/buildkite-cpu-ami.pkr.hcl packer/cpu/scripts/pre-checkout`

AI assistance was used to investigate the Buildkite timing, prepare the change, and run validation. The submitter reviewed the full diff.
