### PR TITLE
Fix CPU AMI rebuild pipeline

### DIFF
--- a/.buildkite/pipelines/rebuild-cpu-ami.yml
+++ b/.buildkite/pipelines/rebuild-cpu-ami.yml
@@ -26,11 +26,17 @@ steps:
         set -euo pipefail
         cd packer/cpu
 
-        # Install yq if not available (Amazon Linux 2)
+        # Install a pinned standalone yq if not available. The PyPI yq package
+        # has unbounded dependencies that can drop support for the agent's Python.
+        export PATH="$$HOME/.local/bin:$$PATH"
         if ! command -v yq &> /dev/null; then
           echo "Installing yq..."
-          pip3 install yq
-          export PATH="$$HOME/.local/bin:$$PATH"
+          YQ_VERSION="v4.44.3"
+          mkdir -p "$$HOME/.local/bin"
+          curl -fsSL \
+            "https://github.com/mikefarah/yq/releases/download/$${YQ_VERSION}/yq_linux_amd64" \
+            -o "$$HOME/.local/bin/yq"
+          chmod +x "$$HOME/.local/bin/yq"
         fi
 
         # Install packer if not available
@@ -130,8 +136,11 @@ steps:
         echo "--- :buildkite: Fetching bake config from CI build #$$CI_BUILD_NUMBER"
         CONFIG_FILE="bake-config-build-$$CI_BUILD_NUMBER.json"
 
-        # Download the artifact using the build UUID from the annotation
-        buildkite-agent artifact download "$$CONFIG_FILE" . --build "$$CI_BUILD_ID" || {
+        # The AMD image step uploads an artifact with the same filename. Scope the
+        # query to the NVIDIA image step that published POSTMERGE_IMAGE.
+        buildkite-agent artifact download "$$CONFIG_FILE" . \
+          --build "$$CI_BUILD_ID" \
+          --step "image-build" || {
           echo "ERROR: Failed to download artifact $$CONFIG_FILE from build #$$CI_BUILD_NUMBER"
           echo "The CI build may not have published the bake config artifact."
           exit 1


### PR DESCRIPTION
## Summary

- scope the bake-config download to the NVIDIA `image-build` step
- replace the unpinned PyPI `yq` install with standalone `yq v4.44.3`

## Root cause

The AMI job queried `bake-config-build-<number>.json` across the entire vLLM CI build. Multiple image jobs upload that filename, so once more than one artifact was present Buildkite returned HTTP 400 (`Multiple artifacts were found`). Build 312 was the first run where that timing race consistently resolved against the AMI job.

The latest run, build 346, exposed a second blocker before artifact lookup: PyPI `yq` pulled `argcomplete 3.7.1`, whose Python 3.10-only type syntax crashes on the packer agent's Python 3.9.

## Impact

The scheduled CPU AMI rebuild can deterministically use the bake configuration that produced `vllm-ci-postmerge-repo:latest`, without depending on AMD job timing or mutable Python dependencies.

## Validation

- `bk pipeline validate --file .buildkite/pipelines/rebuild-cpu-ami.yml`
- Buildkite-interpolated command passes `bash -n`
- `yq v4.44.3` extracts `ami-04ca34320055d861c` from Buildkite stack `v6.21.0`
- read-only check of vLLM CI build 82241 found three same-named artifacts; `image-build` remains the unique NVIDIA producer
- post-merge production [build 347](https://buildkite.com/vllm/rebuild-cpu-build-ami/builds/347) passed on `main@955f1c6`
- build 347 created available AMI `ami-061d860b03d2d3d97`, updated SSM and all four CPU ASGs, and completed old-AMI cleanup