### PR TITLE
[ROCm][CI] Support build-scoped images

### DIFF
--- a/buildkite/bootstrap-amd.sh
+++ b/buildkite/bootstrap-amd.sh
@@ -170,6 +170,11 @@ upload_pipeline() {
     echo "AMD Mirror HW: $AMD_MIRROR_HW"
 
     FAIL_FAST=$(fail_fast)
+    ROCM_BUILD_SCOPED_IMAGES=0
+    if grep -q 'CI_BASE_IMAGE_TAG_BUILD_REF' \
+        .buildkite/scripts/ci-bake-rocm.sh 2>/dev/null; then
+        ROCM_BUILD_SCOPED_IMAGES=1
+    fi
 
     cd .buildkite
     (
@@ -189,7 +194,7 @@ upload_pipeline() {
             -D vllm_ci_branch="$VLLM_CI_BRANCH" \
             -D rocm_base_refresh_skip="${ROCM_BASE_REFRESH_SKIP:-0}" \
             -D rocm_base_refresh_force="${ROCM_BASE_REFRESH_FORCE:-0}" \
-            -D rocm_base_refresh_diff_unavailable="${ROCM_BASE_REFRESH_DIFF_UNAVAILABLE:-0}" \
+            -D rocm_build_scoped_images="$ROCM_BUILD_SCOPED_IMAGES" \
             | sed '/^[[:space:]]*$/d' \
             > pipeline.yaml
     )
@@ -236,14 +241,6 @@ else
 fi
 
 ROCM_BASE_DOCKERFILE="docker/Dockerfile.rocm_base"
-ROCM_BASE_DOCKERFILE_CHANGED=0
-while IFS= read -r file; do
-    file="${file%$'\r'}"
-    if [[ $file == "$ROCM_BASE_DOCKERFILE" ]]; then
-        ROCM_BASE_DOCKERFILE_CHANGED=1
-        break
-    fi
-done < <(printf '%s\n' "${file_diff:-}")
 
 # ----------------------------------------------------------------------
 # Early exit start: skip pipeline if conditions are met
@@ -364,8 +361,7 @@ else
 fi
 
 # Build LIST_FILE_DIFF from the already-computed file_diff. Use a short sentinel
-# for full-coverage modes instead of passing a potentially large diff, but retain
-# the ROCm base Dockerfile marker used to select the refresh step timeout.
+# for full-coverage modes instead of passing a potentially large diff.
 if [[ $RUN_ALL -eq 1 ]]; then
     LIST_FILE_DIFF="run_all"
 elif [[ $NIGHTLY -eq 1 ]]; then
@@ -373,12 +369,5 @@ elif [[ $NIGHTLY -eq 1 ]]; then
 else
     LIST_FILE_DIFF=$(join_file_diff "$file_diff")
 fi
-
-if [[ $ROCM_BASE_DOCKERFILE_CHANGED -eq 1 && \
-      ( $LIST_FILE_DIFF == "run_all" || $LIST_FILE_DIFF == "nightly" ) ]]; then
-    LIST_FILE_DIFF+="|$ROCM_BASE_DOCKERFILE"
-fi
-
-export ROCM_BASE_REFRESH_DIFF_UNAVAILABLE="$diff_unavailable"
 
 upload_pipeline

--- a/buildkite/pipeline_generator/amd.py
+++ b/buildkite/pipeline_generator/amd.py
@@ -39,10 +39,14 @@ AMD_ARTIFACT_GLOB = "artifacts/vllm-rocm-install/vllm-rocm-install.tar.gz"
 AMD_ARTIFACT_CHECKSUM_GLOB = f"{AMD_ARTIFACT_GLOB}.sha256"
 AMD_ARTIFACT_STEP = "image-build-amd"
 AMD_RESULTS_ROOT = "/home/buildkite-agent/huggingface/amd-ci-results"
+AMD_DIAGNOSTICS_DIR = "artifacts/amd-gpu-diagnostics"
 AMD_HF_HOME = "/home/buildkite-agent/huggingface"
 AMD_NATIVE_WORKSPACE = "/vllm-workspace"
 AMD_NATIVE_WORKSPACE_VOLUME = "vllm-workspace"
 AMD_NATIVE_SHM_SIZE = "16Gi"
+AMD_NATIVE_POD_IDENTITY_ENV = {
+    "VLLM_CI_K8S_NODE_NAME": "spec.nodeName",
+}
 AMD_NATIVE_RUNTIME_SOURCE_DEPENDENCIES = (
     ".buildkite/scripts/hardware_ci/run-amd-test.sh",
 )
@@ -310,6 +314,8 @@ def _get_amd_env(
     gpu_count: int,
 ) -> Dict[str, str]:
     env = dict(extra_env or {})
+    env["VLLM_CI_DIAGNOSTICS_DIR"] = AMD_DIAGNOSTICS_DIR
+    env["VLLM_CI_EXPECTED_GPU_COUNT"] = str(gpu_count)
     if not dind:
         # Native agents have no DinD sidecar, so Docker hook inputs must not
         # escape into this execution mode.
@@ -328,7 +334,6 @@ def _get_amd_env(
                 "VLLM_CI_USE_ARTIFACTS": "1",
                 "VLLM_CI_ARTIFACT_GLOB": AMD_ARTIFACT_GLOB,
                 "VLLM_CI_RESULTS_ROOT": AMD_RESULTS_ROOT,
-                "VLLM_CI_EXPECTED_GPU_COUNT": str(gpu_count),
                 "VLLM_CI_WORKSPACE": AMD_NATIVE_WORKSPACE,
                 "VLLM_CI_REQUIRE_WORKSPACE_MOUNT": "1",
                 "VLLM_TEST_COMMANDS": commands,
@@ -395,8 +400,21 @@ def get_amd_k8s_plugin(
                             },
                         ],
                         "env": [
-                            {"name": name, "value": value}
-                            for name, value in container_env.items()
+                            *(
+                                {"name": name, "value": value}
+                                for name, value in container_env.items()
+                            ),
+                            *(
+                                {
+                                    "name": name,
+                                    "valueFrom": {
+                                        "fieldRef": {"fieldPath": field_path}
+                                    },
+                                }
+                                for name, field_path in (
+                                    AMD_NATIVE_POD_IDENTITY_ENV.items()
+                                )
+                            ),
                         ],
                     }
                 ],

--- a/buildkite/pipeline_generator/amd.py
+++ b/buildkite/pipeline_generator/amd.py
@@ -1,10 +1,9 @@
 import os
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Mapping, Optional, TypedDict
+from typing import Any, Dict, List, Mapping, Optional, TypedDict
 
 from constants import AgentQueue, DeviceType
-from step import Step
 
 AMD_TEST_COMMAND = "bash .buildkite/scripts/hardware_ci/run-amd-test.sh"
 AMD_STABLE_CI_BASE_IMAGE = "rocm/vllm-dev:ci_base"
@@ -86,7 +85,9 @@ def ensure_amd_stack_error_retry(
         ):
             return retry_policy
     else:
-        raise ValueError("AMD retry.automatic must be a boolean, mapping, or list.")
+        raise ValueError(
+            "AMD retry.automatic must be a boolean, mapping, or list."
+        )
 
     retry_policy["automatic"] = [
         dict(AMD_STACK_ERROR_RETRY),
@@ -107,35 +108,12 @@ def get_rocm_base_refresh_timeout(list_file_diff: List[str]) -> int:
     return AMD_ROCM_BASE_REFRESH_NOOP_TIMEOUT_MINUTES
 
 
-def _get_amd_mirror_effective_step(step: Step, amd: Mapping[str, Any]) -> Step:
-    source_file_dependencies = list(amd.get("source_file_dependencies") or [])
-    for dependency in step.source_file_dependencies or []:
-        if dependency not in source_file_dependencies:
-            source_file_dependencies.append(dependency)
-    if not source_file_dependencies:
-        source_file_dependencies = None
-
-    return step.model_copy(
-        update={
-            "key": None,
-            "device": amd["device"],
-            "dind": amd.get("dind", True),
-            "optional": amd.get("optional", step.optional),
-            "source_file_dependencies": source_file_dependencies,
-        }
-    )
-
-
 def _amd_mirror_should_run(
-    step: Step,
-    amd: Mapping[str, Any],
-    list_file_diff: List[str],
-    step_should_run: Callable[..., bool],
+    default_should_run: bool, list_file_diff: List[str]
 ) -> bool:
-    return step_should_run(
-        _get_amd_mirror_effective_step(step, amd),
-        list_file_diff,
-        force_auto_run=AMD_ROCM_BASE_DOCKERFILE in list_file_diff,
+    return default_should_run or (
+        os.getenv("NOAUTO") != "1"
+        and AMD_ROCM_BASE_DOCKERFILE in list_file_diff
     )
 
 

--- a/buildkite/pipeline_generator/amd.py
+++ b/buildkite/pipeline_generator/amd.py
@@ -1,14 +1,40 @@
 import os
 from copy import deepcopy
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, TypedDict
 
 from constants import AgentQueue, DeviceType
 
 AMD_TEST_COMMAND = "bash .buildkite/scripts/hardware_ci/run-amd-test.sh"
 AMD_STABLE_CI_BASE_IMAGE = "rocm/vllm-dev:ci_base"
-AMD_NATIVE_BASE_IMAGE = "rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT"
-AMD_FALLBACK_CI_IMAGE = "rocm/vllm-ci:$BUILDKITE_COMMIT"
+AMD_LEGACY_NATIVE_BASE_IMAGE = "rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT"
+AMD_BUILD_NATIVE_BASE_IMAGE = "rocm/vllm-dev:ci_base-build-$BUILDKITE_BUILD_ID"
+AMD_LEGACY_CI_IMAGE = "rocm/vllm-ci:$BUILDKITE_COMMIT"
+AMD_BUILD_CI_IMAGE = "rocm/vllm-ci:build-$BUILDKITE_BUILD_ID"
+
+
+def supports_build_scoped_images() -> bool:
+    producer = Path(".buildkite/scripts/ci-bake-rocm.sh")
+    return producer.is_file() and "CI_BASE_IMAGE_TAG_BUILD_REF" in producer.read_text()
+
+
+def get_amd_native_base_image() -> str:
+    return (
+        AMD_BUILD_NATIVE_BASE_IMAGE
+        if supports_build_scoped_images()
+        else AMD_LEGACY_NATIVE_BASE_IMAGE
+    )
+
+
+def get_amd_ci_image() -> str:
+    return (
+        AMD_BUILD_CI_IMAGE
+        if supports_build_scoped_images()
+        else AMD_LEGACY_CI_IMAGE
+    )
+
+
 AMD_ARTIFACT_GLOB = "artifacts/vllm-rocm-install/vllm-rocm-install.tar.gz"
 AMD_ARTIFACT_CHECKSUM_GLOB = f"{AMD_ARTIFACT_GLOB}.sha256"
 AMD_ARTIFACT_STEP = "image-build-amd"
@@ -22,7 +48,6 @@ AMD_NATIVE_RUNTIME_SOURCE_DEPENDENCIES = (
 )
 AMD_STANDARD_TIMEOUT_MINUTES = 3 * 60
 AMD_ROCM_BASE_REFRESH_STEP_KEY = "refresh-rocm-base-amd"
-AMD_ROCM_BASE_DOCKERFILE = "docker/Dockerfile.rocm_base"
 AMD_ROCM_BASE_REFRESH_TIMEOUT_MINUTES = 9 * 60
 AMD_ROCM_BASE_REFRESH_NOOP_TIMEOUT_MINUTES = 15
 AMD_ALWAYS_RUN_STEP_KEYS = frozenset(
@@ -96,16 +121,10 @@ def ensure_amd_stack_error_retry(
     return retry_policy
 
 
-def get_rocm_base_refresh_timeout(list_file_diff: List[str]) -> int:
+def get_rocm_base_refresh_timeout() -> int:
     if os.getenv("ROCM_BASE_REFRESH_SKIP", "0") == "1":
         return AMD_ROCM_BASE_REFRESH_NOOP_TIMEOUT_MINUTES
-    if (
-        os.getenv("ROCM_BASE_REFRESH_FORCE", "0") == "1"
-        or os.getenv("ROCM_BASE_REFRESH_DIFF_UNAVAILABLE", "0") == "1"
-        or AMD_ROCM_BASE_DOCKERFILE in list_file_diff
-    ):
-        return AMD_ROCM_BASE_REFRESH_TIMEOUT_MINUTES
-    return AMD_ROCM_BASE_REFRESH_NOOP_TIMEOUT_MINUTES
+    return AMD_ROCM_BASE_REFRESH_TIMEOUT_MINUTES
 
 
 def get_rocm_base_refresh_env() -> Dict[str, str]:
@@ -295,7 +314,7 @@ def _get_amd_env(
         env.setdefault("HF_HUB_ETAG_TIMEOUT", "60")
         env.update(
             {
-                "VLLM_CI_BASE_IMAGE": AMD_NATIVE_BASE_IMAGE,
+                "VLLM_CI_BASE_IMAGE": get_amd_native_base_image(),
                 "VLLM_CI_USE_ARTIFACTS": "1",
                 "VLLM_CI_ARTIFACT_GLOB": AMD_ARTIFACT_GLOB,
                 "VLLM_CI_RESULTS_ROOT": AMD_RESULTS_ROOT,
@@ -315,7 +334,7 @@ def _get_amd_env(
                 "DOCKER_BUILDKIT": "1",
                 "DOCKER_IMAGE_NAME": AMD_STABLE_CI_BASE_IMAGE,
                 "VLLM_CI_BASE_IMAGE": AMD_STABLE_CI_BASE_IMAGE,
-                "VLLM_CI_FALLBACK_IMAGE": AMD_FALLBACK_CI_IMAGE,
+                "VLLM_CI_FALLBACK_IMAGE": get_amd_ci_image(),
                 "VLLM_CI_USE_ARTIFACTS": "1",
                 "VLLM_CI_ARTIFACT_GLOB": AMD_ARTIFACT_GLOB,
                 "VLLM_CI_RESULTS_ROOT": AMD_RESULTS_ROOT,
@@ -429,7 +448,7 @@ def build_amd_step_options(
         }
         plugins = [
             get_amd_k8s_plugin(
-                image=AMD_NATIVE_BASE_IMAGE,
+                image=get_amd_native_base_image(),
                 gpu_count=gpu_count,
                 workspace=AMD_NATIVE_WORKSPACE,
                 workspace_volume_name=AMD_NATIVE_WORKSPACE_VOLUME,

--- a/buildkite/pipeline_generator/amd.py
+++ b/buildkite/pipeline_generator/amd.py
@@ -1,9 +1,10 @@
 import os
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, Optional, TypedDict
+from typing import Any, Callable, Dict, List, Mapping, Optional, TypedDict
 
 from constants import AgentQueue, DeviceType
+from step import Step
 
 AMD_TEST_COMMAND = "bash .buildkite/scripts/hardware_ci/run-amd-test.sh"
 AMD_STABLE_CI_BASE_IMAGE = "rocm/vllm-dev:ci_base"
@@ -85,9 +86,7 @@ def ensure_amd_stack_error_retry(
         ):
             return retry_policy
     else:
-        raise ValueError(
-            "AMD retry.automatic must be a boolean, mapping, or list."
-        )
+        raise ValueError("AMD retry.automatic must be a boolean, mapping, or list.")
 
     retry_policy["automatic"] = [
         dict(AMD_STACK_ERROR_RETRY),
@@ -106,6 +105,38 @@ def get_rocm_base_refresh_timeout(list_file_diff: List[str]) -> int:
     ):
         return AMD_ROCM_BASE_REFRESH_TIMEOUT_MINUTES
     return AMD_ROCM_BASE_REFRESH_NOOP_TIMEOUT_MINUTES
+
+
+def _get_amd_mirror_effective_step(step: Step, amd: Mapping[str, Any]) -> Step:
+    source_file_dependencies = list(amd.get("source_file_dependencies") or [])
+    for dependency in step.source_file_dependencies or []:
+        if dependency not in source_file_dependencies:
+            source_file_dependencies.append(dependency)
+    if not source_file_dependencies:
+        source_file_dependencies = None
+
+    return step.model_copy(
+        update={
+            "key": None,
+            "device": amd["device"],
+            "dind": amd.get("dind", True),
+            "optional": amd.get("optional", step.optional),
+            "source_file_dependencies": source_file_dependencies,
+        }
+    )
+
+
+def _amd_mirror_should_run(
+    step: Step,
+    amd: Mapping[str, Any],
+    list_file_diff: List[str],
+    step_should_run: Callable[..., bool],
+) -> bool:
+    return step_should_run(
+        _get_amd_mirror_effective_step(step, amd),
+        list_file_diff,
+        force_auto_run=AMD_ROCM_BASE_DOCKERFILE in list_file_diff,
+    )
 
 
 def get_rocm_base_refresh_env() -> Dict[str, str]:

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -674,10 +674,11 @@ def convert_group_step_to_buildkite_step(
                     agent_tags=amd.get("agent_tags"),
                 )
                 if not _amd_mirror_should_run(
-                    step,
-                    amd,
+                    _step_should_run(
+                        _get_amd_mirror_effective_step(step, amd),
+                        list_file_diff,
+                    ),
                     list_file_diff,
-                    _step_should_run,
                 ):
                     # Block step depends on the shared AMD image build.
                     mirror_build_dep = (
@@ -708,19 +709,12 @@ def convert_group_step_to_buildkite_step(
     return buildkite_group_steps
 
 
-def _step_should_run(
-    step: Step,
-    list_file_diff: List[str],
-    *,
-    force_auto_run: bool = False,
-) -> bool:
+def _step_should_run(step: Step, list_file_diff: List[str]) -> bool:
     if os.getenv("NOAUTO") == "1":
         return False
     global_config = get_global_config()
     if global_config["only_step_keys"] is not None:
         return step.key in global_config["only_step_keys"]
-    if force_auto_run:
-        return True
     if step.key and (
         step.key.startswith("image-build") or step.key in AMD_ALWAYS_RUN_STEP_KEYS
     ):
@@ -741,6 +735,25 @@ def _step_should_run(
         return True
     return _source_file_dependencies_match(
         step.source_file_dependencies, list_file_diff
+    )
+
+
+def _get_amd_mirror_effective_step(step: Step, amd: Dict[str, Any]) -> Step:
+    source_file_dependencies = list(amd.get("source_file_dependencies") or [])
+    for dependency in step.source_file_dependencies or []:
+        if dependency not in source_file_dependencies:
+            source_file_dependencies.append(dependency)
+    if not source_file_dependencies:
+        source_file_dependencies = None
+
+    return step.model_copy(
+        update={
+            "key": None,
+            "device": amd["device"],
+            "dind": amd.get("dind", True),
+            "optional": amd.get("optional", step.optional),
+            "source_file_dependencies": source_file_dependencies,
+        }
     )
 
 

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -7,6 +7,7 @@ from amd import (
     AMD_ALWAYS_RUN_STEP_KEYS,
     AMD_NATIVE_RUNTIME_SOURCE_DEPENDENCIES,
     AMD_ROCM_BASE_REFRESH_STEP_KEY,
+    _amd_mirror_should_run,
     build_amd_step_options,
     ensure_amd_stack_error_retry,
     get_amd_agent_queue,
@@ -672,8 +673,11 @@ def convert_group_step_to_buildkite_step(
                     timeout_in_minutes=amd.get("timeout_in_minutes"),
                     agent_tags=amd.get("agent_tags"),
                 )
-                if not _step_should_run(
-                    _get_amd_mirror_effective_step(step, amd), list_file_diff
+                if not _amd_mirror_should_run(
+                    step,
+                    amd,
+                    list_file_diff,
+                    _step_should_run,
                 ):
                     # Block step depends on the shared AMD image build.
                     mirror_build_dep = (
@@ -704,12 +708,19 @@ def convert_group_step_to_buildkite_step(
     return buildkite_group_steps
 
 
-def _step_should_run(step: Step, list_file_diff: List[str]) -> bool:
+def _step_should_run(
+    step: Step,
+    list_file_diff: List[str],
+    *,
+    force_auto_run: bool = False,
+) -> bool:
     if os.getenv("NOAUTO") == "1":
         return False
     global_config = get_global_config()
     if global_config["only_step_keys"] is not None:
         return step.key in global_config["only_step_keys"]
+    if force_auto_run:
+        return True
     if step.key and (
         step.key.startswith("image-build") or step.key in AMD_ALWAYS_RUN_STEP_KEYS
     ):
@@ -730,25 +741,6 @@ def _step_should_run(step: Step, list_file_diff: List[str]) -> bool:
         return True
     return _source_file_dependencies_match(
         step.source_file_dependencies, list_file_diff
-    )
-
-
-def _get_amd_mirror_effective_step(step: Step, amd: Dict[str, Any]) -> Step:
-    source_file_dependencies = list(amd.get("source_file_dependencies") or [])
-    for dependency in step.source_file_dependencies or []:
-        if dependency not in source_file_dependencies:
-            source_file_dependencies.append(dependency)
-    if not source_file_dependencies:
-        source_file_dependencies = None
-
-    return step.model_copy(
-        update={
-            "key": None,
-            "device": amd["device"],
-            "dind": amd.get("dind", True),
-            "optional": amd.get("optional", step.optional),
-            "source_file_dependencies": source_file_dependencies,
-        }
     )
 
 

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -162,6 +162,8 @@ class BuildkiteCommandStep(BaseModel):
     plugins: Optional[List[Dict[str, Any]]] = None
     env: Optional[Dict[str, str]] = None
     parallelism: Optional[int] = None
+    concurrency: Optional[int] = None
+    concurrency_group: Optional[str] = None
     timeout_in_minutes: Optional[int] = None
     priority: Optional[int] = None
 
@@ -178,6 +180,8 @@ class BuildkiteCommandStep(BaseModel):
             "plugins": self.plugins,
             "env": self.env,
             "parallelism": self.parallelism,
+            "concurrency": self.concurrency,
+            "concurrency_group": self.concurrency_group,
             "timeout_in_minutes": self.timeout_in_minutes,
             "priority": self.priority,
         }
@@ -530,6 +534,8 @@ def convert_group_step_to_buildkite_step(
                     num_nodes=step.num_nodes,
                     soft_fail=step.soft_fail,
                     parallelism=step.parallelism,
+                    concurrency=step.concurrency,
+                    concurrency_group=step.concurrency_group,
                     timeout_in_minutes=step.timeout_in_minutes,
                     agent_tags=step.agent_tags,
                 )
@@ -554,6 +560,8 @@ def convert_group_step_to_buildkite_step(
                 soft_fail=step.soft_fail,
                 agents=_get_step_agents(step),
                 priority=1000 if os.getenv("PRIORITY", "") == "HIGH" else 0,
+                concurrency=step.concurrency,
+                concurrency_group=step.concurrency_group,
             )
 
             if step.env:
@@ -579,7 +587,7 @@ def convert_group_step_to_buildkite_step(
                 refresh_env.update(get_rocm_base_refresh_env())
                 buildkite_step.env = refresh_env
                 buildkite_step.timeout_in_minutes = _get_timeout_in_minutes(
-                    get_rocm_base_refresh_timeout(list_file_diff)
+                    get_rocm_base_refresh_timeout()
                 )
             elif (
                 step.device == DeviceType.AMD_CPU
@@ -669,6 +677,10 @@ def convert_group_step_to_buildkite_step(
                     num_nodes=amd.get("num_nodes", step.num_nodes),
                     soft_fail=amd.get("soft_fail", step.soft_fail or False),
                     parallelism=step.parallelism,
+                    concurrency=amd.get("concurrency", step.concurrency),
+                    concurrency_group=amd.get(
+                        "concurrency_group", step.concurrency_group
+                    ),
                     timeout_in_minutes=amd.get("timeout_in_minutes"),
                     agent_tags=amd.get("agent_tags"),
                 )
@@ -800,6 +812,8 @@ def _create_amd_step(
     num_nodes: Optional[int],
     soft_fail: Optional[bool],
     parallelism: Optional[int],
+    concurrency: Optional[int],
+    concurrency_group: Optional[str],
     key: Optional[str] = None,
     timeout_in_minutes: Optional[int] = None,
     agent_tags: Optional[Dict[str, str]] = None,
@@ -823,6 +837,8 @@ def _create_amd_step(
         key=key,
         soft_fail=soft_fail or False,
         parallelism=parallelism,
+        concurrency=concurrency,
+        concurrency_group=concurrency_group,
         timeout_in_minutes=_get_timeout_in_minutes(
             get_amd_timeout_in_minutes(timeout_in_minutes)
         ),

--- a/buildkite/pipeline_generator/step.py
+++ b/buildkite/pipeline_generator/step.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Optional, List, Dict, Any
 from pydantic import model_validator
 from typing_extensions import Self
@@ -22,6 +22,8 @@ class Step(BaseModel):
     source_file_dependencies: Optional[List[str]] = None
     soft_fail: Optional[bool] = False
     parallelism: Optional[int] = None
+    concurrency: Optional[int] = Field(default=None, gt=0, strict=True)
+    concurrency_group: Optional[str] = None
     timeout_in_minutes: Optional[int] = None
     mount_buildkite_agent: Optional[bool] = False
     env: Optional[Dict[str, str]] = None
@@ -36,6 +38,12 @@ class Step(BaseModel):
     def validate_multi_node(self) -> Self:
         if self.num_nodes and not self.num_devices:
             raise ValueError("'num_devices' must be defined if 'num_nodes' is defined.")
+        if (self.concurrency is None) != (self.concurrency_group is None):
+            raise ValueError(
+                "'concurrency' and 'concurrency_group' must be defined together."
+            )
+        if self.concurrency_group is not None and not self.concurrency_group.strip():
+            raise ValueError("'concurrency_group' must be a nonempty string.")
         return self
 
     @classmethod

--- a/buildkite/test-template-amd.j2
+++ b/buildkite/test-template-amd.j2
@@ -1,8 +1,7 @@
 {% set default_working_dir = "/vllm-workspace/tests" %}
 {% set default_amd_timeout_in_minutes = 180 %}
 {% set list_file_diff = list_file_diff | replace("\r", "") | replace("\n", "|") | split("|") %}
-{% set rocm_base_refresh_needs_build = rocm_base_refresh_force == "1" or rocm_base_refresh_diff_unavailable == "1" or "docker/Dockerfile.rocm_base" in list_file_diff %}
-{% set rocm_base_refresh_timeout_in_minutes = 15 if rocm_base_refresh_skip == "1" else (540 if rocm_base_refresh_needs_build else 15) %}
+{% set rocm_base_refresh_timeout_in_minutes = 15 if rocm_base_refresh_skip == "1" else 540 %}
 {# TODO: Re-enable after validating the ROCm debug agent setup.
 {% set rocm_debug_agent_setup = "if test -f /opt/rocm/lib/librocm-debug-agent.so.2; then export HSA_TOOLS_LIB=/opt/rocm/lib/librocm-debug-agent.so.2 && export HSA_ENABLE_DEBUG=1 && echo ROCm debug agent enabled: /opt/rocm/lib/librocm-debug-agent.so.2; else echo 'WARNING: ROCm debug agent not found at /opt/rocm/lib/librocm-debug-agent.so.2; skipping coredump setup'; fi" %}
 #}
@@ -15,6 +14,8 @@
 {{ indent }}      limit: 1
 {% if retry_exit_status_one %}
 {{ indent }}    - exit_status: 1  # Transient Docker/BuildKit failure
+{{ indent }}      limit: 1
+{{ indent }}    - exit_status: 2  # Exact image found but registry handoff failed
 {{ indent }}      limit: 1
 {% endif %}
 {{ indent }}    - signal_reason: agent_stop  # Agent host stopped unexpectedly
@@ -34,7 +35,19 @@
 
 {# Native in-pod ROCm CI: per-job container-0 image via kubernetes podSpecPatch. #}
 {% macro amd_native_base_image() -%}
+{% if rocm_build_scoped_images == "1" -%}
+rocm/vllm-dev:ci_base-build-$BUILDKITE_BUILD_ID
+{%- else -%}
 rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT
+{%- endif %}
+{%- endmacro %}
+
+{% macro amd_ci_image() -%}
+{% if rocm_build_scoped_images == "1" -%}
+rocm/vllm-ci:build-$BUILDKITE_BUILD_ID
+{%- else -%}
+rocm/vllm-ci:$BUILDKITE_COMMIT
+{%- endif %}
 {%- endmacro %}
 
 {% macro amd_native_k8s_plugin(step) %}
@@ -108,6 +121,8 @@ rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT
         commands:
           - bash .buildkite/scripts/rocm/refresh-base-image.sh
         key: "refresh-rocm-base-amd"
+        concurrency: 1
+        concurrency_group: "vllm/rocm/base-build/$BUILDKITE_COMMIT"
         timeout_in_minutes: {{ rocm_base_refresh_timeout_in_minutes }}
         env:
           ROCM_BASE_REFRESH_SKIP: "{{ rocm_base_refresh_skip }}"
@@ -125,6 +140,8 @@ rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT
         commands:
           - bash .buildkite/scripts/rocm/build-ci-base.sh
         key: "ensure-ci-base-amd"
+        concurrency: 1
+        concurrency_group: "vllm/rocm/ci-base-build/$BUILDKITE_COMMIT"
         timeout_in_minutes: {{ default_amd_timeout_in_minutes }}
         env:
           DOCKER_BUILDKIT: "1"
@@ -151,9 +168,8 @@ rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT
           TERM: "xterm-256color"
           VLLM_BAKE_FILE: "docker/docker-bake-rocm.hcl"
           PYTORCH_ROCM_ARCH: "gfx90a;gfx942;gfx950"
-          IMAGE_TAG: "rocm/vllm-ci:$BUILDKITE_COMMIT"
-          REMOTE_VLLM: "1"
-          VLLM_BRANCH: "$BUILDKITE_COMMIT"
+          IMAGE_TAG: "{{ amd_ci_image() | safe }}"
+          REMOTE_VLLM: "0"
 {{ amd_infra_retry('        ', true) }}
         agents:
           queue: amd-cpu
@@ -230,7 +246,7 @@ rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT
           NUM_NODES: "{{ step.num_nodes or 1 }}"
           # Agent hooks read DOCKER_IMAGE_NAME before run-amd-test.py starts.
           {% if step.dind == false %}
-          # Native: podSpecPatch sets container-0 to ci_base-<commit> from ensure-ci-base-amd.
+          # Native: podSpecPatch uses the ci_base alias owned by this build.
           VLLM_CI_BASE_IMAGE: "{{ amd_native_base_image() | safe }}"
           AMD_CI_RUNTIME: "native"
           NATIVE_CI: "true"
@@ -250,7 +266,7 @@ rocm/vllm-dev:ci_base-$BUILDKITE_COMMIT
           DOCKER_BUILDKIT: "1"
           DOCKER_IMAGE_NAME: "rocm/vllm-dev:ci_base"
           VLLM_CI_BASE_IMAGE: "rocm/vllm-dev:ci_base"
-          VLLM_CI_FALLBACK_IMAGE: "rocm/vllm-ci:$BUILDKITE_COMMIT"
+          VLLM_CI_FALLBACK_IMAGE: "{{ amd_ci_image() | safe }}"
           {% endif %}
           VLLM_CI_USE_ARTIFACTS: "1"
           VLLM_CI_ARTIFACT_GLOB: "artifacts/vllm-rocm-install/vllm-rocm-install.tar.gz"

--- a/buildkite/test-template-amd.j2
+++ b/buildkite/test-template-amd.j2
@@ -103,6 +103,11 @@ rocm/vllm-ci:$BUILDKITE_COMMIT
                         value: "1"
                       - name: PYTORCH_ROCM_ARCH
                         value: ""
+                      # Correlate in-pod GPU/BDF diagnostics with the K8s host.
+                      - name: VLLM_CI_K8S_NODE_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: spec.nodeName
                 volumes:
                   - name: devshm
                     emptyDir:
@@ -251,7 +256,6 @@ rocm/vllm-ci:$BUILDKITE_COMMIT
           AMD_CI_RUNTIME: "native"
           NATIVE_CI: "true"
           VLLM_CI_DOCKER_DISABLED: "1"
-          VLLM_CI_EXPECTED_GPU_COUNT: "{{ 0 if step.no_gpu else (step.num_gpus or 1) }}"
           VLLM_CI_ARTIFACT_STEP: "image-build-amd"
           VLLM_CI_ARTIFACT_CHECKSUM_GLOB: "artifacts/vllm-rocm-install/vllm-rocm-install.tar.gz.sha256"
           VLLM_CI_REQUIRE_PERSISTENT_HF_CACHE: "1"
@@ -271,6 +275,9 @@ rocm/vllm-ci:$BUILDKITE_COMMIT
           VLLM_CI_USE_ARTIFACTS: "1"
           VLLM_CI_ARTIFACT_GLOB: "artifacts/vllm-rocm-install/vllm-rocm-install.tar.gz"
           VLLM_CI_RESULTS_ROOT: "/home/buildkite-agent/huggingface/amd-ci-results"
+          # The runner uploads diagnostics immediately; keep them out of shared HF/NFS storage.
+          VLLM_CI_DIAGNOSTICS_DIR: "artifacts/amd-gpu-diagnostics"
+          VLLM_CI_EXPECTED_GPU_COUNT: "{{ 0 if step.no_gpu else (step.num_gpus or 1) }}"
           {% if container_timeout_s %}
           CONTAINER_TIMEOUT_S: "{{ container_timeout_s }}"
           {% endif %}

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -11,7 +11,9 @@ pytestmark = pytest.mark.usefixtures("fake_global_config")
 
 
 def test_legacy_amd_template_retries_gpu_hang_abort():
-    template = (Path(__file__).parents[2] / "test-template-amd.j2").read_text()
+    template = (
+        Path(__file__).parents[2] / "test-template-amd.j2"
+    ).read_text()
 
     assert (
         "{{ indent }}    - exit_status: 134  # ROCm/KFD GPU hang (SIGABRT)\n"
@@ -68,7 +70,9 @@ def test_rocm_base_refresh_force_uses_build_timeout(monkeypatch):
     assert command_step.timeout_in_minutes == 540
 
 
-def test_skip_timeout_omits_rocm_base_refresh_timeout(fake_global_config, monkeypatch):
+def test_skip_timeout_omits_rocm_base_refresh_timeout(
+    fake_global_config, monkeypatch
+):
     monkeypatch.setenv(buildkite_step.SKIP_TIMEOUT_ENV_VAR, "1")
     fake_global_config["list_file_diff"] = [amd.AMD_ROCM_BASE_DOCKERFILE]
 
@@ -87,7 +91,9 @@ def test_skip_timeout_omits_rocm_base_refresh_timeout(fake_global_config, monkey
         ("mi325_1", AgentQueue.AMD_MI325_1, True, "1"),
     ],
 )
-def test_direct_amd_gpu_steps_use_dind_flag(device, queue, dind, expected_gpu_count):
+def test_direct_amd_gpu_steps_use_dind_flag(
+    device, queue, dind, expected_gpu_count
+):
     step = Step(
         label="AMD direct test",
         group="Direct AMD",
@@ -149,23 +155,6 @@ def test_direct_amd_gpu_steps_use_dind_flag(device, queue, dind, expected_gpu_co
     assert "pytest tests/foo.py" in test_commands
     assert "nvidia-smi" not in test_commands
     assert "CUDA_ENABLE_COREDUMP_ON_EXCEPTION" not in test_commands
-
-
-def test_rocm_base_change_does_not_force_direct_amd_step(fake_global_config):
-    fake_global_config["list_file_diff"] = [amd.AMD_ROCM_BASE_DOCKERFILE]
-    step = Step(
-        label="Direct AMD test",
-        group="Direct AMD",
-        device="mi300_1",
-        optional=True,
-        commands=["pytest tests/direct_amd.py"],
-    )
-
-    group_step = _render_single_step(step)
-
-    assert len(group_step.steps) == 2
-    assert isinstance(group_step.steps[0], buildkite_step.BuildkiteBlockStep)
-    assert isinstance(group_step.steps[1], buildkite_step.BuildkiteCommandStep)
 
 
 def test_amd_device_rejects_conflicting_gpu_count():
@@ -265,43 +254,23 @@ def test_rocm_base_change_runs_only_amd_mirror(fake_global_config, optional):
     step = Step(
         label="ROCm base mirrored test",
         group="Mirrors",
-        key="rocm-base-mirrored-test",
-        depends_on=["image-build"],
-        working_dir="/vllm-workspace/tests",
         commands=["pytest tests/mirror.py"],
         source_file_dependencies=["vllm/"],
         optional=optional,
-        mirror={
-            "amd": {
-                "device": "mi325_1",
-                "depends_on": ["image-build-amd"],
-            }
-        },
+        mirror={"amd": {"device": "mi325_1"}},
     )
 
     group_steps = buildkite_step.convert_group_step_to_buildkite_step(
-        {
-            step.group: [step],
-        }
+        {step.group: [step]}
     )
     default_group = next(group for group in group_steps if group.group == "Mirrors")
     amd_group = next(
         group for group in group_steps if group.group == "Hardware-AMD Tests"
     )
 
-    assert len(default_group.steps) == 2
-    default_block_step = default_group.steps[0]
-    assert isinstance(default_block_step, buildkite_step.BuildkiteBlockStep)
-    default_command_step = default_group.steps[1]
-    assert isinstance(default_command_step, buildkite_step.BuildkiteCommandStep)
-    assert default_command_step.depends_on == [
-        default_block_step.key,
-        "image-build",
-    ]
+    assert isinstance(default_group.steps[0], buildkite_step.BuildkiteBlockStep)
     assert len(amd_group.steps) == 1
-    amd_command_step = amd_group.steps[0]
-    assert isinstance(amd_command_step, buildkite_step.BuildkiteCommandStep)
-    assert amd_command_step.depends_on == ["image-build-amd"]
+    assert isinstance(amd_group.steps[0], buildkite_step.BuildkiteCommandStep)
 
 
 def test_dind_false_mirror_uses_native_runner_gating(fake_global_config):

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -11,9 +11,7 @@ pytestmark = pytest.mark.usefixtures("fake_global_config")
 
 
 def test_legacy_amd_template_retries_gpu_hang_abort():
-    template = (
-        Path(__file__).parents[2] / "test-template-amd.j2"
-    ).read_text()
+    template = (Path(__file__).parents[2] / "test-template-amd.j2").read_text()
 
     assert (
         "{{ indent }}    - exit_status: 134  # ROCm/KFD GPU hang (SIGABRT)\n"
@@ -70,9 +68,7 @@ def test_rocm_base_refresh_force_uses_build_timeout(monkeypatch):
     assert command_step.timeout_in_minutes == 540
 
 
-def test_skip_timeout_omits_rocm_base_refresh_timeout(
-    fake_global_config, monkeypatch
-):
+def test_skip_timeout_omits_rocm_base_refresh_timeout(fake_global_config, monkeypatch):
     monkeypatch.setenv(buildkite_step.SKIP_TIMEOUT_ENV_VAR, "1")
     fake_global_config["list_file_diff"] = [amd.AMD_ROCM_BASE_DOCKERFILE]
 
@@ -91,9 +87,7 @@ def test_skip_timeout_omits_rocm_base_refresh_timeout(
         ("mi325_1", AgentQueue.AMD_MI325_1, True, "1"),
     ],
 )
-def test_direct_amd_gpu_steps_use_dind_flag(
-    device, queue, dind, expected_gpu_count
-):
+def test_direct_amd_gpu_steps_use_dind_flag(device, queue, dind, expected_gpu_count):
     step = Step(
         label="AMD direct test",
         group="Direct AMD",
@@ -155,6 +149,23 @@ def test_direct_amd_gpu_steps_use_dind_flag(
     assert "pytest tests/foo.py" in test_commands
     assert "nvidia-smi" not in test_commands
     assert "CUDA_ENABLE_COREDUMP_ON_EXCEPTION" not in test_commands
+
+
+def test_rocm_base_change_does_not_force_direct_amd_step(fake_global_config):
+    fake_global_config["list_file_diff"] = [amd.AMD_ROCM_BASE_DOCKERFILE]
+    step = Step(
+        label="Direct AMD test",
+        group="Direct AMD",
+        device="mi300_1",
+        optional=True,
+        commands=["pytest tests/direct_amd.py"],
+    )
+
+    group_step = _render_single_step(step)
+
+    assert len(group_step.steps) == 2
+    assert isinstance(group_step.steps[0], buildkite_step.BuildkiteBlockStep)
+    assert isinstance(group_step.steps[1], buildkite_step.BuildkiteCommandStep)
 
 
 def test_amd_device_rejects_conflicting_gpu_count():
@@ -246,6 +257,51 @@ def test_amd_mirror_uses_shared_gating_with_amd_dependency_fallback(
     assert amd_command_step.agents == {"queue": AgentQueue.AMD_MI325_1}
     assert amd_command_step.soft_fail is False
     assert "ROCm debug agent disabled" in (amd_command_step.env["VLLM_TEST_COMMANDS"])
+
+
+@pytest.mark.parametrize("optional", [False, True])
+def test_rocm_base_change_runs_only_amd_mirror(fake_global_config, optional):
+    fake_global_config["list_file_diff"] = [amd.AMD_ROCM_BASE_DOCKERFILE]
+    step = Step(
+        label="ROCm base mirrored test",
+        group="Mirrors",
+        key="rocm-base-mirrored-test",
+        depends_on=["image-build"],
+        working_dir="/vllm-workspace/tests",
+        commands=["pytest tests/mirror.py"],
+        source_file_dependencies=["vllm/"],
+        optional=optional,
+        mirror={
+            "amd": {
+                "device": "mi325_1",
+                "depends_on": ["image-build-amd"],
+            }
+        },
+    )
+
+    group_steps = buildkite_step.convert_group_step_to_buildkite_step(
+        {
+            step.group: [step],
+        }
+    )
+    default_group = next(group for group in group_steps if group.group == "Mirrors")
+    amd_group = next(
+        group for group in group_steps if group.group == "Hardware-AMD Tests"
+    )
+
+    assert len(default_group.steps) == 2
+    default_block_step = default_group.steps[0]
+    assert isinstance(default_block_step, buildkite_step.BuildkiteBlockStep)
+    default_command_step = default_group.steps[1]
+    assert isinstance(default_command_step, buildkite_step.BuildkiteCommandStep)
+    assert default_command_step.depends_on == [
+        default_block_step.key,
+        "image-build",
+    ]
+    assert len(amd_group.steps) == 1
+    amd_command_step = amd_group.steps[0]
+    assert isinstance(amd_command_step, buildkite_step.BuildkiteCommandStep)
+    assert amd_command_step.depends_on == ["image-build-amd"]
 
 
 def test_dind_false_mirror_uses_native_runner_gating(fake_global_config):

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -257,7 +257,7 @@ def test_rocm_base_change_runs_only_amd_mirror(fake_global_config, optional):
         commands=["pytest tests/mirror.py"],
         source_file_dependencies=["vllm/"],
         optional=optional,
-        mirror={"amd": {"device": "mi325_1"}},
+        mirror={"amd": {"device": "mi300_1"}},
     )
 
     group_steps = buildkite_step.convert_group_step_to_buildkite_step(

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -10,6 +10,20 @@ from step import Step
 pytestmark = pytest.mark.usefixtures("fake_global_config")
 
 
+def test_build_scoped_image_capability(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    assert amd.get_amd_native_base_image() == amd.AMD_LEGACY_NATIVE_BASE_IMAGE
+    assert amd.get_amd_ci_image() == amd.AMD_LEGACY_CI_IMAGE
+
+    producer = tmp_path / ".buildkite/scripts/ci-bake-rocm.sh"
+    producer.parent.mkdir(parents=True)
+    producer.write_text("CI_BASE_IMAGE_TAG_BUILD_REF=enabled")
+
+    assert amd.get_amd_native_base_image() == amd.AMD_BUILD_NATIVE_BASE_IMAGE
+    assert amd.get_amd_ci_image() == amd.AMD_BUILD_CI_IMAGE
+
+
 def test_legacy_amd_template_retries_gpu_hang_abort():
     template = (
         Path(__file__).parents[2] / "test-template-amd.j2"
@@ -37,44 +51,24 @@ def _rocm_base_refresh_step():
         device="amd_cpu",
         no_plugin=True,
         commands=["bash .buildkite/scripts/rocm/refresh-base-image.sh"],
+        concurrency=1,
+        concurrency_group="vllm/rocm/base-build/$BUILDKITE_COMMIT",
     )
 
 
-@pytest.mark.parametrize(
-    ("list_file_diff", "expected_timeout"),
-    [
-        ([], 15),
-        (["vllm/config.py"], 15),
-        (["run_all"], 15),
-        (["nightly"], 15),
-        ([amd.AMD_ROCM_BASE_DOCKERFILE], 540),
-        (["run_all", amd.AMD_ROCM_BASE_DOCKERFILE], 540),
-        (["nightly", amd.AMD_ROCM_BASE_DOCKERFILE], 540),
-    ],
-)
-def test_rocm_base_refresh_timeout_tracks_dockerfile_change(
-    fake_global_config, list_file_diff, expected_timeout
-):
-    fake_global_config["list_file_diff"] = list_file_diff
-
-    command_step = _render_single_step(_rocm_base_refresh_step()).steps[0]
-
-    assert command_step.timeout_in_minutes == expected_timeout
-
-
-def test_rocm_base_refresh_force_uses_build_timeout(monkeypatch):
-    monkeypatch.setenv("ROCM_BASE_REFRESH_FORCE", "1")
-
+def test_rocm_base_selector_keeps_build_timeout():
     command_step = _render_single_step(_rocm_base_refresh_step()).steps[0]
 
     assert command_step.timeout_in_minutes == 540
+    assert command_step.concurrency == 1
+    assert command_step.concurrency_group.endswith("/$BUILDKITE_COMMIT")
 
 
 def test_skip_timeout_omits_rocm_base_refresh_timeout(
     fake_global_config, monkeypatch
 ):
     monkeypatch.setenv(buildkite_step.SKIP_TIMEOUT_ENV_VAR, "1")
-    fake_global_config["list_file_diff"] = [amd.AMD_ROCM_BASE_DOCKERFILE]
+    fake_global_config["list_file_diff"] = ["docker/Dockerfile.rocm_base"]
 
     command_step = _render_single_step(_rocm_base_refresh_step()).steps[0]
 
@@ -123,6 +117,7 @@ def test_direct_amd_gpu_steps_use_dind_flag(
         assert command_step.plugins is not None
         pod_patch = command_step.plugins[0]["kubernetes"]["podSpecPatch"]
         container = pod_patch["containers"][0]
+        assert container["image"] == amd.get_amd_native_base_image()
         assert container["resources"]["limits"]["amd.com/gpu"] == expected_gpu_count
         assert container["resources"]["requests"]["amd.com/gpu"] == expected_gpu_count
         assert command_step.env["AMD_CI_RUNTIME"] == "native"
@@ -132,6 +127,13 @@ def test_direct_amd_gpu_steps_use_dind_flag(
         assert command_step.plugins is None
         assert "AMD_CI_RUNTIME" not in command_step.env
         assert command_step.env["DOCKER_IMAGE_NAME"] == amd.AMD_STABLE_CI_BASE_IMAGE
+        assert command_step.env["VLLM_CI_FALLBACK_IMAGE"] == amd.get_amd_ci_image()
+
+    assert command_step.env["VLLM_CI_BASE_IMAGE"] == (
+        amd.get_amd_native_base_image()
+        if not dind
+        else amd.AMD_STABLE_CI_BASE_IMAGE
+    )
 
     assert command_step.retry == amd.AMD_RETRY
     assert len(command_step.retry["automatic"]) == 7

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -35,6 +35,15 @@ def test_legacy_amd_template_retries_gpu_hang_abort():
     ) in template
 
 
+def test_legacy_amd_template_configures_gpu_diagnostics():
+    template = (Path(__file__).parents[2] / "test-template-amd.j2").read_text()
+
+    assert 'VLLM_CI_DIAGNOSTICS_DIR: "artifacts/amd-gpu-diagnostics"' in template
+    for name, field_path in amd.AMD_NATIVE_POD_IDENTITY_ENV.items():
+        assert f"- name: {name}" in template
+        assert f"fieldPath: {field_path}" in template
+
+
 def _render_single_step(step):
     return buildkite_step.convert_group_step_to_buildkite_step(
         {
@@ -113,6 +122,8 @@ def test_direct_amd_gpu_steps_use_dind_flag(
     assert command_step.commands == [
         "bash .buildkite/scripts/hardware_ci/run-amd-test.sh",
     ]
+    assert command_step.env["VLLM_CI_DIAGNOSTICS_DIR"] == amd.AMD_DIAGNOSTICS_DIR
+    assert command_step.env["VLLM_CI_EXPECTED_GPU_COUNT"] == expected_gpu_count
     if not dind:
         assert command_step.plugins is not None
         pod_patch = command_step.plugins[0]["kubernetes"]["podSpecPatch"]
@@ -121,8 +132,13 @@ def test_direct_amd_gpu_steps_use_dind_flag(
         assert container["resources"]["limits"]["amd.com/gpu"] == expected_gpu_count
         assert container["resources"]["requests"]["amd.com/gpu"] == expected_gpu_count
         assert command_step.env["AMD_CI_RUNTIME"] == "native"
-        assert command_step.env["VLLM_CI_EXPECTED_GPU_COUNT"] == expected_gpu_count
         assert "DOCKER_IMAGE_NAME" not in command_step.env
+        container_env = {entry["name"]: entry for entry in container["env"]}
+        for name, field_path in amd.AMD_NATIVE_POD_IDENTITY_ENV.items():
+            assert container_env[name] == {
+                "name": name,
+                "valueFrom": {"fieldRef": {"fieldPath": field_path}},
+            }
     else:
         assert command_step.plugins is None
         assert "AMD_CI_RUNTIME" not in command_step.env

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -117,6 +117,17 @@ def test_selected_step_runs_without_source_match(fake_global_config):
     assert buildkite_step._step_should_run(step, ["changed.py"])
 
 
+def test_noauto_blocks_forced_steps(monkeypatch):
+    monkeypatch.setenv("NOAUTO", "1")
+    step = Step(label="Forced", commands=["test"])
+
+    assert not buildkite_step._step_should_run(
+        step,
+        ["changed.py"],
+        force_auto_run=True,
+    )
+
+
 def test_continue_on_failure_exits_nonzero_after_command_failure(monkeypatch):
     monkeypatch.setenv("CONTINUE_ON_FAILURE", "1")
     step = Step(

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -117,17 +117,6 @@ def test_selected_step_runs_without_source_match(fake_global_config):
     assert buildkite_step._step_should_run(step, ["changed.py"])
 
 
-def test_noauto_blocks_forced_steps(monkeypatch):
-    monkeypatch.setenv("NOAUTO", "1")
-    step = Step(label="Forced", commands=["test"])
-
-    assert not buildkite_step._step_should_run(
-        step,
-        ["changed.py"],
-        force_auto_run=True,
-    )
-
-
 def test_continue_on_failure_exits_nonzero_after_command_failure(monkeypatch):
     monkeypatch.setenv("CONTINUE_ON_FAILURE", "1")
     step = Step(


### PR DESCRIPTION
- Select build-scoped ROCm native and fallback image aliases when the vLLM checkout supports them, while retaining the existing commit-scoped aliases for older checkouts.
- Serialize the shared ROCm base and `ci_base` publication steps per commit, while leaving the build-local test-image and artifact step free to run in parallel.
- Propagate validated Buildkite concurrency settings through generic, direct AMD, and mirrored AMD pipeline-generator paths.
- Remove Dockerfile-diff-based refresh timeout plumbing now that the vLLM base selector determines reuse or rebuild from image content identity.
- Build ROCm images from the checked-out source instead of injecting a remote branch override.

Multiple Buildkite pipelines for the same commit currently share mutable commit-scoped handoff aliases. One build can overwrite or consume another build's image, and forcing `REMOTE_VLLM=1` can make the declared image identity disagree with the local checkout. This causes avoidable rebuilds and makes exact-commit pipelines race each other. The companion vLLM change publishes build-owned aliases using `$BUILDKITE_BUILD_ID`. This change teaches ci-infra to select those aliases when supported. Shared base publication remains serialized because it writes canonical registry state, but each pipeline's full test image and artifacts remain independent. The capability check preserves compatibility during rollout: older vLLM checkouts continue using the existing commit-scoped aliases, while updated checkouts use build-scoped aliases.

This ci-infra change should merge before [vllm-project/vllm#48646](https://github.com/vllm-project/vllm/pull/48646).