### PR TITLE
[CI] Add keys to AMD mirror steps

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -658,6 +658,7 @@ def convert_group_step_to_buildkite_step(
                 extra_env.update(amd.get("env", {}))
                 amd_step = _create_amd_step(
                     label=step.label,
+                    key=f"amd-{_generate_step_key(step.key or step.label)}",
                     device=amd["device"],
                     num_devices=amd_num_devices,
                     commands_str=amd_commands_str,

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -242,6 +242,7 @@ def test_amd_mirror_uses_shared_gating_with_amd_dependency_fallback(
     assert default_command_step.depends_on == ["image-build"]
     assert default_command_step.soft_fail is False
     assert len(amd_group.steps) == 1
+    assert amd_command_step.key == "amd-mirrored-test"
     assert amd_command_step.depends_on == ["image-build-amd"]
     assert amd_command_step.agents == {"queue": AgentQueue.AMD_MI325_1}
     assert amd_command_step.soft_fail is False
@@ -275,6 +276,7 @@ def test_dind_false_mirror_uses_native_runner_gating(fake_global_config):
     assert len(amd_group.steps) == 1
     amd_command_step = amd_group.steps[0]
     assert isinstance(amd_command_step, buildkite_step.BuildkiteCommandStep)
+    assert amd_command_step.key == "amd-native-mirrored-test"
     assert amd_command_step.plugins is not None
 
 


### PR DESCRIPTION
## Summary

- assign deterministic `amd-<source-step-key>` keys to AMD command steps mirrored from vLLM's `.buildkite/test_areas`
- fall back to the normalized source label when a legacy source step has no key
- cover both keyed and unkeyed mirror generation

## Why

The AMD mirror generator called `_create_amd_step` without a key, so the linked `AMD: V1 Sample + Logits (mi300_1)` job in vLLM CI build 82495 had `step_key: null` even though its NVIDIA source step has `key: v1-sample-logits`.

Stable, namespaced keys let CI tooling address AMD mirrors directly without colliding with their NVIDIA source steps. This change only affects AMD mirror jobs expanded from `.buildkite/test_areas`; it does not affect the separate AMD CI pipeline or `.buildkite/test-amd.yaml`.

## Duplicate-work check

Searched the open ci-infra PRs for AMD mirror and step-key changes. No existing PR adds mirror keys. Related PRs #445 and #457 modify AMD gating and image behavior, respectively, but do not address this issue.

## Validation

- `uv run --project buildkite/pipeline_generator --with pytest pytest buildkite/tests/pipeline_generator/test_amd.py -q` — 28 passed
- `uv run --project buildkite/pipeline_generator --with pytest pytest buildkite/tests/pipeline_generator -q` — 63 passed
- rendered the current vLLM CI configuration: 54 AMD mirror command steps, all 54 with unique non-null keys
- verified the linked mirror renders as `amd-v1-sample-logits`
- `bk pipeline validate --file /private/tmp/vllm-pipeline-amd-step-keys.yaml` — passed against Buildkite's online schema

## AI assistance

AI assistance was used to implement and validate this change.