### PR TITLE
[CI] Derive missing step keys from labels and reject duplicates

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -16,7 +16,7 @@ from amd import (
     get_rocm_base_refresh_timeout,
     is_amd_gpu_device,
 )
-from step import Step
+from step import Step, generate_step_key
 from utils_lib.docker_utils import (
     get_image,
     get_ecr_cache_registry,
@@ -507,7 +507,7 @@ def convert_group_step_to_buildkite_step(
             if is_amd_gpu_device(step.device):
                 amd_commands = [
                     "export VLLM_TEST_GROUP_NAME="
-                    f"{_generate_step_key(step.key or step.label)}"
+                    f"{generate_step_key(step.key or step.label)}"
                 ]
                 amd_commands.extend(
                     _prepare_commands(
@@ -536,7 +536,7 @@ def convert_group_step_to_buildkite_step(
                 if not _step_should_run(step, list_file_diff):
                     block_step = _create_block_step(
                         block=f"Run {amd_step.label}",
-                        key=f"block-amd-{_generate_step_key(step.key or step.label)}",
+                        key=f"block-amd-{generate_step_key(step.key or step.label)}",
                         command_step=amd_step,
                         depends_on=amd_step.depends_on,
                     )
@@ -596,7 +596,7 @@ def convert_group_step_to_buildkite_step(
             if not _step_should_run(step, list_file_diff):
                 block_step = _create_block_step(
                     block=f"Run {step.label}",
-                    key=f"block-{_generate_step_key(step.label)}",
+                    key=f"block-{generate_step_key(step.label)}",
                     command_step=buildkite_step,
                     depends_on=[],
                     append_to_command_depends_on=False,
@@ -658,7 +658,7 @@ def convert_group_step_to_buildkite_step(
                 extra_env.update(amd.get("env", {}))
                 amd_step = _create_amd_step(
                     label=step.label,
-                    key=f"amd-{_generate_step_key(step.key or step.label)}",
+                    key=f"amd-{generate_step_key(step.key or step.label)}",
                     device=amd["device"],
                     num_devices=amd_num_devices,
                     commands_str=amd_commands_str,
@@ -684,7 +684,7 @@ def convert_group_step_to_buildkite_step(
                     )
                     amd_block_step = _create_block_step(
                         block=f"Run AMD: {step.label}",
-                        key=f"block-amd-{_generate_step_key(step.label)}",
+                        key=f"block-amd-{generate_step_key(step.label)}",
                         command_step=amd_step,
                         depends_on=[mirror_build_dep],
                     )
@@ -770,21 +770,6 @@ def _source_file_dependencies_match(
         ) and not any(_matches_source_dependency(exc, diff_file) for exc in excludes):
             return True
     return False
-
-
-def _generate_step_key(step_label: str) -> str:
-    return (
-        step_label.replace(" ", "-")
-        .lower()
-        .replace("(", "")
-        .replace(")", "")
-        .replace("%", "")
-        .replace(",", "-")
-        .replace("+", "-")
-        .replace(":", "-")
-        .replace(".", "-")
-        .replace("/", "-")
-    )
 
 
 def _create_amd_step(

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -202,18 +202,15 @@ def validate_unique_step_keys(
 ) -> None:
     """Reject a pipeline in which two steps share a key.
 
-    Command, block, AMD mirror and pre-commit keys share one namespace, so a
-    collision makes depends_on ambiguous and Buildkite rejects the upload
-    without naming the steps that clashed.
+    Command, block, AMD mirror and pre-commit keys share one namespace, and a
+    collision makes every depends_on edge referencing that key ambiguous.
     """
     seen: Dict[str, str] = {}
     for group_step in buildkite_group_steps:
         for step in group_step.steps:
             if not step.key:
                 continue
-            label = (
-                step.label if isinstance(step, BuildkiteCommandStep) else step.block
-            )
+            label = step.label if isinstance(step, BuildkiteCommandStep) else step.block
             origin = f"{group_step.group}/{label}"
             if step.key in seen:
                 raise ValueError(

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -197,6 +197,32 @@ class BuildkiteGroupStep(BaseModel):
     steps: List[Union[BuildkiteCommandStep, BuildkiteBlockStep]]
 
 
+def validate_unique_step_keys(
+    buildkite_group_steps: List[BuildkiteGroupStep],
+) -> None:
+    """Reject a pipeline in which two steps share a key.
+
+    Command, block, AMD mirror and pre-commit keys share one namespace, so a
+    collision makes depends_on ambiguous and Buildkite rejects the upload
+    without naming the steps that clashed.
+    """
+    seen: Dict[str, str] = {}
+    for group_step in buildkite_group_steps:
+        for step in group_step.steps:
+            if not step.key:
+                continue
+            label = (
+                step.label if isinstance(step, BuildkiteCommandStep) else step.block
+            )
+            origin = f"{group_step.group}/{label}"
+            if step.key in seen:
+                raise ValueError(
+                    f"Duplicate CI step key {step.key!r}: "
+                    f"{seen[step.key]} and {origin}."
+                )
+            seen[step.key] = origin
+
+
 def _get_step_plugin(step: Step):
     # Use K8s plugin
     use_cpu = step.device in (

--- a/buildkite/pipeline_generator/pipeline_generator.py
+++ b/buildkite/pipeline_generator/pipeline_generator.py
@@ -8,6 +8,7 @@ from buildkite_step import (
     add_precommit_dependency,
     convert_group_step_to_buildkite_step,
     create_precommit_group_step,
+    validate_unique_step_keys,
 )
 from global_config import get_global_config, init_global_config
 from step import Step, group_steps, read_steps_from_job_dir
@@ -71,6 +72,9 @@ class PipelineGenerator:
                     global_config["github_repo_name"], global_config["commit"]
                 ),
             )
+
+        # Last point where every emitted key exists, pre-commit included.
+        validate_unique_step_keys(buildkite_group_steps)
 
         buildkite_steps_dict = {"steps": []}
         for buildkite_group_step in buildkite_group_steps:

--- a/buildkite/pipeline_generator/step.py
+++ b/buildkite/pipeline_generator/step.py
@@ -59,12 +59,13 @@ def generate_step_key(step_label: str) -> str:
     )
 
 
-def derive_missing_step_keys(steps: List[Step]) -> None:
+def _derive_missing_step_keys(steps: List[Step]) -> None:
     """Key every step the YAML left keyless, deriving one from its label.
 
     Must stay exactly generate_step_key(label). The `step.key or step.label`
-    call sites in buildkite_step rely on that being idempotent, so a prefix or
-    a dedup suffix here would move the AMD mirror and block step keys.
+    call sites in buildkite_step slug it a second time, which is a no-op only
+    for keys STEP_KEY_PATTERN accepts below, so a prefix or a dedup suffix here
+    would move the AMD mirror and block step keys.
     """
     for step in steps:
         if step.key:
@@ -85,7 +86,7 @@ def parse_steps_from_yaml(yaml_data: dict):
     if group:
         for step in steps:
             step.group = group
-    derive_missing_step_keys(steps)
+    _derive_missing_step_keys(steps)
     return steps
 
 

--- a/buildkite/pipeline_generator/step.py
+++ b/buildkite/pipeline_generator/step.py
@@ -3,7 +3,7 @@ from typing import Optional, List, Dict, Any
 from pydantic import model_validator
 from typing_extensions import Self
 from collections import defaultdict
-from global_config import get_global_config
+from global_config import get_global_config, STEP_KEY_PATTERN
 import os
 import yaml
 
@@ -43,6 +43,41 @@ class Step(BaseModel):
         return cls(**yaml_data)
 
 
+def generate_step_key(step_label: str) -> str:
+    return (
+        step_label.strip()
+        .replace(" ", "-")
+        .lower()
+        .replace("(", "")
+        .replace(")", "")
+        .replace("%", "")
+        .replace(",", "-")
+        .replace("+", "-")
+        .replace(":", "-")
+        .replace(".", "-")
+        .replace("/", "-")
+    )
+
+
+def derive_missing_step_keys(steps: List[Step]) -> None:
+    """Key every step the YAML left keyless, deriving one from its label.
+
+    Must stay exactly generate_step_key(label). The `step.key or step.label`
+    call sites in buildkite_step rely on that being idempotent, so a prefix or
+    a dedup suffix here would move the AMD mirror and block step keys.
+    """
+    for step in steps:
+        if step.key:
+            continue
+        key = generate_step_key(step.label)
+        if not STEP_KEY_PATTERN.fullmatch(key):
+            raise ValueError(
+                f"Step label {step.label!r} derives an invalid step key {key!r}. "
+                f"Add an explicit 'key:' to this step."
+            )
+        step.key = key
+
+
 def parse_steps_from_yaml(yaml_data: dict):
     group = yaml_data.get("group", None)
     yaml_steps = yaml_data.get("steps", [])
@@ -50,6 +85,7 @@ def parse_steps_from_yaml(yaml_data: dict):
     if group:
         for step in steps:
             step.group = group
+    derive_missing_step_keys(steps)
     return steps
 
 

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -27,6 +27,18 @@ def _render_single_step(step):
     )[0]
 
 
+def _group(name, *steps):
+    return buildkite_step.BuildkiteGroupStep(group=name, steps=list(steps))
+
+
+def _command(label, key):
+    return buildkite_step.BuildkiteCommandStep(label=label, key=key)
+
+
+def _block(block, key):
+    return buildkite_step.BuildkiteBlockStep(block=block, key=key)
+
+
 def test_read_steps_from_job_dir():
     steps = read_steps_from_job_dir(str(TEST_JOB_DIR))
     steps_by_label = {step.label: step for step in steps}
@@ -86,6 +98,51 @@ def test_steps_read_from_a_job_dir_all_have_keys():
     assert {step.label: step.key for step in steps} == {
         f"Test {letter}": f"test-{letter.lower()}" for letter in "ABCDEFGH"
     }
+
+
+def test_duplicate_step_keys_are_rejected_naming_both_steps():
+    group_steps = [
+        _group("Models", _command("Language Models", "models")),
+        _group("Kernels", _command("Kernel Tests", "models")),
+    ]
+
+    with pytest.raises(ValueError, match="Models/Language Models and Kernels/Kernel"):
+        buildkite_step.validate_unique_step_keys(group_steps)
+
+
+def test_a_command_key_colliding_with_a_block_key_is_rejected():
+    # A step labelled "Block Kernel Tests" derives the key the generator already
+    # mints for the block step gating "Kernel Tests".
+    group_steps = [
+        _group(
+            "Kernels",
+            _block("Run Kernel Tests", "block-kernel-tests"),
+            _command("Block Kernel Tests", "block-kernel-tests"),
+        )
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match="Kernels/Run Kernel Tests and Kernels/Block Kernel Tests",
+    ):
+        buildkite_step.validate_unique_step_keys(group_steps)
+
+
+def test_keyless_steps_do_not_count_as_a_collision():
+    group_steps = [
+        _group("Kernels", _command("A", None), _command("B", None)),
+    ]
+
+    buildkite_step.validate_unique_step_keys(group_steps)
+
+
+def test_distinct_step_keys_pass_validation():
+    group_steps = [
+        _group("Models", _command("Language Models", "models")),
+        _group("Kernels", _block("Run Kernels", "block-kernels"), _command("K", "k")),
+    ]
+
+    buildkite_step.validate_unique_step_keys(group_steps)
 
 
 def test_group_steps_sorts_steps_within_each_group():

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -129,6 +129,8 @@ def test_a_command_key_colliding_with_a_block_key_is_rejected():
 
 
 def test_keyless_steps_do_not_count_as_a_collision():
+    # Defensive: the emitted models still allow a null key even though every
+    # step now carries one.
     group_steps = [
         _group("Kernels", _command("A", None), _command("B", None)),
     ]

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -6,7 +6,13 @@ import pytest
 
 import buildkite_step
 from pipeline_generator import select_steps_and_dependencies
-from step import Step, group_steps, read_steps_from_job_dir
+from step import (
+    Step,
+    generate_step_key,
+    group_steps,
+    parse_steps_from_yaml,
+    read_steps_from_job_dir,
+)
 
 pytestmark = pytest.mark.usefixtures("fake_global_config")
 
@@ -34,6 +40,52 @@ def test_read_steps_from_job_dir():
     assert steps_by_label["Test D"].num_nodes == 2
     assert steps_by_label["Test D"].num_devices == 4
     assert steps_by_label["Test E"].group == "a"
+
+
+def test_missing_step_keys_are_derived_from_the_label():
+    steps = parse_steps_from_yaml(
+        {
+            "steps": [
+                {"label": "CPU-Distributed Tests (DP+TP)"},
+                {"label": "Already Keyed", "key": "explicit-key"},
+            ]
+        }
+    )
+
+    assert [step.key for step in steps] == [
+        "cpu-distributed-tests-dp-tp",
+        "explicit-key",
+    ]
+
+
+def test_generate_step_key_is_idempotent():
+    """Once a key is derived, `step.key or step.label` slugs an already-slugged
+    string. Those sites feed the AMD mirror key, the block step key, and
+    VLLM_TEST_GROUP_NAME, so the second pass has to be a no-op.
+    """
+    label = "A B(C)%D,E+F:G.H/I"
+
+    assert generate_step_key(generate_step_key(label)) == generate_step_key(label)
+
+
+def test_a_label_deriving_an_invalid_key_is_rejected():
+    with pytest.raises(ValueError, match="Bad & Label"):
+        parse_steps_from_yaml({"steps": [{"label": "Bad & Label"}]})
+
+
+def test_a_folded_yaml_label_does_not_derive_a_broken_key():
+    # `label: >` appends a newline, which survives every character replacement.
+    steps = parse_steps_from_yaml({"steps": [{"label": "Kernels Attention\n"}]})
+
+    assert [step.key for step in steps] == ["kernels-attention"]
+
+
+def test_steps_read_from_a_job_dir_all_have_keys():
+    steps = read_steps_from_job_dir(str(TEST_JOB_DIR))
+
+    assert {step.label: step.key for step in steps} == {
+        f"Test {letter}": f"test-{letter.lower()}" for letter in "ABCDEFGH"
+    }
 
 
 def test_group_steps_sorts_steps_within_each_group():


### PR DESCRIPTION
### Summary

50 steps across the CUDA and Intel pipelines declare no `key:`, which leaves them unaddressable. They cannot be re-run on their own, targeted by `depends_on`, or named in `VLLM_CI_ONLY_STEP_KEYS`, and the step selector skips them outright.

This PR derives a key from the step label when the YAML omits one, and fails pipeline generation if two steps end up sharing a key.