### PR TITLE
[CI] Ensure every generated job has a key

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -154,7 +154,7 @@ def _get_timeout_in_minutes(
 class BuildkiteCommandStep(BaseModel):
     label: str
     group: Optional[str] = None
-    key: Optional[str] = None
+    key: str
     agents: Dict[str, str] = {}
     commands: List[str] = []
     depends_on: Optional[List[str]] = None
@@ -191,7 +191,7 @@ class BuildkiteCommandStep(BaseModel):
 class BuildkiteBlockStep(BaseModel):
     block: str
     depends_on: Optional[Union[str, List[str]]] = None
-    key: Optional[str] = None
+    key: str
 
     def to_yaml(self):
         return {"block": self.block, "depends_on": self.depends_on, "key": self.key}
@@ -509,10 +509,10 @@ def convert_group_step_to_buildkite_step(
     for group, steps in group_steps.items():
         group_steps_list = []
         for step in steps:
+            step_key = step.key or _generate_step_key(step.label)
             if is_amd_gpu_device(step.device):
                 amd_commands = [
-                    "export VLLM_TEST_GROUP_NAME="
-                    f"{_generate_step_key(step.key or step.label)}"
+                    f"export VLLM_TEST_GROUP_NAME={step_key}"
                 ]
                 amd_commands.extend(
                     _prepare_commands(
@@ -523,7 +523,7 @@ def convert_group_step_to_buildkite_step(
                 )
                 amd_step = _create_amd_step(
                     label=step.label,
-                    key=step.key,
+                    key=step_key,
                     device=step.device,
                     num_devices=step.num_devices,
                     commands_str=" && ".join(amd_commands),
@@ -543,7 +543,7 @@ def convert_group_step_to_buildkite_step(
                 if not _step_should_run(step, list_file_diff):
                     block_step = _create_block_step(
                         block=f"Run {amd_step.label}",
-                        key=f"block-amd-{_generate_step_key(step.key or step.label)}",
+                        key=f"block-amd-{step_key}",
                         command_step=amd_step,
                         depends_on=amd_step.depends_on,
                     )
@@ -556,6 +556,7 @@ def convert_group_step_to_buildkite_step(
 
             buildkite_step = BuildkiteCommandStep(
                 label=step.label,
+                key=step_key,
                 commands=step_commands,
                 depends_on=step.depends_on,
                 soft_fail=step.soft_fail,
@@ -572,8 +573,6 @@ def convert_group_step_to_buildkite_step(
             buildkite_step.retry = ensure_exit_status_negative_one_retry(
                 buildkite_step.retry
             )
-            if step.key:
-                buildkite_step.key = step.key
             if step.parallelism:
                 buildkite_step.parallelism = step.parallelism
             if (
@@ -605,7 +604,7 @@ def convert_group_step_to_buildkite_step(
             if not _step_should_run(step, list_file_diff):
                 block_step = _create_block_step(
                     block=f"Run {step.label}",
-                    key=f"block-{_generate_step_key(step.label)}",
+                    key=f"block-{step_key}",
                     command_step=buildkite_step,
                     depends_on=[],
                     append_to_command_depends_on=False,
@@ -667,7 +666,7 @@ def convert_group_step_to_buildkite_step(
                 extra_env.update(amd.get("env", {}))
                 amd_step = _create_amd_step(
                     label=step.label,
-                    key=f"amd-{_generate_step_key(step.key or step.label)}",
+                    key=f"amd-{step_key}",
                     device=amd["device"],
                     num_devices=amd_num_devices,
                     commands_str=amd_commands_str,
@@ -701,7 +700,7 @@ def convert_group_step_to_buildkite_step(
                     )
                     amd_block_step = _create_block_step(
                         block=f"Run AMD: {step.label}",
-                        key=f"block-amd-{_generate_step_key(step.label)}",
+                        key=f"block-amd-{step_key}",
                         command_step=amd_step,
                         depends_on=[mirror_build_dep],
                     )
@@ -820,7 +819,7 @@ def _create_amd_step(
     parallelism: Optional[int],
     concurrency: Optional[int],
     concurrency_group: Optional[str],
-    key: Optional[str] = None,
+    key: str,
     timeout_in_minutes: Optional[int] = None,
     agent_tags: Optional[Dict[str, str]] = None,
 ) -> BuildkiteCommandStep:

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -258,6 +258,7 @@ def test_amd_mirror_uses_shared_gating_with_amd_dependency_fallback(
     )
 
     assert default_command_step.depends_on == ["image-build"]
+    assert default_command_step.key == "mirrored-test"
     assert default_command_step.soft_fail is False
     assert len(amd_group.steps) == 1
     assert amd_command_step.key == "amd-mirrored-test"

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -117,6 +117,38 @@ def test_selected_step_runs_without_source_match(fake_global_config):
     assert buildkite_step._step_should_run(step, ["changed.py"])
 
 
+def test_every_generated_job_has_a_unique_key():
+    steps = read_steps_from_job_dir(str(TEST_JOB_DIR))
+
+    buildkite_groups = buildkite_step.convert_group_step_to_buildkite_step(
+        group_steps(steps)
+    )
+    jobs = [job for group in buildkite_groups for job in group.steps]
+    keys = [job.key for job in jobs]
+
+    assert all(keys)
+    assert len(keys) == len(set(keys))
+    assert "test-a" in keys
+    assert "block-test-a" in keys
+
+
+def test_explicit_step_key_is_preserved():
+    step = Step(
+        label="Label-derived key should not win",
+        group="Keys",
+        key="configured-key",
+        commands=["true"],
+    )
+
+    command_step = next(
+        job
+        for job in _render_single_step(step).steps
+        if isinstance(job, buildkite_step.BuildkiteCommandStep)
+    )
+
+    assert command_step.key == "configured-key"
+
+
 def test_continue_on_failure_exits_nonzero_after_command_failure(monkeypatch):
     monkeypatch.setenv("CONTINUE_ON_FAILURE", "1")
     step = Step(


### PR DESCRIPTION
## Summary

- preserve explicitly configured Buildkite job keys
- derive stable label-based keys for unkeyed command and direct AMD jobs
- require keys on generated command and block step models
- keep block and AMD mirror keys namespaced from their source jobs
- add regression coverage for generated keys, uniqueness, and explicit-key preservation

## Why

The current vLLM job definitions contain 22 steps without explicit keys. Before this change, those source steps produced unkeyed jobs. This makes key assignment a generator invariant instead of requiring every consumer config to be updated atomically.

## Validation

- Current vLLM config audit: 230 source steps, 22 without explicit keys, 354 generated jobs, 0 missing keys, 0 duplicate keys
- Python 3.9: 62 pipeline-generator tests passed
- Python 3.12: 62 pipeline-generator tests passed
- Python 3.13: 62 pipeline-generator tests passed
- Buildkite preflight [ci-infra #51](https://buildkite.com/vllm/ci-infra/builds/51): passed on Amazon Linux with Python 3.9.16; both init and pipeline-generator test jobs passed, with 62 tests passing

The stock ci-infra preflight [#50](https://buildkite.com/vllm/ci-infra/builds/50) initially stopped before tests because the pipeline is still configured to upload the removed root `buildkite_steps.yaml`. Build #51 supplied that file only in the temporary preflight snapshot to exercise this branch; it is not part of this PR.