### PR TITLE
Forward Buildkite analytics token to Kubernetes jobs

### DIFF
--- a/buildkite/pipeline_generator/README.md
+++ b/buildkite/pipeline_generator/README.md
@@ -83,6 +83,7 @@ The generator relies on several environment variables, typically provided by Bui
     ignoring normal source-file selection. Unknown keys fail generation.
 
 Kubernetes-backed test jobs read `BUILDKITE_ANALYTICS_TOKEN` from the
-`buildkite-analytics-token-secret` Secret's `token` key. Provision it in each
-Buildkite job namespace with `infra-k8s/create-buildkite-analytics-secret.sh`
-before deploying a generator version that references the Secret.
+`buildkite-analytics-token-secret` Secret's `token` key when it is available.
+The Secret is optional, so missing credentials do not prevent jobs from running.
+Provision it in a Buildkite job namespace with
+`infra-k8s/create-buildkite-analytics-secret.sh` to enable test result uploads.

--- a/buildkite/pipeline_generator/README.md
+++ b/buildkite/pipeline_generator/README.md
@@ -81,3 +81,8 @@ The generator relies on several environment variables, typically provided by Bui
 *   `VLLM_CI_ONLY_STEP_KEYS`: A non-empty JSON array of stable step keys. When
     set, the generator emits those steps and their transitive dependencies,
     ignoring normal source-file selection. Unknown keys fail generation.
+
+Kubernetes-backed test jobs read `BUILDKITE_ANALYTICS_TOKEN` from the
+`buildkite-analytics-token-secret` Secret's `token` key. Provision it in each
+Buildkite job namespace with `infra-k8s/create-buildkite-analytics-secret.sh`
+before deploying a generator version that references the Secret.

--- a/buildkite/pipeline_generator/plugin/analytics.py
+++ b/buildkite/pipeline_generator/plugin/analytics.py
@@ -1,0 +1,15 @@
+BUILDKITE_ANALYTICS_TOKEN = "BUILDKITE_ANALYTICS_TOKEN"
+BUILDKITE_ANALYTICS_SECRET = "buildkite-analytics-token-secret"
+
+
+def get_buildkite_analytics_token_env():
+    """Return a Kubernetes env entry backed by the CI analytics secret."""
+    return {
+        "name": BUILDKITE_ANALYTICS_TOKEN,
+        "valueFrom": {
+            "secretKeyRef": {
+                "name": BUILDKITE_ANALYTICS_SECRET,
+                "key": "token",
+            }
+        },
+    }

--- a/buildkite/pipeline_generator/plugin/analytics.py
+++ b/buildkite/pipeline_generator/plugin/analytics.py
@@ -10,6 +10,7 @@ def get_buildkite_analytics_token_env():
             "secretKeyRef": {
                 "name": BUILDKITE_ANALYTICS_SECRET,
                 "key": "token",
+                "optional": True,
             }
         },
     }

--- a/buildkite/pipeline_generator/plugin/docker_plugin.py
+++ b/buildkite/pipeline_generator/plugin/docker_plugin.py
@@ -145,5 +145,4 @@ def get_docker_plugin(step: Step, image: str):
         plugin["mount_buildkite_agent"] = True
     if step.device in (DeviceType.CPU, DeviceType.CPU_SMALL, DeviceType.CPU_MEDIUM) and plugin.get("gpus"):
         del plugin["gpus"]
-    # TODO: Add BUILDKITE_ANALYTICS_TOKEN and pytest addopts for fail_fast
     return plugin

--- a/buildkite/pipeline_generator/plugin/k8s_plugin.py
+++ b/buildkite/pipeline_generator/plugin/k8s_plugin.py
@@ -1,6 +1,7 @@
 import copy
 from step import Step
 from constants import DeviceType
+from plugin.analytics import get_buildkite_analytics_token_env
 
 HF_HOME = "/root/.cache/huggingface"
 
@@ -32,6 +33,7 @@ nebius_h200_plugin_template = {
                                 }
                             },
                         },
+                        get_buildkite_analytics_token_env(),
                     ],
                 }
             ],
@@ -71,6 +73,7 @@ h100_plugin_template = {
                                 }
                             },
                         },
+                        get_buildkite_analytics_token_env(),
                     ],
                 }
             ],
@@ -110,6 +113,7 @@ a100_plugin_template = {
                                 }
                             },
                         },
+                        get_buildkite_analytics_token_env(),
                     ],
                 }
             ],
@@ -161,6 +165,7 @@ b200_plugin_template = {
                                 }
                             },
                         },
+                        get_buildkite_analytics_token_env(),
                     ],
                 }
             ],
@@ -211,6 +216,7 @@ h100_rh_plugin_template = {
                                 }
                             },
                         },
+                        get_buildkite_analytics_token_env(),
                     ],
                 }
             ],

--- a/buildkite/tests/pipeline_generator/test_plugins.py
+++ b/buildkite/tests/pipeline_generator/test_plugins.py
@@ -41,6 +41,7 @@ def test_standard_k8s_templates_inject_buildkite_analytics_token(template):
             "secretKeyRef": {
                 "name": BUILDKITE_ANALYTICS_SECRET,
                 "key": "token",
+                "optional": True,
             }
         },
     }

--- a/buildkite/tests/pipeline_generator/test_plugins.py
+++ b/buildkite/tests/pipeline_generator/test_plugins.py
@@ -1,0 +1,46 @@
+import pytest
+
+from plugin import docker_plugin, k8s_plugin
+from plugin.analytics import (
+    BUILDKITE_ANALYTICS_SECRET,
+    BUILDKITE_ANALYTICS_TOKEN,
+)
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        docker_plugin.docker_plugin_template,
+        docker_plugin.h200_18gb_plugin_template,
+        docker_plugin.h200_35gb_plugin_template,
+        docker_plugin.h200_plugin_template,
+        docker_plugin.b200_plugin_template,
+    ],
+)
+def test_standard_docker_templates_forward_buildkite_analytics_token(template):
+    assert BUILDKITE_ANALYTICS_TOKEN in template["environment"]
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        k8s_plugin.nebius_h200_plugin_template,
+        k8s_plugin.h100_plugin_template,
+        k8s_plugin.a100_plugin_template,
+        k8s_plugin.b200_plugin_template,
+        k8s_plugin.h100_rh_plugin_template,
+    ],
+)
+def test_standard_k8s_templates_inject_buildkite_analytics_token(template):
+    container = template["kubernetes"]["podSpec"]["containers"][0]
+    env = {entry["name"]: entry for entry in container["env"]}
+
+    assert env[BUILDKITE_ANALYTICS_TOKEN] == {
+        "name": BUILDKITE_ANALYTICS_TOKEN,
+        "valueFrom": {
+            "secretKeyRef": {
+                "name": BUILDKITE_ANALYTICS_SECRET,
+                "key": "token",
+            }
+        },
+    }

--- a/infra-k8s/create-buildkite-analytics-secret.sh
+++ b/infra-k8s/create-buildkite-analytics-secret.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <kube-context> <namespace>" >&2
+  exit 2
+fi
+
+if [[ -z "${BUILDKITE_ANALYTICS_TOKEN:-}" ]]; then
+  echo "BUILDKITE_ANALYTICS_TOKEN is not set." >&2
+  exit 1
+fi
+
+context=$1
+namespace=$2
+
+# Stream the token through stdin so it is not exposed in the process list.
+printf '%s' "$BUILDKITE_ANALYTICS_TOKEN" \
+  | kubectl --context "$context" --namespace "$namespace" create secret generic \
+      buildkite-analytics-token-secret \
+      --from-file=token=/dev/stdin \
+      --dry-run=client \
+      -o yaml \
+  | kubectl --context "$context" --namespace "$namespace" apply -f -


### PR DESCRIPTION
## Summary

- inject `BUILDKITE_ANALYTICS_TOKEN` into the standard non-AMD Kubernetes job templates
- source the token from the optional `buildkite-analytics-token-secret/token` reference
- keep jobs runnable when the Secret or key is absent
- add regression coverage for the standard Docker and Kubernetes templates
- document and provide a helper for provisioning the Kubernetes Secret

Docker-backed jobs already forward `BUILDKITE_ANALYTICS_TOKEN`; this closes the container-boundary gap for the standard Kubernetes-backed jobs.

AMD pipelines are intentionally out of scope.

## Behavior

When `buildkite-analytics-token-secret/token` exists, test collectors receive the token and can upload results. When it is absent, Kubernetes omits the environment variable and the job continues normally.

## Validation

- `70 passed` — pipeline-generator test suite
- `bash -n infra-k8s/create-buildkite-analytics-secret.sh`
- `git diff --check`