### PR TITLE
refactor(tpu-inference/k8s): single agent-stack controller on one queue

### DIFF
--- a/terraform/gcp_old/tpu-inference/k8s/buildkite.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/buildkite.tf
@@ -1,5 +1,24 @@
-# Buildkite Agent Stack Helm Release (Manager Cluster Only)
-# Note: Agent Stack controller is installed on manager only so worker clusters don't race to claim Buildkite jobs.
+# Buildkite Agent Stack (manager cluster only, so worker clusters never race
+# to claim Buildkite jobs).
+#
+# One controller, one queue. Every TPU step goes through the launcher, which
+# submits the real workload as a Kueue-managed object, so the Buildkite queue
+# no longer has to encode a TPU shape - the profile is an argument to `launch`.
+# Adding a TPU profile is then a regenerated ConfigMap rather than another Helm
+# release.
+#
+# The agent pod is CPU-only and carries no Kueue queue label, so Kueue never
+# queues or evicts it. Two properties follow:
+#
+#   - The agent acquires its Buildkite job in seconds rather than after TPU
+#     admission and node pool scale-up, so the job is never held reserved long
+#     enough for the reservation to lapse and be picked up twice.
+#   - Kueue preemption evicts the workload without killing the agent, so a
+#     preempted run is a pause in the step log rather than a failed build
+#     needing `retry: automatic`.
+#
+# Placement - node selector, TPU resources, Kueue queue label - belongs to the
+# submitted workload, not here.
 
 resource "kubernetes_namespace_v1" "buildkite_manager" {
   provider = kubernetes.manager
@@ -15,12 +34,11 @@ resource "kubernetes_namespace_v1" "buildkite_manager" {
 }
 
 resource "helm_release" "buildkite_agent_stack" {
-  for_each = local.buildkite_queues
-
   provider         = helm.manager
-  name             = "agent-${each.key}"
+  name             = "agent-stack-k8s"
   repository       = "oci://ghcr.io/buildkite/helm"
   chart            = "agent-stack-k8s"
+  version          = var.buildkite_agent_stack_chart_version
   namespace        = kubernetes_namespace_v1.buildkite_manager.metadata[0].name
   create_namespace = false
   force_update     = true
@@ -29,48 +47,18 @@ resource "helm_release" "buildkite_agent_stack" {
 
   values = [
     yamlencode({
-      fullnameOverride = "agent-${each.key}"
-      image            = "us-central1-docker.pkg.dev/cloud-ullm-inference-ci-cd/tpu-inference-ci/agent-stack-k8s:pr-933"
       agentStackSecret = "agent-stack-k8s-secret"
+
       config = {
-        debug               = true
-        queue               = each.value.queue
-        pod-pending-timeout = "180m"
-        pod-spec-patch = {
-          containers = [
-            {
-              name = "agent"
-            }
-          ]
-          nodeSelector = {
-            "cloud.google.com/gke-tpu-accelerator" = each.value.accelerator_label
-            "cloud.google.com/gke-tpu-topology"    = each.value.topology
-          }
-        }
-      }
-      rbac = {
-        rules = [
-          {
-            apiGroups = ["batch"]
-            resources = ["jobs"]
-            verbs     = ["get", "list", "watch", "create", "update", "delete"]
-          },
-          {
-            apiGroups = [""]
-            resources = ["pods"]
-            verbs     = ["get", "list", "watch", "delete"]
-          },
-          {
-            apiGroups = [""]
-            resources = ["podtemplates", "secrets"]
-            verbs     = ["get"]
-          },
-          {
-            apiGroups = [""]
-            resources = ["events"]
-            verbs     = ["list"]
-          }
-        ]
+        id    = "tpu-ci"
+        queue = var.buildkite_queue
+        debug = var.buildkite_agent_stack_debug
+
+        # Applies to the launcher pod only; the workload carries its own
+        # activeDeadlineSeconds. Sized to outlast queue wait plus the run,
+        # because the launcher waits for both.
+        job-active-deadline-seconds = var.tpu_job_max_runtime_seconds
+        pod-pending-timeout         = "180m"
       }
     })
   ]

--- a/terraform/gcp_old/tpu-inference/k8s/locals.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/locals.tf
@@ -47,15 +47,4 @@ locals {
     ]) : item.key => item
   }
 
-  buildkite_queues = merge([
-    for worker_name, worker in var.worker_clusters : {
-      for profile_name, pool in worker.tpu_pools : profile_name => {
-        queue             = profile_name
-        topology          = pool.topology
-        machine_type      = pool.machine_type
-        accelerator       = pool.accelerator
-        accelerator_label = pool.accelerator_label
-      }
-    }
-  ]...)
 }

--- a/terraform/gcp_old/tpu-inference/k8s/variables.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/variables.tf
@@ -105,6 +105,24 @@ variable "buildkite_queue" {
   default     = "kube"
 }
 
+variable "buildkite_agent_stack_chart_version" {
+  type        = string
+  description = "Helm chart version for agent-stack-k8s. 0.47.0 is the first release containing the podless-Job cancellation fix (buildkite/agent-stack-k8s#933), so the stock controller image is sufficient from here on."
+  default     = "0.47.0"
+}
+
+variable "buildkite_agent_stack_debug" {
+  type        = bool
+  description = "Verbose controller logging"
+  default     = true
+}
+
+variable "tpu_job_max_runtime_seconds" {
+  type        = number
+  description = "Wall-clock cap for a TPU workload, applied to the launcher Job and to the submitted workload so the two deadlines cannot drift apart."
+  default     = 10800
+}
+
 variable "create_service_accounts" {
   type        = bool
   description = "Whether to create dedicated GKE node service accounts via Terraform"


### PR DESCRIPTION
With every TPU step going through the launcher, the Buildkite queue no longer
carries any information: the launcher submits the real workload and the TPU
profile is an argument to `launch`. A controller per profile was therefore
buying nothing, while making "add a TPU profile" mean "add a Helm release".

Collapse back to one controller on var.buildkite_queue, and drop
local.buildkite_queues along with the per-queue pod-spec-patch nodeSelector.
Placement - node selector, TPU resources, Kueue queue label - moves to the
submitted workload, where it belongs; the controller is now shape-agnostic and
adding a profile is a regenerated ConfigMap.

The agent pod is CPU-only and carries no Kueue queue label, so Kueue never
queues or evicts it. That is what makes the launcher worth having: the agent
acquires its Buildkite job in seconds instead of after admission and node pool
scale-up, and preemption evicts the workload without killing the build.

Also drops the custom controller image and the RBAC override. Both carried
buildkite/agent-stack-k8s#933, which shipped in v0.47.0, and the chart's
default Role at that version already grants delete on batch/jobs - the
override is now byte-identical to the default. Pin the chart and use the stock
image.

job-active-deadline-seconds and the workload deadline are derived from one
variable so they cannot drift apart.

Signed-off-by: theminghuang <theminghuang@gmail.com>

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>