### PR TITLE
feat(tpu-inference/k8s): install JobSet and enable the Kueue integration

### DIFF
--- a/terraform/gcp_old/tpu-inference/k8s/jobset.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/jobset.tf
@@ -1,0 +1,42 @@
+# JobSet operator.
+#
+# Required for any workload that spans more than one pod: multi-host TPU slices
+# (one pod per host, gang admitted) and prefill/decode disaggregation (separate
+# server pods plus a benchmark pod). A batch/v1 Job cannot express either.
+#
+# Installed on the manager and on every worker. MultiKueue mirrors the JobSet
+# object onto the selected worker, so the CRD and the operator must exist on
+# both sides at compatible versions.
+
+resource "helm_release" "jobset_manager" {
+  provider         = helm.manager
+  name             = "jobset"
+  repository       = "oci://registry.k8s.io/jobset/charts"
+  chart            = "jobset"
+  version          = var.jobset_version
+  namespace        = "jobset-system"
+  create_namespace = true
+  wait             = true
+}
+
+resource "null_resource" "jobset_worker" {
+  for_each = var.worker_clusters
+
+  triggers = {
+    version  = var.jobset_version
+    endpoint = google_container_cluster.worker[each.key].endpoint
+  }
+
+  provisioner "local-exec" {
+    command = <<EOT
+      gcloud container clusters get-credentials ${google_container_cluster.worker[each.key].name} \
+        --location ${google_container_cluster.worker[each.key].location} \
+        --project ${each.value.project}
+
+      helm upgrade --install jobset oci://registry.k8s.io/jobset/charts/jobset \
+        --version ${var.jobset_version} \
+        --namespace jobset-system --create-namespace \
+        --wait
+    EOT
+  }
+}

--- a/terraform/gcp_old/tpu-inference/k8s/kueue.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue.tf
@@ -3,7 +3,7 @@ resource "helm_release" "kueue_manager" {
   name             = "kueue"
   repository       = "oci://registry.k8s.io/kueue/charts"
   chart            = "kueue"
-  version          = "0.19.0"
+  version          = var.kueue_version
   namespace        = "kueue-system"
   create_namespace = true
   wait             = false
@@ -28,14 +28,23 @@ resource "helm_release" "kueue_manager" {
       }
     })
   ]
+
+  # The jobset.x-k8s.io/jobset integration only registers if the JobSet CRDs
+  # already exist when the Kueue controller starts.
+  depends_on = [helm_release.jobset_manager]
 }
 
 resource "null_resource" "kueue_worker" {
   for_each = var.worker_clusters
 
   triggers = {
-    version  = "0.19.0"
+    version  = var.kueue_version
     endpoint = google_container_cluster.worker[each.key].endpoint
+    # local-exec only re-runs when a trigger changes, so the config content has
+    # to be one. Without this, editing worker-config.yaml - adding the JobSet
+    # integration, for instance - silently leaves every worker on the old
+    # config while terraform reports no changes.
+    config = filemd5("${path.module}/kueue/worker-config.yaml")
   }
 
   provisioner "local-exec" {
@@ -45,7 +54,7 @@ resource "null_resource" "kueue_worker" {
         --project ${each.value.project}
 
       helm upgrade --install kueue oci://registry.k8s.io/kueue/charts/kueue \
-        --version 0.19.0 \
+        --version ${var.kueue_version} \
         --namespace kueue-system --create-namespace \
         --set-file managerConfig.controllerManagerConfigYaml=${path.module}/kueue/worker-config.yaml
 
@@ -55,4 +64,7 @@ resource "null_resource" "kueue_worker" {
         --dry-run=client -o yaml | kubectl apply -f -
     EOT
   }
+
+  # Same CRD ordering requirement as the manager.
+  depends_on = [null_resource.jobset_worker]
 }

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/manager-config.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/manager-config.yaml
@@ -15,6 +15,9 @@ leaderElection:
 integrations:
   frameworks:
     - batch/job
+    # Multi-pod workloads (multi-host TPU slices, prefill/decode disagg).
+    # Must be enabled identically on manager and workers for MultiKueue.
+    - jobset.x-k8s.io/jobset
 multiKueue:
   clusterProfile:
     accessProviders:
@@ -24,5 +27,8 @@ multiKueue:
           command: /plugins/gcp-auth-plugin
           interactiveMode: Never
 waitForPodsReady:
+  # NOTE: inert without `enable: true`. Left off deliberately - turning it on
+  # adds readiness-timeout eviction and requeue accounting, which interacts
+  # with preemption testing. Enable once that behaviour is wanted.
   blockAdmission: false
   timeout: 10800s

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/worker-config.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/worker-config.yaml
@@ -13,6 +13,12 @@ leaderElection:
 integrations:
   frameworks:
     - batch/job
+    # Multi-pod workloads (multi-host TPU slices, prefill/decode disagg).
+    # Must be enabled identically on manager and workers for MultiKueue.
+    - jobset.x-k8s.io/jobset
 waitForPodsReady:
+  # NOTE: inert without `enable: true`. Left off deliberately - turning it on
+  # adds readiness-timeout eviction and requeue accounting, which interacts
+  # with preemption testing. Enable once that behaviour is wanted.
   blockAdmission: false
   timeout: 10800s

--- a/terraform/gcp_old/tpu-inference/k8s/variables.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/variables.tf
@@ -87,6 +87,12 @@ variable "kueue_version" {
   default     = "0.19.0"
 }
 
+variable "jobset_version" {
+  type        = string
+  description = "Helm chart version for the JobSet operator. Must be identical on manager and workers; MultiKueue mirrors JobSet objects across them. The chart has no 'latest' tag, so this is required."
+  default     = "0.12.0"
+}
+
 variable "buildkite_secret_project" {
   type        = string
   description = "GCP Project ID containing the Buildkite agent token secret"


### PR DESCRIPTION
A batch/v1 Job cannot span hosts, so neither multi-host TPU slices (one pod
per host, gang admitted as a unit) nor prefill/decode disaggregation
(independent server pods plus a benchmark pod) can be expressed today. JobSet
covers both, and is the object Kueue gang-admits.

Install the operator on the manager and on every worker, and add
jobset.x-k8s.io/jobset to integrations.frameworks in both Kueue configs.
MultiKueue mirrors the JobSet onto the selected worker, so the CRD, the
operator version and the enabled framework list all have to match on both
sides - hence a single jobset_version variable driving both installs.

Kueue only registers the integration if the JobSet CRDs already exist when its
controller starts, so both Kueue releases now depend on the JobSet release.

Two adjacent fixes in the same files:

  - kueue.tf pinned the chart version to a "0.19.0" literal in three places
    while var.kueue_version existed and was unused, so bumping Kueue meant
    editing the literals and the variable stayed silently wrong.
  - waitForPodsReady is inert in both configs: the block sets blockAdmission
    and timeout but never `enable: true`. Left off deliberately for now, but
    annotated so it does not read as active configuration.

Signed-off-by: theminghuang <theminghuang@gmail.com>

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
(cherry picked from commit 700917f563430c56c01c3cbb90f33afb6286ed1b)