### PR TITLE
Automatically trace vLLM nightly pytest jobs

### DIFF
--- a/.github/workflows/pipeline-generator-tests.yml
+++ b/.github/workflows/pipeline-generator-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install -r requirements.txt
-          python -m pip install pytest ./buildkite/pipeline_generator
+          python -m pip install pytest pytest-cov ./buildkite/pipeline_generator
 
       - name: Run tests
         run: python -m pytest buildkite/tests

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -1,14 +1,14 @@
-from pydantic import BaseModel
-from typing import Dict, List, Optional, Any, Union, Literal
-from copy import deepcopy
 import base64
+from copy import deepcopy
 from functools import lru_cache
 import gzip
 from io import BytesIO
+import json
 import os
 from pathlib import Path
 import re
 import tarfile
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from amd import (
     AMD_ALWAYS_RUN_STEP_KEYS,
@@ -24,16 +24,18 @@ from amd import (
     get_rocm_base_refresh_timeout,
     is_amd_gpu_device,
 )
+from constants import AgentQueue, DeviceType
+from global_config import get_global_config
+from plugin.docker_plugin import get_docker_plugin
+from plugin.k8s_plugin import get_k8s_plugin
+from pydantic import BaseModel
 from step import Step
+from test_selection.collector_bundle import download_prelude
 from utils_lib.docker_utils import (
-    get_image,
     get_ecr_cache_registry,
+    get_image,
     get_torch_nightly_image,
 )
-from global_config import get_global_config
-from plugin.k8s_plugin import get_k8s_plugin
-from plugin.docker_plugin import get_docker_plugin
-from constants import DeviceType, AgentQueue
 
 # Key for the dedicated pre-commit step. Test steps that depend on an image
 # build also depend on this so pre-commit and image build can run in parallel.
@@ -434,12 +436,179 @@ def _prepare_commands(
     if trace_commands:
         commands.append(_otel_setup_command())
 
-    continue_on_failure = os.getenv("CONTINUE_ON_FAILURE") == "1"
+    continue_on_failure = (
+        os.getenv("CONTINUE_ON_FAILURE") == "1" and not step.trace_represented_job_key
+    )
 
     if continue_on_failure:
         commands.append("CI_OVERALL_STATUS=0")
 
-    if step.commands:
+    if step.trace_represented_job_key:
+        encoded_commands = []
+        for command in step.commands or []:
+            for variable, value in variables_to_inject.items():
+                if value:
+                    command = re.sub(re.escape(variable) + r"\b", value, command)
+            # The source YAML doubles dollars to survive pipeline upload. The
+            # payload is opaque base64 at upload time, so normalize it here for
+            # the shell that will eventually execute the decoded command.
+            encoded_commands.append(command.replace("$$", "$"))
+        # Run the original command list as one shell script so setup exports,
+        # virtualenv activation, and working-directory changes keep their
+        # existing semantics. Pytest auto-loads the collector when reached.
+        payload = base64.b64encode(
+            json.dumps(
+                ["set -e\n" + "\n".join(encoded_commands)],
+                separators=(",", ":"),
+            ).encode()
+        ).decode()
+        fallback_script = base64.b64encode(
+            b"""import base64,json,subprocess,sys
+commands=json.loads(base64.b64decode(sys.argv[2]))
+for command in commands:
+    result=subprocess.run([\"bash\",\"-lc\",command],check=False)
+    if result.returncode:
+        raise SystemExit(result.returncode)
+"""
+        ).decode()
+        fallback_command = (
+            'python3 -c "import base64,sys;exec(base64.b64decode(sys.argv[1]))" '
+            f"{fallback_script} {payload}"
+        )
+        in_place = step.key == step.trace_represented_job_key
+        trace_root = f"trace-output/{step.trace_represented_job_key}"
+        output_dir = (
+            f"{trace_root}/$$BUILDKITE_PARALLEL_JOB" if step.parallelism else trace_root
+        )
+        gpu_option = "--capture-gpu" if step.trace_gpu else "--python-only"
+        fallback_marker_script = """import base64,json,os,pathlib,sys
+path=pathlib.Path(sys.argv[1])
+path.parent.mkdir(parents=True,exist_ok=True)
+document={
+    "capture_mode":sys.argv[2],
+    "collector_sha256":sys.argv[3],
+    "collector_version":"unavailable",
+    "failure_reason":sys.argv[4],
+    "healthy":False,
+    "job_key":base64.b64decode(sys.argv[5]).decode(),
+    "parallel_job":int(os.environ.get("BUILDKITE_PARALLEL_JOB","0")),
+    "parallel_job_count":int(os.environ.get("BUILDKITE_PARALLEL_JOB_COUNT","1")),
+    "repository_sha":os.environ.get("BUILDKITE_COMMIT",""),
+    "represented_job_key":base64.b64decode(sys.argv[6]).decode(),
+}
+path.write_text(json.dumps(document,sort_keys=True,separators=(",",":"))+"\\n",encoding="utf-8")
+"""
+
+        def fallback_marker(failure_reason: str) -> str:
+            marker_script_payload = base64.b64encode(
+                fallback_marker_script.encode()
+            ).decode()
+            job_key_payload = base64.b64encode((step.key or "").encode()).decode()
+            represented_key_payload = base64.b64encode(
+                (step.trace_represented_job_key or "").encode()
+            ).decode()
+            marker_command = " ".join(
+                [
+                    "python3",
+                    "-c",
+                    '"import base64,sys;payload=sys.argv.pop(1);'
+                    'exec(base64.b64decode(payload))"',
+                    marker_script_payload,
+                    f'"{output_dir}/trace-job.json"',
+                    "gpu" if step.trace_gpu else "python-only",
+                    step.trace_collector_sha256 or "",
+                    failure_reason,
+                    job_key_payload,
+                    represented_key_payload,
+                ]
+            )
+            return (
+                f"if ! {marker_command}; then "
+                'echo "Trace fallback marker creation failed" >&2; fi; '
+                "if command -v buildkite-agent >/dev/null 2>&1; then "
+                f'if ! buildkite-agent artifact upload "{trace_root}/**/*"; then '
+                'echo "Trace fallback marker upload failed; preserving the production '
+                'command status" >&2; fi; fi; '
+            )
+
+        if in_place:
+            poll_timeout = (
+                'echo "Trace collector bundle poll exhausted after 12 attempts with a '
+                '5-second interval; running the production commands uninstrumented" '
+                ">&2; "
+                + fallback_marker("collector_bundle_poll_timeout")
+                + f"{fallback_command}; exit $$?;"
+            )
+            invalid_bundle = (
+                'echo "Trace collector bundle failed checksum or extraction; running '
+                'the production commands uninstrumented" >&2; '
+                + fallback_marker("collector_bundle_invalid")
+                + f"{fallback_command}; exit $$?;"
+            )
+            missing_collector = (
+                'if [ "$$TRACE_COLLECTOR_READY" = "1" ]; then '
+                f"{invalid_bundle} else {poll_timeout} fi;"
+            )
+        else:
+            missing_collector = (
+                'echo "Trace collector bundle is unavailable" >&2; exit 2;'
+            )
+        collector_probe = (
+            'python3 -c "import ci_test_selection.run_job_trace as runner, sys; '
+            'print(sys.executable, runner.__file__)"'
+            if in_place
+            else (
+                'python3 -c "import ci_test_selection, coverage, '
+                "pytest_cov, sys; print(sys.executable, "
+                'ci_test_selection.__file__)"'
+            )
+        )
+        runner = (
+            "python3 -m ci_test_selection.run_job_trace "
+            f"--output-dir {output_dir} --job-key {step.key} "
+            f"--represented-job-key {step.trace_represented_job_key} "
+            f"{gpu_option} --commands-base64 {payload}"
+        )
+        if in_place:
+            runner += " --preserve-command-exit-code"
+            runner = (
+                f"if {runner}; then TRACE_COMMAND_STATUS=0; "
+                "else TRACE_COMMAND_STATUS=$$?; fi; "
+                "if command -v buildkite-agent >/dev/null 2>&1; then "
+                f'if ! buildkite-agent artifact upload "{trace_root}/**/*"; then '
+                'echo "Trace artifact upload failed; preserving the production '
+                'command status" >&2; fi; '
+                'else echo "Buildkite agent unavailable; skipping trace artifact '
+                'upload" >&2; fi; exit $$TRACE_COMMAND_STATUS'
+            )
+        trace_command = (
+            'TRACE_COLLECTOR_DIR="$$(mktemp -d)"; '
+            + download_prelude("$$TRACE_COLLECTOR_DIR")
+            + 'if [ "$$TRACE_COLLECTOR_READY" = "1" ] && '
+            f'echo "{step.trace_collector_sha256}  '
+            '$$TRACE_COLLECTOR_DIR/test-selection-collector.zip" | sha256sum -c - && '
+            "python3 -m zipfile -e "
+            '"$$TRACE_COLLECTOR_DIR/test-selection-collector.zip" '
+            '"$$TRACE_COLLECTOR_DIR/src"; then :; '
+            f"else {missing_collector} fi; "
+            "export PYTHONDONTWRITEBYTECODE=1 "
+            'VLLM_CI_TEST_SELECTION_COLLECTOR_SHA256="'
+            f'{step.trace_collector_sha256}" '
+            'PYTHONPATH="$$TRACE_COLLECTOR_DIR/src:/vllm-workspace'
+            '$${PYTHONPATH:+:$${PYTHONPATH}}"; '
+            + (
+                f"if {collector_probe}; then {runner}; "
+                f'else echo "Trace collector import failed; running the '
+                f'production commands uninstrumented" >&2; '
+                + fallback_marker("collector_import_failed")
+                + f"{fallback_command}; fi"
+                if in_place
+                else f"{collector_probe} && {runner}"
+            )
+        )
+        _validate_trace_wrapper_dollars(trace_command)
+        commands.append(trace_command)
+    elif step.commands:
         for i, cmd in enumerate(step.commands):
             # Sanitize command preview for use in echo (remove quotes and special chars)
             preview = cmd[:80].replace("'", "").replace('"', "").replace("$", "")
@@ -465,9 +634,7 @@ def _prepare_commands(
             if continue_on_failure:
                 # Note: We don't use a subshell here to preserve environment changes between commands
                 # (export, cd, etc).
-                commands.append(
-                    f"{{ {prepared_command}\n}} || CI_OVERALL_STATUS=1"
-                )
+                commands.append(f"{{ {prepared_command}\n}} || CI_OVERALL_STATUS=1")
             else:
                 commands.append(prepared_command)
 
@@ -493,6 +660,16 @@ def _prepare_commands(
         final_commands.insert(0, f"cd {step.working_dir}")
 
     return final_commands
+
+
+def _validate_trace_wrapper_dollars(command: str) -> None:
+    """Reject shell dollar expansion that Buildkite would interpolate first."""
+    for match in re.finditer(r"\$+", command):
+        if len(match.group()) % 2:
+            raise ValueError(
+                "trace wrapper contains an undoubled dollar expansion at "
+                f"offset {match.start()}"
+            )
 
 
 def _create_block_step(
@@ -712,6 +889,9 @@ def convert_group_step_to_buildkite_step(
                             "commands": custom_commands,
                             "working_dir": amd.get("working_dir", step.working_dir),
                             "no_plugin": amd_no_plugin,
+                            "trace_gpu": False,
+                            "trace_collector_sha256": None,
+                            "trace_represented_job_key": None,
                         }
                     )
                     amd_commands_str = " && ".join(
@@ -723,7 +903,12 @@ def convert_group_step_to_buildkite_step(
                     )
                 else:
                     amd_command_step = step.model_copy(
-                        update={"no_plugin": amd_no_plugin}
+                        update={
+                            "no_plugin": amd_no_plugin,
+                            "trace_gpu": False,
+                            "trace_collector_sha256": None,
+                            "trace_represented_job_key": None,
+                        }
                     )
                     amd_commands_str = " && ".join(
                         _prepare_commands(

--- a/buildkite/pipeline_generator/global_config.py
+++ b/buildkite/pipeline_generator/global_config.py
@@ -4,11 +4,12 @@ import re
 from typing import Dict, FrozenSet, List, Optional, TypedDict
 
 import yaml
-
-from utils_lib.git_utils import get_merge_base_commit, get_list_file_diff, get_pr_labels
-
+from utils_lib.git_utils import get_list_file_diff, get_merge_base_commit, get_pr_labels
 
 ONLY_STEP_KEYS_ENV_VAR = "VLLM_CI_ONLY_STEP_KEYS"
+TRACE_S3_BUCKET_ENV_VAR = "VLLM_CI_TRACE_S3_BUCKET"
+TRACE_S3_PREFIX_ENV_VAR = "VLLM_CI_TRACE_S3_PREFIX"
+DEFAULT_VLLM_TRACE_BUCKET = "vllm-ci-test-selection-traces-936637512419-us-east-1"
 STEP_KEY_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
@@ -30,6 +31,8 @@ class GlobalConfig(TypedDict):
     merge_base_commit: Optional[str] = None
     fail_fast: bool = False
     only_step_keys: Optional[FrozenSet[str]] = None
+    trace_s3_bucket: Optional[str] = None
+    trace_s3_prefix: str = "test-selection/vllm"
 
 
 config = None
@@ -59,6 +62,26 @@ def init_global_config(pipeline_config_path: str):
     list_file_diff = get_list_file_diff(branch, merge_base_commit)
     pr_labels = get_pr_labels(pull_request, pipeline_config["github_repo_name"])
 
+    only_step_keys = _parse_only_step_keys(os.getenv(ONLY_STEP_KEYS_ENV_VAR))
+    nightly = os.getenv("NIGHTLY", "0")
+    commit = os.getenv("BUILDKITE_COMMIT")
+    trace_s3_bucket = os.getenv(TRACE_S3_BUCKET_ENV_VAR)
+    if (
+        pipeline_config["github_repo_name"] == "vllm-project/vllm"
+        and nightly == "1"
+        and branch == "main"
+        and pull_request in (None, "false")
+    ):
+        trace_s3_bucket = trace_s3_bucket or DEFAULT_VLLM_TRACE_BUCKET
+    if trace_s3_bucket and not re.fullmatch(
+        r"[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]", trace_s3_bucket
+    ):
+        raise ValueError(f"{TRACE_S3_BUCKET_ENV_VAR} is invalid.")
+    trace_s3_prefix = os.getenv(TRACE_S3_PREFIX_ENV_VAR, "test-selection/vllm")
+    if not re.fullmatch(r"[a-zA-Z0-9._/-]+", trace_s3_prefix) or any(
+        part in ("", ".", "..") for part in trace_s3_prefix.split("/")
+    ):
+        raise ValueError(f"{TRACE_S3_PREFIX_ENV_VAR} is invalid.")
     config = GlobalConfig(
         name=pipeline_config["name"],
         github_repo_name=pipeline_config["github_repo_name"],
@@ -66,12 +89,12 @@ def init_global_config(pipeline_config_path: str):
         registries=pipeline_config["registries"],
         repositories=pipeline_config["repositories"],
         branch=branch,
-        commit=os.getenv("BUILDKITE_COMMIT"),
+        commit=commit,
         pull_request=pull_request,
         docs_only_disable=os.getenv("DOCS_ONLY_DISABLE", "0"),
         run_all_patterns=pipeline_config.get("run_all_patterns", None),
         run_all_exclude_patterns=pipeline_config.get("run_all_exclude_patterns", None),
-        nightly=os.getenv("NIGHTLY", "0"),
+        nightly=nightly,
         torch_nightly=os.getenv("TORCH_NIGHTLY", "0"),
         run_all=_should_run_all(
             pr_labels,
@@ -82,7 +105,9 @@ def init_global_config(pipeline_config_path: str):
         merge_base_commit=merge_base_commit,
         list_file_diff=list_file_diff,
         fail_fast=_should_fail_fast(pr_labels),
-        only_step_keys=_parse_only_step_keys(os.getenv(ONLY_STEP_KEYS_ENV_VAR)),
+        only_step_keys=only_step_keys,
+        trace_s3_bucket=trace_s3_bucket,
+        trace_s3_prefix=trace_s3_prefix,
     )
     if "ready-run-all-tests" in pr_labels:
         config["run_all"] = True
@@ -100,23 +125,29 @@ def get_global_config():
 
 
 def _parse_only_step_keys(value: Optional[str]) -> Optional[FrozenSet[str]]:
+    return _parse_step_keys(value, ONLY_STEP_KEYS_ENV_VAR)
+
+
+def _parse_step_keys(
+    value: Optional[str], environment_variable: str
+) -> Optional[FrozenSet[str]]:
     if value is None:
         return None
     try:
         parsed = json.loads(value)
     except json.JSONDecodeError as error:
         raise ValueError(
-            f"{ONLY_STEP_KEYS_ENV_VAR} must be a JSON array of step keys."
+            f"{environment_variable} must be a JSON array of step keys."
         ) from error
     if not isinstance(parsed, list) or not parsed:
-        raise ValueError(f"{ONLY_STEP_KEYS_ENV_VAR} must be a non-empty JSON array.")
+        raise ValueError(f"{environment_variable} must be a non-empty JSON array.")
     if any(
         not isinstance(key, str) or not STEP_KEY_PATTERN.fullmatch(key)
         for key in parsed
     ):
-        raise ValueError(f"{ONLY_STEP_KEYS_ENV_VAR} contains an invalid step key.")
+        raise ValueError(f"{environment_variable} contains an invalid step key.")
     if len(set(parsed)) != len(parsed):
-        raise ValueError(f"{ONLY_STEP_KEYS_ENV_VAR} contains duplicate step keys.")
+        raise ValueError(f"{environment_variable} contains duplicate step keys.")
     return frozenset(parsed)
 
 

--- a/buildkite/pipeline_generator/pipeline_generator.py
+++ b/buildkite/pipeline_generator/pipeline_generator.py
@@ -154,6 +154,7 @@ _K8S_TRACE_DEVICES = {
 TRACE_COLLECTOR_STEP_KEY = "test-selection-collector"
 REPUBLISH_INVENTORY_ENV = "VLLM_CI_REPUBLISH_INVENTORY_B64"
 REPUBLISH_SOURCE_BUILD_ENV = "VLLM_CI_REPUBLISH_SOURCE_BUILD"
+REPUBLISH_SOURCE_BUILD_ID_ENV = "VLLM_CI_REPUBLISH_SOURCE_BUILD_ID"
 REPUBLISH_TRIALS_ENV = "VLLM_CI_REPUBLISH_TRIALS_JSON"
 
 # Full-fleet canary #84324 measured prohibitive Python-coverage overhead for
@@ -447,6 +448,7 @@ def _snapshot_republish_requested() -> bool:
         for name in (
             REPUBLISH_INVENTORY_ENV,
             REPUBLISH_SOURCE_BUILD_ENV,
+            REPUBLISH_SOURCE_BUILD_ID_ENV,
             REPUBLISH_TRIALS_ENV,
         )
     )
@@ -459,13 +461,19 @@ def _snapshot_republish_inputs(global_config: dict) -> dict:
         )
     encoded_inventory = os.getenv(REPUBLISH_INVENTORY_ENV)
     source_build = os.getenv(REPUBLISH_SOURCE_BUILD_ENV)
-    if not encoded_inventory or not source_build:
+    source_build_id = os.getenv(REPUBLISH_SOURCE_BUILD_ID_ENV)
+    if not encoded_inventory or not source_build or not source_build_id:
         raise ValueError(
-            f"{REPUBLISH_INVENTORY_ENV} and {REPUBLISH_SOURCE_BUILD_ENV} "
-            "must both be set"
+            f"{REPUBLISH_INVENTORY_ENV}, {REPUBLISH_SOURCE_BUILD_ENV}, and "
+            f"{REPUBLISH_SOURCE_BUILD_ID_ENV} must all be set"
         )
     if not re.fullmatch(r"[1-9][0-9]*", source_build):
         raise ValueError(f"{REPUBLISH_SOURCE_BUILD_ENV} must be a build number")
+    if not re.fullmatch(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        source_build_id,
+    ):
+        raise ValueError(f"{REPUBLISH_SOURCE_BUILD_ID_ENV} must be a build UUID")
     try:
         inventory_bytes = base64.b64decode(encoded_inventory, validate=True)
         inventory = json.loads(inventory_bytes)
@@ -562,6 +570,7 @@ def _snapshot_republish_inputs(global_config: dict) -> dict:
         "inventory_sha256": hashlib.sha256(inventory_bytes).hexdigest(),
         "repository_sha": repository_sha,
         "source_build": source_build,
+        "source_build_id": source_build_id,
         "trials": normalized_trials,
     }
 
@@ -574,6 +583,7 @@ def create_snapshot_republish_group_step(global_config: dict) -> BuildkiteGroupS
     bucket = shlex.quote(str(global_config["trace_s3_bucket"]))
     prefix = shlex.quote(str(global_config["trace_s3_prefix"]))
     source_build = inputs["source_build"]
+    source_build_id = inputs["source_build_id"]
     repository_sha = inputs["repository_sha"]
     command = [
         "set -euo pipefail",
@@ -607,7 +617,7 @@ def create_snapshot_republish_group_step(global_config: dict) -> BuildkiteGroupS
         ),
         (
             'buildkite-agent artifact download "trace-output/**/*" '
-            f'"$$D/evidence" --build {shlex.quote(source_build)}'
+            f'"$$D/evidence" --build {shlex.quote(source_build_id)}'
         ),
         (
             '"$$D/venv/bin/vllm-test-selection" publish-snapshot '
@@ -630,6 +640,7 @@ def create_snapshot_republish_group_step(global_config: dict) -> BuildkiteGroupS
         'cp "$$D/readback.sqlite.sha256" "$$D/results/"',
         f"printf '%s\\n' {revision} > \"$$D/results/publisher-revision.txt\"",
         f"printf '%s\\n' {source_build} > \"$$D/results/source-build.txt\"",
+        (f"printf '%s\\n' {source_build_id} > \"$$D/results/source-build-id.txt\""),
         "TRIAL_STATUS=0",
     ]
     for trial in inputs["trials"]:

--- a/buildkite/pipeline_generator/pipeline_generator.py
+++ b/buildkite/pipeline_generator/pipeline_generator.py
@@ -1,16 +1,30 @@
+import base64
+import importlib.metadata
+import json
 import os
+import re
+import shlex
 import subprocess
-from typing import FrozenSet, List, Optional, Tuple
+from math import ceil
+from pathlib import Path
+from typing import FrozenSet, List, Optional, Set, Tuple
 
 import yaml
-
+from amd import is_amd_gpu_device
 from buildkite_step import (
+    BuildkiteCommandStep,
+    BuildkiteGroupStep,
     add_precommit_dependency,
     convert_group_step_to_buildkite_step,
     create_precommit_group_step,
 )
+from constants import AgentQueue, DeviceType
 from global_config import get_global_config, init_global_config
 from step import Step, group_steps, read_steps_from_job_dir
+from test_selection.collector_bundle import (
+    bundle_bytes,
+    bundle_sha256,
+)
 
 
 class PipelineGenerator:
@@ -49,8 +63,22 @@ class PipelineGenerator:
                 return
 
         steps = []
+        test_area_keys = set()
         for job_dir in global_config["job_dirs"]:
-            steps.extend(read_steps_from_job_dir(job_dir))
+            job_steps = read_steps_from_job_dir(job_dir)
+            steps.extend(job_steps)
+            if Path(job_dir).as_posix().rstrip("/").endswith(".buildkite/test_areas"):
+                test_area_keys.update(step.key for step in job_steps if step.key)
+        publish_trace_snapshot = should_trace_nightly(global_config)
+        collector = bundle_bytes() if publish_trace_snapshot else b""
+        collector_sha256 = bundle_sha256(collector) if collector else None
+        steps, trace_inventory = configure_test_tracing(
+            steps,
+            test_area_keys if publish_trace_snapshot else set(),
+            global_config["commit"],
+            _ci_infra_revision() if publish_trace_snapshot else None,
+            collector_sha256,
+        )
         steps, selected_step_keys = select_steps_and_dependencies(
             steps, global_config["only_step_keys"]
         )
@@ -59,6 +87,15 @@ class PipelineGenerator:
 
         buildkite_group_steps = convert_group_step_to_buildkite_step(grouped_steps)
         buildkite_group_steps = sorted(buildkite_group_steps, key=lambda x: x.group)
+        if publish_trace_snapshot:
+            finalize_trace_inventory(trace_inventory, buildkite_group_steps)
+            buildkite_group_steps.append(
+                create_snapshot_group_step(trace_inventory, global_config)
+            )
+        if trace_inventory["jobs"]:
+            buildkite_group_steps.insert(
+                0, create_collector_group_step(collector, collector_sha256 or "")
+            )
 
         # Run pre-commit as a dedicated step in parallel with the image build.
         # Steps that depend on the image build also wait for pre-commit to pass.
@@ -82,6 +119,381 @@ class PipelineGenerator:
                 buildkite_steps_dict, f, sort_keys=False, default_flow_style=False
             )
         return
+
+
+_PYTEST_COMMAND = re.compile(r"(?:^|[\s;&|])(?:python3?\s+-m\s+)?pytest(?:\s|$)")
+_NVIDIA_TRACE_DEVICES = {
+    DeviceType.A100,
+    DeviceType.B200,
+    DeviceType.B200_K8S,
+    DeviceType.DGX_SPARK,
+    DeviceType.GH200,
+    DeviceType.H100,
+    DeviceType.H200,
+    DeviceType.H200_18GB,
+    DeviceType.H200_35GB,
+}
+_K8S_TRACE_DEVICES = {
+    DeviceType.A100,
+    DeviceType.B200_K8S,
+    DeviceType.H100,
+}
+TRACE_COLLECTOR_STEP_KEY = "test-selection-collector"
+
+# Full-fleet canary #84324 measured prohibitive Python-coverage overhead for
+# these exact jobs. Keep the evidence-based keys visible in the inventory but
+# uninstrumented until a lower-overhead collector is proven.
+_FLEET_CPU_OVERHEAD_ALWAYS_RUN = frozenset(
+    {
+        "benchmarks-cli-test",
+        "engine",
+        "engine-1-gpu",
+        "multi-modal-processor-cpu",
+        "v1-others-cpu",
+    }
+)
+
+# Full-fleet canaries #84375 and #84580 proved these exact jobs incompatible
+# with per-test Python dynamic contexts. The latter found the exact forked-CUDA
+# root in every listed newly enrolled job's trace-wrapped log; subprocess/server
+# startup, IPC, or long-running GPU work also failed or timed out in #84375
+# while repeated plain-main controls passed. The automatic nightly path must
+# preserve these carve-outs; removing the old TRACE_ALL switch does not
+# invalidate the underlying fleet evidence.
+_FLEET_COLLECTOR_COMPATIBILITY_ALWAYS_RUN = frozenset(
+    {
+        "async-engine-inputs-utils-worker",
+        "basic-models-tests-extra-initialization",
+        "basic-models-tests-initialization",
+        "basic-models-tests-other",
+        "bitsandbytes-plugin",
+        "distributed-comm-ops",
+        "distributed-tests-2xh100-2xmi300",
+        "e2e-core-1-gpu",
+        "e2e-scheduling-1-gpu",
+        "entrypoints-unit-tests",
+        "extract-hidden-states-integration",
+        "gguf-plugin",
+        "kernels-fp8-moe-test-2xh100",
+        "kv-offload-large",
+        "language-models-test-extended-pooling",
+        "language-models-test-mteb",
+        "language-models-test-ppl",
+        "lm-eval-humming-act-b200",
+        "lm-eval-humming-f16-b200",
+        "lm-eval-qwen3-5-models-2xb200",
+        "lora",
+        "model-runner-v2-core-tests",
+        "model-runner-v2-spec-decode",
+        "moe-refactor-integration-test-b200-dp-temporary",
+        "multi-modal-accuracy-eval-small-models",
+        "multi-modal-models-extended-generation-1",
+        "multi-modal-models-extended-generation-2",
+        "multi-modal-models-extended-generation-3",
+        "multi-modal-models-extended-pooling",
+        "multi-modal-models-extended-ppl",
+        "multi-modal-models-standard-1-qwen2",
+        "multi-modal-models-standard-2-qwen3-gemma",
+        "multi-modal-models-standard-3-llava-qwen2-vl",
+        "multi-modal-models-standard-4-other-whisper",
+        "pipeline-context-parallelism-4-gpus",
+        "pytorch-compilation-unit-tests-h100",
+        "quantized-models-test",
+        "regression",
+        "spec-decode-dflash-nightly",
+        "spec-decode-draft-model",
+        "spec-decode-dspark-nightly",
+        "spec-decode-eagle-1-deepseek-qwen",
+        "spec-decode-eagle-2-llama3-qwen-vl-other",
+        "spec-decode-mtp-other-acceptance-nightly",
+        "spec-decode-ngram-suffix",
+        "spec-decode-speculators-mtp",
+    }
+)
+
+
+def should_trace_nightly(global_config: dict) -> bool:
+    """Trace vLLM test-area pytest jobs on trusted main nightlies."""
+
+    return bool(
+        global_config["github_repo_name"] == "vllm-project/vllm"
+        and global_config["nightly"] == "1"
+        and global_config["branch"] == "main"
+        and global_config["pull_request"] in (None, "false")
+        and global_config["trace_s3_bucket"]
+    )
+
+
+def _ci_infra_revision() -> str:
+    """Resolve the exact generator commit so the fan-in cannot branch-drift."""
+
+    override = os.getenv("VLLM_CI_REVISION")
+    if override:
+        if not re.fullmatch(r"[0-9a-f]{40}", override):
+            raise ValueError("VLLM_CI_REVISION must be a 40-character Git SHA.")
+        return override
+    try:
+        direct_url_text = importlib.metadata.distribution(
+            "pipeline-generator"
+        ).read_text("direct_url.json")
+        direct_url = json.loads(direct_url_text or "{}")
+        commit_id = direct_url.get("vcs_info", {}).get("commit_id")
+        if re.fullmatch(r"[0-9a-f]{40}", str(commit_id)):
+            return str(commit_id)
+    except (importlib.metadata.PackageNotFoundError, json.JSONDecodeError):
+        pass
+    repository_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    revision = result.stdout.strip()
+    if result.returncode or not re.fullmatch(r"[0-9a-f]{40}", revision):
+        raise ValueError("cannot resolve the exact ci-infra generator revision")
+    return revision
+
+
+def _is_traceable_pytest_step(step: Step) -> bool:
+    return bool(step.commands) and any(
+        _PYTEST_COMMAND.search(command) for command in step.commands or []
+    )
+
+
+def _trace_rejection(step: Step) -> Optional[str]:
+    if not step.key:
+        return "missing_step_key"
+    if not _is_traceable_pytest_step(step):
+        return "not_plain_pytest_commands"
+    return None
+
+
+def configure_test_tracing(
+    steps: List[Step],
+    test_area_step_keys: Set[str],
+    repository_sha: Optional[str] = None,
+    ci_infra_revision: Optional[str] = None,
+    collector_sha256: Optional[str] = None,
+) -> Tuple[List[Step], dict]:
+    """Instrument selected existing jobs with the exact ci-infra collector."""
+
+    steps_by_key = {step.key: step for step in steps if step.key}
+    if test_area_step_keys and not re.fullmatch(
+        r"[0-9a-f]{40}", ci_infra_revision or ""
+    ):
+        raise ValueError("nightly trace inventory requires an exact ci-infra revision")
+    if test_area_step_keys and not re.fullmatch(
+        r"[0-9a-f]{64}", collector_sha256 or ""
+    ):
+        raise ValueError("trace collection requires an exact collector checksum")
+    rejected = {}
+    traced = []
+    for step_key in sorted(test_area_step_keys):
+        step = steps_by_key[step_key]
+        if step_key in _FLEET_COLLECTOR_COMPATIBILITY_ALWAYS_RUN:
+            rejected[step_key] = "collector_compatibility_policy"
+            continue
+        if step_key in _FLEET_CPU_OVERHEAD_ALWAYS_RUN:
+            rejected[step_key] = "cpu_overhead_policy"
+            continue
+        rejection = _trace_rejection(step)
+        if rejection:
+            rejected[step_key] = rejection
+            continue
+        timeout = step.timeout_in_minutes
+        if timeout is not None:
+            timeout = max(timeout + 15, ceil(timeout * 1.5))
+        mode = (
+            "kernel-set"
+            if step.device in _NVIDIA_TRACE_DEVICES
+            and not is_amd_gpu_device(step.device)
+            else "python-only"
+        )
+        step.timeout_in_minutes = timeout
+        step.mount_buildkite_agent = bool(
+            step.mount_buildkite_agent or step.device not in _K8S_TRACE_DEVICES
+        )
+        step.trace_collector_sha256 = collector_sha256
+        step.trace_represented_job_key = step_key
+        step.trace_gpu = mode == "kernel-set"
+        traced.append(
+            {
+                "expected_shards": step.parallelism or 1,
+                "key": step_key,
+                "mode": mode,
+            }
+        )
+
+    inventory = {
+        "always_run": [
+            {"key": key, "reason": reason} for key, reason in sorted(rejected.items())
+        ],
+        "ci_infra_revision": ci_infra_revision,
+        "collector_sha256": collector_sha256,
+        "jobs": traced,
+        "repository_sha": repository_sha,
+        "schema_version": 1,
+    }
+    return steps, inventory
+
+
+def finalize_trace_inventory(
+    inventory: dict, buildkite_group_steps: List[BuildkiteGroupStep]
+) -> None:
+    """Account for exact rendered command keys, including generated mirrors."""
+
+    rendered_steps = [
+        step
+        for group in buildkite_group_steps
+        for step in group.steps
+        if isinstance(step, BuildkiteCommandStep)
+    ]
+    rendered = {step.key: step for step in rendered_steps}
+    if len(rendered) != len(rendered_steps):
+        raise ValueError("rendered pipeline contains duplicate command step keys")
+    traced = {
+        key
+        for key, step in rendered.items()
+        if any(
+            "ci_test_selection.run_job_trace" in command for command in step.commands
+        )
+    }
+    expected = {job["key"]: job for job in inventory["jobs"]}
+    if traced != set(expected):
+        raise ValueError(
+            "rendered trace inventory mismatch: expected=%s observed=%s"
+            % (sorted(expected), sorted(traced))
+        )
+    for key, job in expected.items():
+        rendered_shards = rendered[key].parallelism or 1
+        if rendered_shards != job["expected_shards"]:
+            raise ValueError(f"rendered trace shard count changed for {key}")
+    always_run = {row["key"]: row["reason"] for row in inventory["always_run"]}
+    overlap = set(always_run) & set(expected)
+    if overlap:
+        raise ValueError(
+            "trace inventory accounts job twice: " + ", ".join(sorted(overlap))
+        )
+    for key in sorted(set(rendered) - set(expected) - set(always_run)):
+        always_run[key] = "rendered_uninstrumented_step"
+    accounted = set(expected) | set(always_run)
+    if accounted != set(rendered):
+        raise ValueError("trace inventory does not match exact rendered command keys")
+    inventory["always_run"] = [
+        {"key": key, "reason": reason} for key, reason in sorted(always_run.items())
+    ]
+
+
+def create_collector_group_step(
+    collector: bytes, collector_sha256: str
+) -> BuildkiteGroupStep:
+    """Publish the exact ci-infra-owned collector once for all traced jobs."""
+
+    encoded = base64.b64encode(collector).decode()
+    command = "\n".join(
+        [
+            "set -euo pipefail",
+            'COLLECTOR_DIR="$$(mktemp -d)"',
+            "trap 'rm -rf \"$$COLLECTOR_DIR\"' EXIT",
+            (
+                f"printf '%s' {shlex.quote(encoded)} | base64 -d "
+                '> "$$COLLECTOR_DIR/test-selection-collector.zip"'
+            ),
+            (
+                f'echo "{collector_sha256}  '
+                '$$COLLECTOR_DIR/test-selection-collector.zip" | sha256sum -c -'
+            ),
+            'cd "$$COLLECTOR_DIR"',
+            'buildkite-agent artifact upload "test-selection-collector.zip"',
+        ]
+    )
+    return BuildkiteGroupStep(
+        group="Test selection collector",
+        steps=[
+            BuildkiteCommandStep(
+                agents={"queue": AgentQueue.SMALL_CPU_PREMERGE.value},
+                commands=[command],
+                key=TRACE_COLLECTOR_STEP_KEY,
+                label=":package: Publish test-selection collector",
+                retry={"automatic": [{"exit_status": -1, "limit": 1}]},
+                soft_fail=True,
+                timeout_in_minutes=10,
+            )
+        ],
+    )
+
+
+def create_snapshot_group_step(
+    inventory: dict, global_config: dict
+) -> BuildkiteGroupStep:
+    """Create the bounded, self-waiting publisher for a trace snapshot."""
+
+    encoded_inventory = base64.b64encode(
+        json.dumps(inventory, sort_keys=True, separators=(",", ":")).encode()
+    ).decode()
+    bucket = shlex.quote(global_config["trace_s3_bucket"])
+    prefix = shlex.quote(global_config["trace_s3_prefix"])
+    revision = inventory["ci_infra_revision"]
+    group = "Test selection snapshot"
+    label = ":database: Publish test-selection snapshot"
+    command = "\n".join(
+        [
+            "set -euo pipefail",
+            'SNAPSHOT_DIR="$$(mktemp -d)"',
+            "trap 'rm -rf \"$$SNAPSHOT_DIR\"' EXIT",
+            'mkdir -p "$$SNAPSHOT_DIR/evidence"',
+            (
+                f"printf '%s' {shlex.quote(encoded_inventory)} | base64 -d "
+                '> "$$SNAPSHOT_DIR/inventory.json"'
+            ),
+            'python3 -m venv "$$SNAPSHOT_DIR/venv"',
+            (
+                '"$$SNAPSHOT_DIR/venv/bin/pip" install --quiet '
+                '"git+https://github.com/vllm-project/ci-infra.git@'
+                f'{revision}#subdirectory=buildkite/pipeline_generator"'
+            ),
+            f"TRACE_S3_BUCKET={bucket}",
+            f"TRACE_S3_PREFIX={prefix}",
+            'echo "+++ :hourglass_flowing_sand: Wait for traced steps"',
+            (
+                '"$$SNAPSHOT_DIR/venv/bin/vllm-test-selection" wait-for-steps '
+                '--inventory "$$SNAPSHOT_DIR/inventory.json" '
+                "--timeout-seconds 28800 --poll-seconds 120"
+            ),
+            (
+                'buildkite-agent artifact download "trace-output/**/*" '
+                '"$$SNAPSHOT_DIR/evidence"'
+            ),
+            (
+                '"$$SNAPSHOT_DIR/venv/bin/vllm-test-selection" publish-snapshot '
+                '--input "$$SNAPSHOT_DIR/evidence" '
+                '--inventory "$$SNAPSHOT_DIR/inventory.json" '
+                '--bucket "$$TRACE_S3_BUCKET" --prefix "$$TRACE_S3_PREFIX"'
+            ),
+        ]
+    )
+    return BuildkiteGroupStep(
+        group=group,
+        steps=[
+            BuildkiteCommandStep(
+                agents={"queue": AgentQueue.CPU_POSTMERGE_US_EAST_1.value},
+                commands=[command],
+                # Buildkite hard-invalidates dependents when any dependency is
+                # canceled, even with both dependency-failure tolerance knobs.
+                # Poll aggregate step state instead and let the inventory make
+                # bounded nonterminal/missing evidence explicitly always-run.
+                depends_on=None,
+                key="test-selection-snapshot",
+                label=label,
+                priority=-100,
+                retry={"automatic": [{"exit_status": -1, "limit": 1}]},
+                soft_fail=True,
+                timeout_in_minutes=510,
+            )
+        ],
+    )
 
 
 def select_steps_and_dependencies(
@@ -108,6 +520,8 @@ def select_steps_and_dependencies(
     while pending:
         step_key = pending.pop()
         for dependency in steps_by_key[step_key].depends_on or []:
+            if dependency == TRACE_COLLECTOR_STEP_KEY:
+                continue
             if dependency not in steps_by_key:
                 raise ValueError(
                     f"CI step {step_key} depends on unknown step {dependency}."
@@ -130,7 +544,7 @@ def is_docs_only_change(list_file_diff: List[str]) -> bool:
             continue
         if file_path.endswith(".md"):
             continue
-        if file_path == "mkdocs.yaml":
+        if file_path in {"mkdocs.yml", "mkdocs.yaml"}:
             continue
         return False
     return True

--- a/buildkite/pipeline_generator/pipeline_generator.py
+++ b/buildkite/pipeline_generator/pipeline_generator.py
@@ -1,4 +1,6 @@
 import base64
+import binascii
+import hashlib
 import importlib.metadata
 import json
 import os
@@ -39,6 +41,17 @@ class PipelineGenerator:
 
     def generate(self):
         global_config = get_global_config()
+
+        if _snapshot_republish_requested():
+            republish_step = create_snapshot_republish_group_step(global_config)
+            with open(self.output_file_path, "w") as output:
+                yaml.dump(
+                    {"steps": [republish_step.dict(exclude_none=True)]},
+                    output,
+                    sort_keys=False,
+                    default_flow_style=False,
+                )
+            return
 
         # Skip if changes are doc-only (unless RUN_ALL is set)
         if (
@@ -139,6 +152,9 @@ _K8S_TRACE_DEVICES = {
     DeviceType.H100,
 }
 TRACE_COLLECTOR_STEP_KEY = "test-selection-collector"
+REPUBLISH_INVENTORY_ENV = "VLLM_CI_REPUBLISH_INVENTORY_B64"
+REPUBLISH_SOURCE_BUILD_ENV = "VLLM_CI_REPUBLISH_SOURCE_BUILD"
+REPUBLISH_TRIALS_ENV = "VLLM_CI_REPUBLISH_TRIALS_JSON"
 
 # Full-fleet canary #84324 measured prohibitive Python-coverage overhead for
 # these exact jobs. Keep the evidence-based keys visible in the inventory but
@@ -420,6 +436,239 @@ def create_collector_group_step(
                 retry={"automatic": [{"exit_status": -1, "limit": 1}]},
                 soft_fail=True,
                 timeout_in_minutes=10,
+            )
+        ],
+    )
+
+
+def _snapshot_republish_requested() -> bool:
+    return any(
+        os.getenv(name) is not None
+        for name in (
+            REPUBLISH_INVENTORY_ENV,
+            REPUBLISH_SOURCE_BUILD_ENV,
+            REPUBLISH_TRIALS_ENV,
+        )
+    )
+
+
+def _snapshot_republish_inputs(global_config: dict) -> dict:
+    if not should_trace_nightly(global_config):
+        raise ValueError(
+            "test-selection republish requires a trusted vLLM main nightly"
+        )
+    encoded_inventory = os.getenv(REPUBLISH_INVENTORY_ENV)
+    source_build = os.getenv(REPUBLISH_SOURCE_BUILD_ENV)
+    if not encoded_inventory or not source_build:
+        raise ValueError(
+            f"{REPUBLISH_INVENTORY_ENV} and {REPUBLISH_SOURCE_BUILD_ENV} "
+            "must both be set"
+        )
+    if not re.fullmatch(r"[1-9][0-9]*", source_build):
+        raise ValueError(f"{REPUBLISH_SOURCE_BUILD_ENV} must be a build number")
+    try:
+        inventory_bytes = base64.b64decode(encoded_inventory, validate=True)
+        inventory = json.loads(inventory_bytes)
+    except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"{REPUBLISH_INVENTORY_ENV} is invalid") from error
+    if not isinstance(inventory, dict):
+        raise ValueError("republish inventory must be an object")
+    canonical_inventory = (
+        json.dumps(inventory, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode()
+    if inventory_bytes != canonical_inventory:
+        raise ValueError("republish inventory must be canonical JSON with a newline")
+    repository_sha = str(inventory.get("repository_sha", ""))
+    if repository_sha != global_config["commit"] or not re.fullmatch(
+        r"[0-9a-f]{40}", repository_sha
+    ):
+        raise ValueError("republish inventory repository SHA must match the build")
+    if inventory.get("schema_version") != 1:
+        raise ValueError("republish inventory schema is unsupported")
+    if not re.fullmatch(
+        r"[0-9a-f]{40}", str(inventory.get("ci_infra_revision", ""))
+    ) or not re.fullmatch(r"[0-9a-f]{64}", str(inventory.get("collector_sha256", ""))):
+        raise ValueError("republish inventory identity is invalid")
+    jobs = inventory.get("jobs")
+    always_run = inventory.get("always_run")
+    wait_results = inventory.get("wait_results")
+    if (
+        not isinstance(jobs, list)
+        or not jobs
+        or not isinstance(always_run, list)
+        or not isinstance(wait_results, dict)
+    ):
+        raise ValueError("republish inventory accounting is invalid")
+    if not all(
+        isinstance(row, dict)
+        and re.fullmatch(r"[a-zA-Z0-9_-]+", str(row.get("key", "")))
+        and isinstance(row.get("expected_shards"), int)
+        and not isinstance(row.get("expected_shards"), bool)
+        and row["expected_shards"] > 0
+        and row.get("mode") in ("python-only", "kernel-set")
+        for row in jobs
+    ) or not all(
+        isinstance(row, dict)
+        and re.fullmatch(r"[a-zA-Z0-9_-]+", str(row.get("key", "")))
+        and isinstance(row.get("reason"), str)
+        and row["reason"]
+        for row in always_run
+    ):
+        raise ValueError("republish inventory job rows are invalid")
+    job_keys = [str(row["key"]) for row in jobs]
+    current_jobs = sorted(job_keys + [str(row["key"]) for row in always_run])
+    if len(current_jobs) != len(set(current_jobs)):
+        raise ValueError("republish inventory contains duplicate job keys")
+    if set(wait_results) != set(job_keys) or not all(
+        isinstance(result, dict)
+        and result.get("status") in ("terminal", "poll_timeout")
+        for result in wait_results.values()
+    ):
+        raise ValueError("republish inventory wait results are incomplete")
+
+    trials_text = os.getenv(REPUBLISH_TRIALS_ENV, "[]")
+    try:
+        trials = json.loads(trials_text)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{REPUBLISH_TRIALS_ENV} is invalid") from error
+    if not isinstance(trials, list) or len(trials) > 10:
+        raise ValueError("republish trials must be a list of at most 10 entries")
+    normalized_trials = []
+    for row in trials:
+        if not isinstance(row, dict):
+            raise ValueError("republish trial entry must be an object")
+        pull_request = row.get("pull_request")
+        head = str(row.get("head", ""))
+        if (
+            not isinstance(pull_request, int)
+            or isinstance(pull_request, bool)
+            or pull_request < 1
+            or not re.fullmatch(r"[0-9a-f]{40}", head)
+        ):
+            raise ValueError("republish trial entry is invalid")
+        normalized_trials.append({"head": head, "pull_request": pull_request})
+    if len({row["pull_request"] for row in normalized_trials}) != len(
+        normalized_trials
+    ):
+        raise ValueError("republish trials contain duplicate pull requests")
+
+    current_jobs_bytes = (
+        json.dumps(current_jobs, separators=(",", ":")) + "\n"
+    ).encode()
+    return {
+        "current_jobs_base64": base64.b64encode(current_jobs_bytes).decode(),
+        "current_jobs_sha256": hashlib.sha256(current_jobs_bytes).hexdigest(),
+        "inventory_base64": base64.b64encode(inventory_bytes).decode(),
+        "inventory_sha256": hashlib.sha256(inventory_bytes).hexdigest(),
+        "repository_sha": repository_sha,
+        "source_build": source_build,
+        "trials": normalized_trials,
+    }
+
+
+def create_snapshot_republish_group_step(global_config: dict) -> BuildkiteGroupStep:
+    """Render one fail-closed cross-build snapshot republisher and verifier."""
+
+    inputs = _snapshot_republish_inputs(global_config)
+    revision = _ci_infra_revision()
+    bucket = shlex.quote(str(global_config["trace_s3_bucket"]))
+    prefix = shlex.quote(str(global_config["trace_s3_prefix"]))
+    source_build = inputs["source_build"]
+    repository_sha = inputs["repository_sha"]
+    command = [
+        "set -euo pipefail",
+        f'test "$$BUILDKITE_COMMIT" = {shlex.quote(repository_sha)}',
+        f'test "$$BUILDKITE_BUILD_NUMBER" != {shlex.quote(source_build)}',
+        'D="$$(mktemp -d)"',
+        "trap 'rm -rf \"$$D\"' EXIT",
+        'mkdir -p "$$D/evidence" "$$D/results"',
+        (
+            f"printf '%s' {shlex.quote(inputs['inventory_base64'])} | base64 -d "
+            '> "$$D/inventory.json"'
+        ),
+        (
+            'test "$$(sha256sum "$$D/inventory.json" | awk \'{print $$1}\')" = '
+            f"{inputs['inventory_sha256']}"
+        ),
+        (
+            f"printf '%s' {shlex.quote(inputs['current_jobs_base64'])} | base64 -d "
+            '> "$$D/results/current-jobs.json"'
+        ),
+        (
+            'test "$$(sha256sum "$$D/results/current-jobs.json" | '
+            "awk '{print $$1}')\" = "
+            f"{inputs['current_jobs_sha256']}"
+        ),
+        'python3 -m venv "$$D/venv"',
+        (
+            '"$$D/venv/bin/pip" install --quiet '
+            '"git+https://github.com/vllm-project/ci-infra.git@'
+            f'{revision}#subdirectory=buildkite/pipeline_generator"'
+        ),
+        (
+            'buildkite-agent artifact download "trace-output/**/*" '
+            f'"$$D/evidence" --build {shlex.quote(source_build)}'
+        ),
+        (
+            '"$$D/venv/bin/vllm-test-selection" publish-snapshot '
+            '--input "$$D/evidence" --inventory "$$D/inventory.json" '
+            f'--bucket {bucket} --prefix {prefix} | tee "$$D/results/publish.json"'
+        ),
+        (
+            '"$$D/venv/bin/vllm-test-selection" fetch-snapshot '
+            f'--bucket {bucket} --prefix {prefix} --repo "$$PWD" '
+            f'--base {repository_sha} --output "$$D/readback.sqlite" '
+            '--max-snapshot-age-days 1 | tee "$$D/results/fetch.json"'
+        ),
+        (
+            '"$$D/venv/bin/vllm-test-selection" inspect-graph '
+            '--graph "$$D/readback.sqlite" --metadata | '
+            'tee "$$D/results/metadata.json"'
+        ),
+        'sha256sum "$$D/readback.sqlite" | tee "$$D/results/readback.sha256"',
+        'cp "$$D/inventory.json" "$$D/results/source-inventory.json"',
+        'cp "$$D/readback.sqlite.sha256" "$$D/results/"',
+        f"printf '%s\\n' {revision} > \"$$D/results/publisher-revision.txt\"",
+        f"printf '%s\\n' {source_build} > \"$$D/results/source-build.txt\"",
+        "TRIAL_STATUS=0",
+    ]
+    for trial in inputs["trials"]:
+        pull_request = trial["pull_request"]
+        head = trial["head"]
+        remote = f"origin/pr-{pull_request}"
+        command.extend(
+            [
+                (
+                    "git fetch --force origin "
+                    f"refs/pull/{pull_request}/head:refs/remotes/{remote}"
+                ),
+                f'test "$$(git rev-parse {remote})" = {head}',
+                (
+                    '"$$D/venv/bin/vllm-test-selection" select '
+                    '--graph "$$D/readback.sqlite" --repo "$$PWD" '
+                    f"--base {repository_sha} --head {remote} "
+                    '--current-jobs "$$D/results/current-jobs.json" '
+                    f'> "$$D/results/pr-{pull_request}.json" || TRIAL_STATUS=$$?'
+                ),
+            ]
+        )
+    command.extend(
+        [
+            'buildkite-agent artifact upload "$$D/results/*"',
+            'test "$$TRIAL_STATUS" -eq 0',
+        ]
+    )
+    return BuildkiteGroupStep(
+        group="Test selection snapshot republish",
+        steps=[
+            BuildkiteCommandStep(
+                agents={"queue": AgentQueue.CPU_POSTMERGE_US_EAST_1.value},
+                commands=["\n".join(command)],
+                key="test-selection-snapshot-republish",
+                label=":database: Republish test-selection snapshot",
+                priority=-100,
+                retry={"automatic": [{"exit_status": -1, "limit": 1}]},
+                timeout_in_minutes=180,
             )
         ],
     )

--- a/buildkite/pipeline_generator/pyproject.toml
+++ b/buildkite/pipeline_generator/pyproject.toml
@@ -6,6 +6,8 @@ build-backend = "setuptools.build_meta"
 name = "pipeline-generator"
 version = "0.1.0"
 dependencies = [
+    "boto3>=1.36.0,<2",
+    "botocore>=1.36.26,<2",
     "pyyaml",
     "click",
     "pydantic>=2.0",
@@ -14,6 +16,7 @@ dependencies = [
 
 [project.scripts]
 pipeline-generator = "main:main"
+vllm-test-selection = "test_selection.cli:main"
 
 [tool.setuptools]
 py-modules = [
@@ -28,7 +31,8 @@ py-modules = [
 ]
 
 [tool.setuptools.packages.find]
-include = [".", "otel_helpers", "plugin", "utils_lib"]
+include = [".", "otel_helpers", "plugin", "test_selection*", "utils_lib"]
 
 [tool.setuptools.package-data]
 otel_helpers = ["*.sh"]
+"test_selection.collector" = ["*.sh"]

--- a/buildkite/pipeline_generator/step.py
+++ b/buildkite/pipeline_generator/step.py
@@ -1,11 +1,11 @@
-from pydantic import BaseModel, Field
-from typing import Optional, List, Dict, Any
-from pydantic import model_validator
-from typing_extensions import Self
-from collections import defaultdict
-from global_config import get_global_config
 import os
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
 import yaml
+from global_config import get_global_config
+from pydantic import BaseModel, Field, model_validator
+from typing_extensions import Self
 
 
 class Step(BaseModel):
@@ -33,6 +33,9 @@ class Step(BaseModel):
     no_gpu: Optional[bool] = False
     dind: bool = True
     mirror: Optional[Dict[str, Dict[str, Any]]] = None
+    trace_represented_job_key: Optional[str] = None
+    trace_gpu: bool = False
+    trace_collector_sha256: Optional[str] = None
 
     def otel_tracing_enabled(self) -> bool:
         config = get_global_config()
@@ -96,7 +99,9 @@ def read_steps_from_job_dir(job_dir: str):
                         and global_config["github_repo_name"] == "vllm-project/vllm"
                     ):
                         step.working_dir = "/vllm-workspace/tests"
-                    step.source_file_dependencies = getattr(step, "source_file_dependencies", [])
+                    step.source_file_dependencies = getattr(
+                        step, "source_file_dependencies", []
+                    )
                     if not step.source_file_dependencies:
                         step.source_file_dependencies = []
                     step.source_file_dependencies.append(os.path.relpath(yaml_path))

--- a/buildkite/pipeline_generator/test_selection/README.md
+++ b/buildkite/pipeline_generator/test_selection/README.md
@@ -38,7 +38,10 @@ omitted by the selector.
 
 If publication fails after a nightly has collected its evidence, a trusted
 main-nightly build can set `VLLM_CI_REPUBLISH_INVENTORY_B64` and
-`VLLM_CI_REPUBLISH_SOURCE_BUILD` to enter the fail-closed recovery path. The
+`VLLM_CI_REPUBLISH_SOURCE_BUILD` plus
+`VLLM_CI_REPUBLISH_SOURCE_BUILD_ID` to enter the fail-closed recovery path.
+The source build number is retained for human-readable provenance; the source
+build UUID is required by `buildkite-agent artifact download --build`. The
 generator validates the canonical inventory against the build commit and emits
 exactly one CPU postmerge step; it does not render or rerun the fleet. Optional
 `VLLM_CI_REPUBLISH_TRIALS_JSON` entries pin shadow trials to exact PR heads.

--- a/buildkite/pipeline_generator/test_selection/README.md
+++ b/buildkite/pipeline_generator/test_selection/README.md
@@ -1,0 +1,58 @@
+# Trace-guided test selection
+
+The vLLM main nightly automatically traces pytest jobs loaded from
+`.buildkite/test_areas`. vLLM job YAML has no tracing fields.
+
+## Evidence
+
+Each pytest job records presence-only edges:
+
+- Python: repository file and line → pytest node → Buildkite job.
+- NVIDIA: mangled CUDA kernel identity → pytest node/job.
+
+Counts, call order, Python stacks, and raw Nsight timelines are not stored in
+the selection database. Unsupported or unhealthy jobs remain always-run.
+
+The generator publishes one deterministic collector bundle. A test job polls
+briefly for that bundle and otherwise runs its original command script
+unchanged. Collector failure is evidence loss, not a test result.
+
+## Snapshot
+
+The independent fan-in waits for the traced jobs, downloads their compact
+artifacts, and builds `graph.sqlite`. It publishes immutable objects under:
+
+```text
+test-selection/vllm/snapshots/<main-sha>/
+  graph.sqlite
+  graph.sqlite.sha256
+  manifest.json
+test-selection/vllm/index.json
+```
+
+The manifest accounts for every discovered pytest job as healthy, missing, or
+unhealthy. Missing and unhealthy jobs are never omitted by the selector.
+
+## PR selection
+
+The PR path fetches the newest fresh snapshot whose commit is an ancestor of
+the PR merge base, verifies all checksums, and joins changed files to jobs.
+
+```bash
+vllm-test-selection fetch-snapshot \
+  --bucket "$VLLM_CI_TRACE_S3_BUCKET" \
+  --repo /path/to/vllm --base "$MERGE_BASE" --output graph.sqlite
+
+vllm-test-selection current-jobs \
+  --pipeline pipeline.yaml --output current-jobs.json
+
+vllm-test-selection select \
+  --graph graph.sqlite --repo /path/to/vllm \
+  --base "$MERGE_BASE" --head "$PR_HEAD" \
+  --current-jobs current-jobs.json
+```
+
+Any stale/non-ancestral snapshot, checksum error, unmapped changed file, or
+invalid input returns fallback status. The caller must then leave
+`VLLM_CI_ONLY_STEP_KEYS` unset and run the normal pipeline. Selection remains
+shadow-only until fleet evidence and false-negative audits justify enforcement.

--- a/buildkite/pipeline_generator/test_selection/README.md
+++ b/buildkite/pipeline_generator/test_selection/README.md
@@ -49,6 +49,8 @@ The recovery step downloads the source build's evidence, publishes with the
 current ci-infra revision, and verifies a fresh read-back before any trial.
 This path is intended only for trusted operators recovering immutable evidence,
 not for normal nightly or pull-request execution.
+Do not set any republish variable on a normal nightly: its presence deliberately
+replaces the full generated fleet with the single recovery step.
 
 Snapshot manifests are produced by this trusted publisher. Readers enforce the
 publisher-declared decompression bound and both compressed and logical hashes;

--- a/buildkite/pipeline_generator/test_selection/README.md
+++ b/buildkite/pipeline_generator/test_selection/README.md
@@ -24,14 +24,17 @@ artifacts, and builds `graph.sqlite`. It publishes immutable objects under:
 
 ```text
 test-selection/vllm/snapshots/<main-sha>/
-  graph.sqlite
+  graph.sqlite.gz
   graph.sqlite.sha256
   manifest.json
 test-selection/vllm/index.json
 ```
 
 The manifest accounts for every discovered pytest job as healthy, missing, or
-unhealthy. Missing and unhealthy jobs are never omitted by the selector.
+unhealthy. It binds both the deterministic gzip object and the logical SQLite
+bytes; readers verify the compressed object before bounded decompression, then
+verify the SQLite checksum sidecar. Missing and unhealthy jobs are never
+omitted by the selector.
 
 ## PR selection
 

--- a/buildkite/pipeline_generator/test_selection/README.md
+++ b/buildkite/pipeline_generator/test_selection/README.md
@@ -36,6 +36,22 @@ bytes; readers verify the compressed object before bounded decompression, then
 verify the SQLite checksum sidecar. Missing and unhealthy jobs are never
 omitted by the selector.
 
+If publication fails after a nightly has collected its evidence, a trusted
+main-nightly build can set `VLLM_CI_REPUBLISH_INVENTORY_B64` and
+`VLLM_CI_REPUBLISH_SOURCE_BUILD` to enter the fail-closed recovery path. The
+generator validates the canonical inventory against the build commit and emits
+exactly one CPU postmerge step; it does not render or rerun the fleet. Optional
+`VLLM_CI_REPUBLISH_TRIALS_JSON` entries pin shadow trials to exact PR heads.
+The recovery step downloads the source build's evidence, publishes with the
+current ci-infra revision, and verifies a fresh read-back before any trial.
+This path is intended only for trusted operators recovering immutable evidence,
+not for normal nightly or pull-request execution.
+
+Snapshot manifests are produced by this trusted publisher. Readers enforce the
+publisher-declared decompression bound and both compressed and logical hashes;
+they must not treat an untrusted manifest's size declaration as an independent
+resource limit.
+
 ## PR selection
 
 The PR path fetches the newest fresh snapshot whose commit is an ancestor of

--- a/buildkite/pipeline_generator/test_selection/__init__.py
+++ b/buildkite/pipeline_generator/test_selection/__init__.py
@@ -1,0 +1,3 @@
+"""Minimal trace graph and shadow selector for vLLM CI."""
+
+SCHEMA_VERSION = 1

--- a/buildkite/pipeline_generator/test_selection/cli.py
+++ b/buildkite/pipeline_generator/test_selection/cli.py
@@ -1,0 +1,160 @@
+"""Command-line entry point for the minimal trace-guided CI selector."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+from test_selection.graph import (
+    build_graph,
+    current_jobs_from_pipeline,
+    graph_metadata,
+    job_coverage,
+    paths_to_jobs,
+    select_jobs,
+)
+from test_selection.snapshot import (
+    Boto3ObjectStore,
+    build_and_publish,
+    fetch_snapshot,
+)
+from test_selection.wait import wait_for_steps
+
+
+def _print(document: Dict[str, Any]) -> None:
+    print(json.dumps(document, sort_keys=True, indent=2))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="vllm-test-selection")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    materialize = commands.add_parser("build-graph")
+    materialize.add_argument("--input", type=Path, required=True)
+    materialize.add_argument("--output", type=Path, required=True)
+
+    inventory = commands.add_parser("current-jobs")
+    inventory.add_argument("--pipeline", type=Path, required=True)
+    inventory.add_argument("--output", type=Path, required=True)
+
+    coverage = commands.add_parser("job-coverage")
+    coverage.add_argument("--graph", type=Path, required=True)
+    coverage.add_argument("--current-jobs", type=Path, required=True)
+
+    why = commands.add_parser("why")
+    why.add_argument("--graph", type=Path, required=True)
+    why.add_argument("--source", required=True)
+
+    select = commands.add_parser("select")
+    select.add_argument("--graph", type=Path, required=True)
+    select.add_argument("--repo", type=Path, required=True)
+    select.add_argument("--base", required=True)
+    select.add_argument("--head", required=True)
+    select.add_argument("--current-jobs", type=Path, required=True)
+    select.add_argument("--max-snapshot-age-days", type=int, default=11)
+    select.add_argument("--format", choices=("json", "step-keys-json"), default="json")
+
+    inspect = commands.add_parser("inspect-graph")
+    inspect.add_argument("--graph", type=Path, required=True)
+    inspect.add_argument("--metadata", action="store_true")
+
+    publish = commands.add_parser("publish-snapshot")
+    publish.add_argument("--input", type=Path, required=True)
+    publish.add_argument("--inventory", type=Path, required=True)
+    publish.add_argument("--bucket", required=True)
+    publish.add_argument("--prefix", default="test-selection/vllm")
+
+    wait = commands.add_parser("wait-for-steps")
+    wait.add_argument("--inventory", type=Path, required=True)
+    wait.add_argument("--timeout-seconds", type=float, required=True)
+    wait.add_argument("--poll-seconds", type=float, default=120)
+
+    fetch = commands.add_parser("fetch-snapshot")
+    fetch.add_argument("--bucket", required=True)
+    fetch.add_argument("--prefix", default="test-selection/vllm")
+    fetch.add_argument("--repo", type=Path, required=True)
+    fetch.add_argument("--base", required=True)
+    fetch.add_argument("--output", type=Path, required=True)
+    fetch.add_argument("--max-snapshot-age-days", type=int, default=11)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        if args.command == "build-graph":
+            _print(build_graph(args.input, args.output))
+        elif args.command == "current-jobs":
+            keys = current_jobs_from_pipeline(args.pipeline)
+            temporary = args.output.with_suffix(args.output.suffix + ".tmp")
+            temporary.write_text(
+                json.dumps(keys, separators=(",", ":")) + "\n", encoding="utf-8"
+            )
+            temporary.replace(args.output)
+            _print({"count": len(keys), "output": str(args.output)})
+        elif args.command == "job-coverage":
+            _print(job_coverage(args.graph, args.current_jobs))
+        elif args.command == "why":
+            paths = paths_to_jobs(args.graph, args.source)
+            _print({"paths": paths, "source": args.source})
+            if not paths:
+                return 2
+        elif args.command == "select":
+            result = select_jobs(
+                args.graph,
+                args.repo,
+                args.base,
+                args.head,
+                args.current_jobs,
+                args.max_snapshot_age_days,
+            )
+            if args.format == "step-keys-json":
+                if result["fallback"]:
+                    print("null")
+                    return 2
+                print(json.dumps(result["step_keys"], separators=(",", ":")))
+            else:
+                _print(result)
+            if result["fallback"]:
+                return 2
+        elif args.command == "inspect-graph":
+            _print(graph_metadata(args.graph))
+        elif args.command == "publish-snapshot":
+            _print(
+                build_and_publish(
+                    args.input,
+                    args.inventory,
+                    Boto3ObjectStore(args.bucket),
+                    args.prefix,
+                )
+            )
+        elif args.command == "wait-for-steps":
+            _print(
+                wait_for_steps(
+                    args.inventory,
+                    timeout_seconds=args.timeout_seconds,
+                    poll_seconds=args.poll_seconds,
+                )
+            )
+        elif args.command == "fetch-snapshot":
+            _print(
+                fetch_snapshot(
+                    Boto3ObjectStore(args.bucket),
+                    args.prefix,
+                    args.repo,
+                    args.base,
+                    args.output,
+                    max_age_days=args.max_snapshot_age_days,
+                )
+            )
+    except Exception as error:
+        print("vllm-test-selection: %s" % error, file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/buildkite/pipeline_generator/test_selection/collector/__init__.py
+++ b/buildkite/pipeline_generator/test_selection/collector/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Minimal per-test Python-line and CUDA-kernel evidence collector."""
+
+COLLECTOR_VERSION = "line-kernel-set-v2"

--- a/buildkite/pipeline_generator/test_selection/collector/nsys_runtime.py
+++ b/buildkite/pipeline_generator/test_selection/collector/nsys_runtime.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Soundly canonicalize Nsight CUDA runtime launch rows."""
+
+from __future__ import annotations
+
+import sqlite3
+import re
+from collections import defaultdict
+from typing import Any
+
+_VERSION_SUFFIX = re.compile(r"_v[0-9]+$")
+
+
+def _columns(connection: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in connection.execute(f"PRAGMA table_info({table})")}
+
+
+def _api_name(row: dict[str, Any], strings: dict[int, str]) -> str | None:
+    identifier = row.get("nameId")
+    if identifier is None:
+        return None
+    return strings.get(identifier, str(identifier))
+
+
+def _canonical_api(name: str) -> str:
+    return _VERSION_SUFFIX.sub("", name)
+
+
+def _canonical_alias(
+    rows: list[dict[str, Any]], strings: dict[int, str]
+) -> dict[str, Any]:
+    """Collapse the versioned/unversioned wrapper pair emitted by Nsight.
+
+    Recent Nsight releases can record both ``cudaLaunchKernel`` and its ABI
+    alias (for example ``cudaLaunchKernel_v7000``) with the same process-local
+    correlation ID. They are one nested API call, not two launches. Accept the
+    pair only when thread, canonical API name, and overlapping intervals prove
+    that relationship; every other duplicate remains a fail-closed error.
+    """
+
+    threads = {row["global_tid"] for row in rows}
+    names = [_api_name(row, strings) for row in rows]
+    if len(threads) != 1 or any(name is None for name in names):
+        raise SystemExit(
+            "duplicate CUDA runtime correlation ID is not a proven API alias"
+        )
+    if len({_canonical_api(name) for name in names if name is not None}) != 1:
+        raise SystemExit(
+            "duplicate CUDA runtime correlation ID has different API names"
+        )
+    if any(row.get("end") is None for row in rows):
+        raise SystemExit(
+            "duplicate CUDA runtime correlation ID lacks interval evidence"
+        )
+    if max(row["start_ns"] for row in rows) > min(int(row["end"]) for row in rows):
+        raise SystemExit(
+            "duplicate CUDA runtime correlation ID has disjoint API intervals"
+        )
+
+    # The unversioned wrapper carries Nsight's Python/native launch callchain
+    # in current exports. Prefer any row with a callchain, then the outermost
+    # (earliest-starting, latest-ending) wrapper for attribution time.
+    return min(
+        rows,
+        key=lambda row: (
+            row.get("callchainId") is None,
+            row["start_ns"],
+            -int(row["end"]),
+        ),
+    )
+
+
+def load_runtime_launches(
+    connection: sqlite3.Connection, strings: dict[int, str]
+) -> tuple[dict[tuple[int, int], dict[str, Any]], int]:
+    """Return one sound CUDA runtime launch per process/correlation key."""
+
+    columns = _columns(connection, "CUPTI_ACTIVITY_KIND_RUNTIME")
+    required = {"correlationId", "globalTid", "start"}
+    if not required <= columns:
+        raise SystemExit("CUDA runtime table lacks launch correlation columns")
+    optional = [name for name in ("end", "nameId", "callchainId") if name in columns]
+    select = ", ".join(["correlationId", "globalTid", "start", *optional])
+    grouped: dict[tuple[int, int], list[dict[str, Any]]] = defaultdict(list)
+    for correlation_id, global_tid, start, *values in connection.execute(
+        f"SELECT {select} FROM CUPTI_ACTIVITY_KIND_RUNTIME"
+    ):
+        launch = {
+            "correlation_id": int(correlation_id),
+            "global_tid": int(global_tid),
+            "process_key": int(global_tid) >> 24,
+            "start_ns": int(start),
+        }
+        launch.update(dict(zip(optional, values)))
+        grouped[(launch["process_key"], launch["correlation_id"])].append(launch)
+
+    launches = {}
+    aliases = 0
+    for key, rows in grouped.items():
+        if len(rows) == 1:
+            launches[key] = rows[0]
+        else:
+            launches[key] = _canonical_alias(rows, strings)
+            aliases += len(rows) - 1
+    return launches, aliases

--- a/buildkite/pipeline_generator/test_selection/collector/nvtx_test_ranges.py
+++ b/buildkite/pipeline_generator/test_selection/collector/nvtx_test_ranges.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Pytest plugin: wrap every test phase in an NVTX range named by nodeid.
+
+nsys records these ranges alongside CUDA launch activity; the parser joins
+kernels to tests by launch-site timestamp within the range on the same
+thread. Setup/teardown get their own prefixed ranges so fixture-launched
+kernels are attributed explicitly instead of falling outside every range.
+
+Zero hard dependencies: if torch or a CUDA context is unavailable the plugin
+is inert, so the same pytest command runs unchanged outside the trace step.
+
+Usage: pytest -p nvtx_test_ranges ... (with this file on PYTHONPATH), or
+copy next to conftest.py and add to plugins.
+"""
+
+import os
+from contextlib import suppress
+
+import pytest
+
+
+def _configured_nvtx():
+    if os.environ.get("VLLM_CI_TEST_SELECTION_NVTX") != "1":
+        return None
+    try:
+        import torch
+
+        return torch.cuda.nvtx if torch.cuda.is_available() else None
+    except Exception:
+        return None
+
+
+_nvtx = _configured_nvtx()
+
+PREFIX = {
+    "setup": "citest-setup::",
+    "call": "citest::",
+    "teardown": "citest-teardown::",
+}
+
+
+def _wrap(phase, item):
+    if _nvtx is None:
+        yield
+        return
+    pushed = False
+    try:
+        _nvtx.range_push(PREFIX[phase] + item.nodeid)
+        pushed = True
+    except Exception:
+        # NVTX is evidence-only. A driver/tooling failure must never change
+        # the pytest phase's correctness result.
+        pass
+    try:
+        yield
+    finally:
+        if pushed:
+            with suppress(Exception):
+                _nvtx.range_pop()
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_setup(item):
+    yield from _wrap("setup", item)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item):
+    yield from _wrap("call", item)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_teardown(item):
+    yield from _wrap("teardown", item)

--- a/buildkite/pipeline_generator/test_selection/collector/parse_nsys_sqlite.py
+++ b/buildkite/pipeline_generator/test_selection/collector/parse_nsys_sqlite.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Convert a minimal CUDA/NVTX capture to unordered kernel/test edges.
+
+Attribution is by LAUNCH SITE, not execution time: each GPU kernel row is
+joined via correlationId to its CUDA runtime launch row, and the launch is
+attributed to the innermost citest NVTX range covering it on the same
+thread. Async execution and stream overlap therefore cannot misattribute;
+the known loss is CUDA-graph capture (kernels inside a replayed graph
+attribute to the launching test, which is correct for selection purposes,
+but capture-time structure is not recovered).
+
+Outputs only the unordered kernel-identity -> test/job set on --out and a
+capture summary on stderr. The raw timeline is temporary implementation detail
+and is deleted by the caller after this set is materialized.
+"""
+
+import argparse
+import json
+import pathlib
+import sqlite3
+import sys
+import tempfile
+from bisect import bisect_right
+from collections import Counter, defaultdict
+from heapq import heappop, heappush
+
+try:
+    from .nsys_runtime import load_runtime_launches
+except ImportError:  # direct script execution from run_traced.sh
+    from nsys_runtime import load_runtime_launches
+
+CALL_PREFIX = "citest::"
+AUX_PREFIXES = ("citest-setup::", "citest-teardown::")
+
+
+def columns(con, table):
+    try:
+        return {r[1] for r in con.execute(f"PRAGMA table_info({table})")}
+    except sqlite3.Error:
+        return set()
+
+
+def string_ids(con):
+    return {i: v for i, v in con.execute("SELECT id, value FROM StringIds")}
+
+
+def load_ranges(con, strings):
+    """citest NVTX push/pop ranges: (globalTid, start, end, nodeid, phase)."""
+    cols = columns(con, "NVTX_EVENTS")
+    if not cols:
+        raise SystemExit("no NVTX_EVENTS table: was --trace=nvtx enabled?")
+    text_col = "text" if "text" in cols else "NULL"
+    text_id_col = "textId" if "textId" in cols else "NULL"
+    ranges = []
+    for row in con.execute(
+        f"SELECT start, end, globalTid, {text_col}, {text_id_col}"
+        " FROM NVTX_EVENTS WHERE end IS NOT NULL"
+    ):
+        start, end, gtid, text, text_id = row
+        label = text if text is not None else strings.get(text_id)
+        if not label:
+            continue
+        if label.startswith(CALL_PREFIX):
+            phase, nodeid = "call", label[len(CALL_PREFIX) :]
+        else:
+            for p in AUX_PREFIXES:
+                if label.startswith(p):
+                    phase, nodeid = p.split("::")[0], label[len(p) :]
+                    break
+            else:
+                continue
+        ranges.append((gtid, start, end, nodeid, phase))
+    return ranges
+
+
+def kernel_name_column(con):
+    cols = columns(con, "CUPTI_ACTIVITY_KIND_KERNEL")
+    if not cols:
+        raise SystemExit(
+            "no CUPTI_ACTIVITY_KIND_KERNEL table: was --trace=cuda enabled?"
+        )
+    if "mangledName" not in cols:
+        raise SystemExit(
+            "kernel table has no mangledName; stable kernel identity is unavailable"
+        )
+    return "mangledName"
+
+
+def temporal_attributions(ranges, launches):
+    """Attribute launch times only when exactly one test range is active.
+
+    This is the bounded fallback for child processes whose CUDA launch thread
+    cannot carry the parent's NVTX range. Concurrent/ambiguous launches do not
+    receive test precision.
+    """
+
+    ordered_ranges = sorted(ranges, key=lambda span: span[1])
+    ordered_launches = sorted(launches.items(), key=lambda item: item[1][1])
+    active = Counter()
+    endings = []
+    range_index = 0
+    result = {}
+    for launch_key, (_gtid, launch_time) in ordered_launches:
+        while (
+            range_index < len(ordered_ranges)
+            and ordered_ranges[range_index][1] <= launch_time
+        ):
+            _gtid, start, end, nodeid, phase = ordered_ranges[range_index]
+            key = (nodeid, phase)
+            active[key] += 1
+            heappush(endings, (end, key))
+            range_index += 1
+        while endings and endings[0][0] < launch_time:
+            _end, key = heappop(endings)
+            active[key] -= 1
+            if active[key] == 0:
+                del active[key]
+        if sum(active.values()) == 1:
+            result[launch_key] = next(iter(active))
+        elif active:
+            result[launch_key] = False
+        else:
+            result[launch_key] = None
+    return result
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("sqlite", help="nsys export --type sqlite output")
+    ap.add_argument("--out", default="-", help="edge JSONL output")
+    ap.add_argument(
+        "--job-key", required=True, help="represented production Buildkite step key"
+    )
+    ap.add_argument("--repository-sha", required=True)
+    ap.add_argument("--created-at", required=True)
+    args = ap.parse_args(argv)
+
+    con = sqlite3.connect(f"file:{args.sqlite}?mode=ro", uri=True)
+    try:
+        strings = string_ids(con)
+        name_col = kernel_name_column(con)
+
+        # per-thread launch attribution index: sorted range starts, innermost win
+        ranges = load_ranges(con, strings)
+        by_tid = defaultdict(list)
+        for gtid, start, end, nodeid, phase in ranges:
+            by_tid[gtid].append((start, end, nodeid, phase))
+        for tid in by_tid:
+            by_tid[tid].sort()
+
+        starts_by_tid = {
+            tid: [span[0] for span in spans] for tid, spans in by_tid.items()
+        }
+
+        def attribute(gtid, t):
+            """Return the innermost test range covering launch time ``t``.
+
+            Push/pop ranges on one thread are properly nested, and inner ranges
+            start later. The first covering span found while scanning backwards
+            is therefore the innermost range.
+            """
+            spans = by_tid.get(gtid, ())
+            starts = starts_by_tid.get(gtid, ())
+            for i in range(bisect_right(starts, t) - 1, -1, -1):
+                start, end, nodeid, phase = spans[i]
+                if end >= t:
+                    return nodeid, phase
+            return None
+
+        # CUPTI correlation IDs are process-scoped: with fork tracing enabled
+        # two processes can reuse the same correlationId, so the kernel->launch
+        # join must include process identity. Recent Nsight versions can also
+        # emit nested versioned/unversioned API aliases for one launch; the
+        # shared loader collapses only aliases proven by name/thread/interval.
+        runtime_launches, runtime_aliases = load_runtime_launches(con, strings)
+        launches = {
+            key: (launch["global_tid"], launch["start_ns"])
+            for key, launch in runtime_launches.items()
+        }
+        temporal_by_launch = temporal_attributions(ranges, launches)
+
+        kernel_cols = columns(con, "CUPTI_ACTIVITY_KIND_KERNEL")
+        kernel_pid_col = (
+            "globalPid"
+            if "globalPid" in kernel_cols
+            else "globalTid"
+            if "globalTid" in kernel_cols
+            else None
+        )
+        process_scoped = kernel_pid_col is not None
+        if not process_scoped:
+            # single-process fallback: correlation-only join, flagged in summary
+            by_cid_only = {}
+            by_cid_launch_key = {}
+            collided = set()
+            for launch_key, value in launches.items():
+                _pid, cid = launch_key
+                if cid in by_cid_only:
+                    collided.add(cid)
+                by_cid_only[cid] = value
+                by_cid_launch_key[cid] = launch_key
+
+        stats = defaultdict(int)
+        seen_pairs = set()
+        rows = []
+        pid_select = f", {kernel_pid_col}" if process_scoped else ""
+        for row in con.execute(
+            f"SELECT correlationId, {name_col}{pid_select}"
+            " FROM CUPTI_ACTIVITY_KIND_KERNEL"
+        ):
+            cid, name_id = row[0], row[1]
+            stats["kernel_rows"] += 1
+            name = strings.get(name_id, name_id)
+            if process_scoped:
+                launch_key = (row[2] >> 24, cid)
+                launch = launches.get(launch_key)
+            else:
+                if cid in collided:
+                    raise SystemExit(
+                        "kernel table has no process column and the referenced "
+                        "correlation ID is not unique: join would be unsound"
+                    )
+                launch = by_cid_only.get(cid)
+                launch_key = by_cid_launch_key.get(cid)
+            if launch is None:
+                stats["no_launch_row"] += 1
+                continue
+            hit = attribute(*launch)
+            if hit is not None:
+                destination_kind = "test"
+                nodeid, phase = hit
+                destination = nodeid
+                attribution_mode = "exact_test"
+                stats["attribution_exact_test"] += 1
+            else:
+                fallback = temporal_by_launch.get(launch_key)
+                if fallback:
+                    destination_kind = "test"
+                    nodeid, phase = fallback
+                    destination = nodeid
+                    attribution_mode = "temporal_test"
+                    stats["attribution_temporal_test"] += 1
+                else:
+                    destination_kind = "job"
+                    nodeid, phase = None, "job"
+                    destination = args.job_key
+                    attribution_mode = "job_union"
+                    stats["attribution_job_union"] += 1
+                    if fallback is False:
+                        stats["ambiguous_active_test_ranges"] += 1
+                    else:
+                        stats["outside_any_test_range"] += 1
+            pair = (name, destination_kind, destination, phase, attribution_mode)
+            if pair in seen_pairs:
+                continue
+            seen_pairs.add(pair)
+            rows.append(
+                {
+                    "source_kind": "kernel",
+                    "source": name,
+                    "edge_kind": (
+                        "executed_by"
+                        if destination_kind == "test"
+                        else "executed_by_job"
+                    ),
+                    "destination_kind": destination_kind,
+                    "destination": destination,
+                    "phase": phase,
+                    "attribution_mode": attribution_mode,
+                    "created_at": args.created_at,
+                    "job_key": args.job_key,
+                    "repository_sha": args.repository_sha,
+                    **({"test_id": nodeid} if nodeid is not None else {}),
+                }
+            )
+    finally:
+        con.close()
+
+    rows.sort(
+        key=lambda row: (
+            row["source"],
+            row["destination"],
+            row["phase"],
+        )
+    )
+
+    if args.out == "-":
+        for row in rows:
+            print(json.dumps(row, sort_keys=True))
+    else:
+        output = pathlib.Path(args.out)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            "w", dir=output.parent, suffix=".tmp", delete=False
+        ) as stream:
+            temporary = pathlib.Path(stream.name)
+            for row in rows:
+                stream.write(json.dumps(row, sort_keys=True) + "\n")
+        temporary.replace(output)
+
+    summary = dict(stats)
+    summary["kernel_name_column"] = name_col
+    summary["mangled_identity"] = True
+    summary["process_scoped_join"] = process_scoped
+    summary["unique_kernel_test_pairs"] = len(seen_pairs)
+    summary["unique_kernel_destination_pairs"] = len(seen_pairs)
+    summary["citest_ranges"] = len(ranges)
+    summary["runtime_alias_rows_deduplicated"] = runtime_aliases
+    summary["attributed_kernel_rows"] = (
+        stats["attribution_exact_test"]
+        + stats["attribution_temporal_test"]
+        + stats["attribution_job_union"]
+    )
+    test_attributed = (
+        stats["attribution_exact_test"] + stats["attribution_temporal_test"]
+    )
+    summary["test_attribution_rate"] = (
+        test_attributed / stats["kernel_rows"] if stats["kernel_rows"] else 0.0
+    )
+    summary["job_union_rate"] = (
+        stats["attribution_job_union"] / stats["kernel_rows"]
+        if stats["kernel_rows"]
+        else 0.0
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/buildkite/pipeline_generator/test_selection/collector/pytest_trace_plugin.py
+++ b/buildkite/pipeline_generator/test_selection/collector/pytest_trace_plugin.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Record the exact pytest node IDs and outcomes in a trace pilot run."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+_STATE: dict[str, Any] = {"collected": [], "outcomes": {}}
+
+
+def _collector_warning(component: str, error: Exception) -> None:
+    print(
+        f"test-selection collector {component} failed: {type(error).__name__}: {error}",
+        file=sys.stderr,
+    )
+
+
+def pytest_collection_finish(session: Any) -> None:
+    _STATE["collected"] = sorted(item.nodeid for item in session.items)
+
+
+def pytest_runtest_logreport(report: Any) -> None:
+    outcomes = _STATE["outcomes"].setdefault(report.nodeid, {})
+    outcomes[report.when] = report.outcome
+
+
+def pytest_sessionfinish(session: Any, exitstatus: int) -> None:
+    output = os.environ.get("VLLM_CI_TEST_SELECTION_NODEIDS")
+    if not output:
+        return
+
+    try:
+        document = {
+            "collected": _STATE["collected"],
+            "exit_status": int(exitstatus),
+            "outcomes": {
+                nodeid: _STATE["outcomes"][nodeid]
+                for nodeid in sorted(_STATE["outcomes"])
+            },
+        }
+        path = Path(output)
+        worker = os.environ.get("PYTEST_XDIST_WORKER")
+        if worker:
+            path = path.with_name(f"{path.stem}.{worker}{path.suffix}")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_suffix(path.suffix + ".tmp")
+        temporary.write_text(
+            json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except Exception as error:
+        _collector_warning("node/outcome export", error)

--- a/buildkite/pipeline_generator/test_selection/collector/run_job_trace.py
+++ b/buildkite/pipeline_generator/test_selection/collector/run_job_trace.py
@@ -188,6 +188,13 @@ def main() -> int:
             and command_status.get("command_executed") is True
             and command_status.get("phase") in ("started", "finished")
         )
+        failure_reason = (
+            str(shard_job["failure_reason"])
+            if shard_job and shard_job.get("failure_reason")
+            else "collector_runtime_error"
+            if collector_error
+            else None
+        )
         fallback_uninstrumented = False
         if (
             args.preserve_command_exit_code
@@ -210,6 +217,7 @@ def main() -> int:
                 "collector_error": collector_error,
                 "collector_exit_code": collector_exit_code,
                 "command_exit_code": command_exit_code,
+                "failure_reason": failure_reason,
                 "fallback_uninstrumented": fallback_uninstrumented,
                 "healthy": bool(
                     collector_exit_code == 0
@@ -226,6 +234,18 @@ def main() -> int:
         result["command_exit_code"] == 0 and result["healthy"]
         for result in command_results
     )
+    failure_reasons = sorted(
+        {
+            result["failure_reason"]
+            for result in command_results
+            if result["failure_reason"]
+        }
+    )
+    failure_reason = None
+    if not healthy:
+        failure_reason = (
+            failure_reasons[0] if len(failure_reasons) == 1 else "collector_unhealthy"
+        )
     summary_path = output_dir / "trace-job.json"
     try:
         parallel_job = int(os.environ.get("BUILDKITE_PARALLEL_JOB", "0"))
@@ -241,6 +261,7 @@ def main() -> int:
                 "command_count": len(commands),
                 "command_results": command_results,
                 "created_at": datetime.now(UTC).isoformat(),
+                "failure_reason": failure_reason,
                 "healthy": healthy,
                 "job_key": args.job_key,
                 "parallel_job": parallel_job,

--- a/buildkite/pipeline_generator/test_selection/collector/run_job_trace.py
+++ b/buildkite/pipeline_generator/test_selection/collector/run_job_trace.py
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Run an enrolled Buildkite pytest job under generic trace collection."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from . import COLLECTOR_VERSION
+
+
+def _atomic_json(path: Path, document: Any) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def _shell_exit_code(returncode: int) -> int:
+    return 128 - returncode if returncode < 0 else returncode
+
+
+def decode_commands(value: str) -> list[str]:
+    try:
+        document = json.loads(base64.b64decode(value, validate=True).decode("utf-8"))
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        message = "--commands-base64 must contain base64-encoded JSON"
+        raise SystemExit(message) from error
+    if not isinstance(document, list) or not document:
+        raise SystemExit("trace command payload must be a non-empty JSON list")
+    if not all(isinstance(command, str) and command.strip() for command in document):
+        raise SystemExit("every trace command must be a non-empty string")
+    return document
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--job-key", required=True)
+    parser.add_argument("--represented-job-key", required=True)
+    parser.add_argument("--commands-base64", required=True)
+    parser.add_argument("--repo-root", type=Path, default=Path("/vllm-workspace"))
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--capture-gpu", action="store_true")
+    mode.add_argument("--python-only", action="store_true")
+    parser.add_argument(
+        "--preserve-command-exit-code",
+        action="store_true",
+        help=(
+            "Return the existing job command's status even when collection or "
+            "export fails. If collection fails before starting the command, run "
+            "that command once without instrumentation."
+        ),
+    )
+    return parser
+
+
+def _encoded_command(command: str) -> str:
+    return base64.b64encode(command.encode("utf-8")).decode("ascii")
+
+
+def _run_command(
+    command: str,
+    *,
+    command_index: int,
+    job_key: str,
+    command_cwd: Path,
+    output_dir: Path,
+    repo_root: Path,
+    represented_job_key: str,
+    capture_gpu: bool,
+) -> subprocess.CompletedProcess[Any]:
+    shard_dir = output_dir / "commands" / f"{command_index:03d}"
+    shard_dir.mkdir(parents=True, exist_ok=True)
+    package = __package__ or "ci_test_selection"
+    runner = [
+        sys.executable,
+        "-m",
+        f"{package}.run_trace",
+        "--output-dir",
+        str(shard_dir),
+        "--job-key",
+        job_key,
+        "--represented-job-key",
+        represented_job_key,
+        "--repo-root",
+        str(repo_root),
+        "--command-cwd",
+        str(command_cwd),
+        "--command-base64",
+        _encoded_command(command),
+    ]
+    environment = dict(os.environ)
+    environment["VLLM_CI_TEST_SELECTION_NVTX"] = "1" if capture_gpu else "0"
+    if capture_gpu:
+        wrapper = Path(__file__).with_name("run_traced.sh")
+        runner = [
+            "bash",
+            str(wrapper),
+            str(shard_dir),
+            represented_job_key,
+            *runner,
+        ]
+    return subprocess.run(runner, cwd=command_cwd, env=environment, check=False)
+
+
+def _job_document(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return document if isinstance(document, dict) else None
+
+
+def _run_uninstrumented(command: str, cwd: Path) -> subprocess.CompletedProcess[Any]:
+    print(
+        "Trace collector did not start the command; running it uninstrumented.",
+        file=sys.stderr,
+    )
+    return subprocess.run(
+        ["bash", "-lc", command],
+        cwd=cwd,
+        env=dict(os.environ),
+        check=False,
+    )
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    commands = decode_commands(args.commands_base64)
+    output_dir = args.output_dir.resolve()
+    repo_root = args.repo_root.resolve()
+    command_cwd = Path.cwd().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    command_results = []
+    return_code = 0
+    for index, command in enumerate(commands):
+        collector_error = None
+        try:
+            result = _run_command(
+                command,
+                command_index=index,
+                job_key=args.job_key,
+                command_cwd=command_cwd,
+                output_dir=output_dir,
+                repo_root=repo_root,
+                represented_job_key=args.represented_job_key,
+                capture_gpu=args.capture_gpu,
+            )
+        except Exception as error:
+            collector_error = f"{type(error).__name__}: {error}"
+            result = subprocess.CompletedProcess([], 1)
+        command_output = output_dir / "commands" / f"{index:03d}"
+        shard_job = _job_document(command_output / "job.json")
+        command_status = _job_document(command_output / "command-status.json")
+        command_executed = bool(shard_job and shard_job.get("command_executed"))
+        command_exit_code = (
+            _shell_exit_code(int(shard_job["pytest_exit_code"]))
+            if command_executed and isinstance(shard_job.get("pytest_exit_code"), int)
+            else None
+        )
+        if (
+            command_exit_code is None
+            and command_status
+            and command_status.get("command_executed") is True
+            and command_status.get("phase") == "finished"
+            and isinstance(command_status.get("exit_code"), int)
+        ):
+            command_executed = True
+            command_exit_code = _shell_exit_code(int(command_status["exit_code"]))
+        command_started = bool(
+            command_status
+            and command_status.get("command_executed") is True
+            and command_status.get("phase") in ("started", "finished")
+        )
+        fallback_uninstrumented = False
+        if (
+            args.preserve_command_exit_code
+            and command_exit_code is None
+            and not command_started
+        ):
+            fallback = _run_uninstrumented(command, command_cwd)
+            command_exit_code = _shell_exit_code(fallback.returncode)
+            fallback_uninstrumented = True
+        collector_exit_code = _shell_exit_code(result.returncode)
+        effective_exit_code = (
+            command_exit_code
+            if args.preserve_command_exit_code and command_exit_code is not None
+            else collector_exit_code
+        )
+        command_results.append(
+            {
+                "command_index": index,
+                "command_sha256": hashlib.sha256(command.encode("utf-8")).hexdigest(),
+                "collector_error": collector_error,
+                "collector_exit_code": collector_exit_code,
+                "command_exit_code": command_exit_code,
+                "fallback_uninstrumented": fallback_uninstrumented,
+                "healthy": bool(
+                    collector_exit_code == 0
+                    and shard_job
+                    and shard_job.get("healthy") is True
+                ),
+            }
+        )
+        if effective_exit_code != 0:
+            return_code = effective_exit_code
+            break
+
+    healthy = len(command_results) == len(commands) and all(
+        result["command_exit_code"] == 0 and result["healthy"]
+        for result in command_results
+    )
+    summary_path = output_dir / "trace-job.json"
+    try:
+        parallel_job = int(os.environ.get("BUILDKITE_PARALLEL_JOB", "0"))
+        parallel_job_count = int(os.environ.get("BUILDKITE_PARALLEL_JOB_COUNT", "1"))
+        _atomic_json(
+            summary_path,
+            {
+                "capture_mode": "gpu" if args.capture_gpu else "python-only",
+                "collector_sha256": os.environ.get(
+                    "VLLM_CI_TEST_SELECTION_COLLECTOR_SHA256"
+                ),
+                "collector_version": COLLECTOR_VERSION,
+                "command_count": len(commands),
+                "command_results": command_results,
+                "created_at": datetime.now(UTC).isoformat(),
+                "healthy": healthy,
+                "job_key": args.job_key,
+                "parallel_job": parallel_job,
+                "parallel_job_count": parallel_job_count,
+                "repository_sha": os.environ.get("BUILDKITE_COMMIT"),
+                "represented_job_key": args.represented_job_key,
+            },
+        )
+    except Exception as error:
+        print(
+            "test-selection collector job summary failed: "
+            f"{type(error).__name__}: {error}",
+            file=sys.stderr,
+        )
+        healthy = False
+    if not healthy and return_code == 0 and not args.preserve_command_exit_code:
+        return_code = 1
+    return return_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/buildkite/pipeline_generator/test_selection/collector/run_trace.py
+++ b/buildkite/pipeline_generator/test_selection/collector/run_trace.py
@@ -10,6 +10,8 @@ import base64
 import hashlib
 import json
 import os
+import shlex
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -204,6 +206,38 @@ def _command_environment(
     return environment
 
 
+def _collector_import_root() -> Path:
+    """Return the path that makes this collector's top-level package importable."""
+
+    package = __package__ or "ci_test_selection"
+    return Path(__file__).resolve().parents[len(package.split("."))]
+
+
+def _install_pytest_launcher(
+    directory: Path,
+    environment: dict[str, str],
+) -> None:
+    """Keep collector plugins importable across command-local PYTHONPATH changes."""
+
+    real_pytest = shutil.which("pytest", path=environment.get("PATH"))
+    if real_pytest:
+        target = f'{shlex.quote(real_pytest)} "$@"'
+    else:
+        target = f'{shlex.quote(sys.executable)} -m pytest "$@"'
+    collector_root = shlex.quote(str(_collector_import_root()))
+    launcher = directory / "pytest"
+    launcher.write_text(
+        "#!/bin/sh\n"
+        f"export PYTHONPATH={collector_root}${{PYTHONPATH:+:$PYTHONPATH}}\n"
+        f"exec {target}\n",
+        encoding="utf-8",
+    )
+    launcher.chmod(0o755)
+    environment["PATH"] = os.pathsep.join(
+        value for value in (str(directory), environment.get("PATH")) if value
+    )
+
+
 _IMPORT_PREFLIGHT = r"""
 import importlib
 import json
@@ -309,11 +343,21 @@ def validate_import_environment(
             pytest_environment["VLLM_CI_TEST_SELECTION_NODEIDS"] = str(
                 pytest_preflight_dir / "pytest-nodes.json"
             )
+            # Exercise the same direct ``pytest`` launcher used by production
+            # commands after replacing PYTHONPATH, which catches command-local
+            # assignments such as ``PYTHONPATH=/vllm-workspace pytest ...``.
+            pytest_environment["PYTHONPATH"] = str(repo_root.resolve())
+            pytest_launcher = shutil.which(
+                "pytest", path=pytest_environment.get("PATH")
+            )
+            preflight_command = (
+                [pytest_launcher]
+                if pytest_launcher
+                else [sys.executable, "-m", "pytest"]
+            )
             pytest_result = subprocess.run(
                 [
-                    sys.executable,
-                    "-m",
-                    "pytest",
+                    *preflight_command,
                     "--collect-only",
                     "--quiet",
                     str(pytest_target),
@@ -380,54 +424,64 @@ def main() -> int:
     command_status_file = output_dir / "command-status.json"
     repository_sha = _git_sha(args.repo_root)
 
-    environment = _command_environment(
-        coverage_file=coverage_file,
-        node_file=node_file,
-        repo_root=args.repo_root,
-        auto_load_pytest=bool(args.command_base64),
-    )
-    command_cwd = (args.command_cwd or args.repo_root).resolve()
-    if args.command_base64:
-        command_text = _decode_command(args.command_base64)
-        command = ["bash", "-lc", command_text]
-    else:
-        command_text = None
-        command = pytest_command(tests)
-    preflight_status = validate_import_environment(
-        command_cwd=command_cwd,
-        environment=environment,
-        output_path=output_dir / "import-environment.json",
-        repo_root=args.repo_root,
-    )
-    if preflight_status == 0:
-        _atomic_json(
-            command_status_file,
-            {
-                "command_executed": True,
-                "created_at": datetime.now(UTC).isoformat(),
-                "exit_code": None,
-                "phase": "started",
-            },
+    with tempfile.TemporaryDirectory(
+        prefix=".pytest-launcher-", dir=output_dir
+    ) as launcher_directory:
+        environment = _command_environment(
+            coverage_file=coverage_file,
+            node_file=node_file,
+            repo_root=args.repo_root,
+            auto_load_pytest=bool(args.command_base64),
         )
-        result = subprocess.run(
-            command,
-            cwd=command_cwd,
-            env=environment,
-            check=False,
+        command_cwd = (args.command_cwd or args.repo_root).resolve()
+        if args.command_base64:
+            command_text = _decode_command(args.command_base64)
+            launcher_path = Path(launcher_directory)
+            _install_pytest_launcher(launcher_path, environment)
+            command = [
+                "bash",
+                "-lc",
+                f'export PATH={shlex.quote(str(launcher_path))}:"$PATH"; '
+                + command_text,
+            ]
+        else:
+            command_text = None
+            command = pytest_command(tests)
+        preflight_status = validate_import_environment(
+            command_cwd=command_cwd,
+            environment=environment,
+            output_path=output_dir / "import-environment.json",
+            repo_root=args.repo_root,
         )
-        command_exit_code = _shell_exit_code(result.returncode)
-        _atomic_json(
-            command_status_file,
-            {
-                "command_executed": True,
-                "created_at": datetime.now(UTC).isoformat(),
-                "exit_code": command_exit_code,
-                "phase": "finished",
-            },
-        )
-    else:
-        result = subprocess.CompletedProcess(command, preflight_status)
-        command_exit_code = preflight_status
+        if preflight_status == 0:
+            _atomic_json(
+                command_status_file,
+                {
+                    "command_executed": True,
+                    "created_at": datetime.now(UTC).isoformat(),
+                    "exit_code": None,
+                    "phase": "started",
+                },
+            )
+            result = subprocess.run(
+                command,
+                cwd=command_cwd,
+                env=environment,
+                check=False,
+            )
+            command_exit_code = _shell_exit_code(result.returncode)
+            _atomic_json(
+                command_status_file,
+                {
+                    "command_executed": True,
+                    "created_at": datetime.now(UTC).isoformat(),
+                    "exit_code": command_exit_code,
+                    "phase": "finished",
+                },
+            )
+        else:
+            result = subprocess.CompletedProcess(command, preflight_status)
+            command_exit_code = preflight_status
     command_executed = preflight_status == 0
 
     rows = (
@@ -447,6 +501,11 @@ def main() -> int:
         and bool(node_document["collected"])
         and coverage_file.exists()
     )
+    failure_reason = None
+    if preflight_status != 0:
+        failure_reason = "collector_import_failed"
+    elif not healthy:
+        failure_reason = "collector_unhealthy"
     _atomic_json(
         job_file,
         {
@@ -460,6 +519,7 @@ def main() -> int:
             "command_cwd": str(command_cwd),
             "command_executed": command_executed,
             "created_at": datetime.now(UTC).isoformat(),
+            "failure_reason": failure_reason,
             "healthy": healthy,
             "image_tag": os.environ.get("IMAGE_TAG"),
             "import_preflight_exit_code": preflight_status,

--- a/buildkite/pipeline_generator/test_selection/collector/run_trace.py
+++ b/buildkite/pipeline_generator/test_selection/collector/run_trace.py
@@ -1,0 +1,481 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Run a bounded pytest pilot and export per-test Python line coverage."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from coverage import CoverageData
+
+from . import COLLECTOR_VERSION
+
+
+def _atomic_json(path: Path, document: Any) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def _atomic_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    with temporary.open("w", encoding="utf-8") as stream:
+        for row in rows:
+            stream.write(json.dumps(row, sort_keys=True, separators=(",", ":")))
+            stream.write("\n")
+    temporary.replace(path)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _shell_exit_code(returncode: int) -> int:
+    return 128 - returncode if returncode < 0 else returncode
+
+
+def _git_sha(repo_root: Path) -> str:
+    configured = os.environ.get("BUILDKITE_COMMIT")
+    if configured:
+        return configured
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def normalize_repository_path(filename: str, repo_root: Path) -> str | None:
+    """Map source/install paths to a repository-relative ``vllm/...`` path."""
+
+    path = Path(filename).resolve()
+    try:
+        relative = path.relative_to(repo_root.resolve())
+    except ValueError:
+        relative = None
+    if relative is not None and relative.parts and relative.parts[0] == "vllm":
+        return relative.as_posix()
+
+    parts = path.parts
+    for index, part in enumerate(parts):
+        if part == "vllm":
+            candidate = Path(*parts[index:]).as_posix()
+            if candidate.startswith("vllm/"):
+                return candidate
+    return None
+
+
+def _node_id(context: str) -> str | None:
+    if not context or context == "":
+        return None
+    node_id, separator, phase = context.rpartition("|")
+    if separator and phase in {"run", "setup", "teardown"}:
+        return node_id
+    return None
+
+
+def coverage_rows(
+    coverage_file: Path,
+    repo_root: Path,
+    *,
+    repository_sha: str,
+    job_key: str,
+) -> list[dict[str, Any]]:
+    data = CoverageData(basename=str(coverage_file))
+    data.read()
+    rows: set[tuple[str, str, int]] = set()
+    for filename in data.measured_files():
+        repository_path = normalize_repository_path(filename, repo_root)
+        if repository_path is None:
+            continue
+        for line, contexts in data.contexts_by_lineno(filename).items():
+            for context in contexts:
+                node_id = _node_id(context)
+                if node_id:
+                    rows.add((node_id, repository_path, int(line)))
+
+    return [
+        {
+            "collector_version": COLLECTOR_VERSION,
+            "file": file,
+            "job_key": job_key,
+            "line": line,
+            "repository_sha": repository_sha,
+            "test_id": test_id,
+        }
+        for test_id, file, line in sorted(rows)
+    ]
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--job-key", required=True)
+    parser.add_argument("--represented-job-key", required=True)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--command-base64")
+    parser.add_argument("--command-cwd", type=Path)
+    parser.add_argument("tests", nargs=argparse.REMAINDER)
+    return parser
+
+
+def pytest_command(tests: list[str]) -> list[str]:
+    package = __package__ or "ci_test_selection"
+    return [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-p",
+        f"{package}.pytest_trace_plugin",
+        "-p",
+        f"{package}.nvtx_test_ranges",
+        "--cov=vllm",
+        "--cov-context=test",
+        "--cov-report=",
+        *tests,
+    ]
+
+
+def _decode_command(value: str) -> str:
+    try:
+        return base64.b64decode(value, validate=True).decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as error:
+        message = "--command-base64 must contain base64-encoded UTF-8"
+        raise SystemExit(message) from error
+
+
+def _command_environment(
+    *,
+    coverage_file: Path,
+    node_file: Path,
+    repo_root: Path,
+    auto_load_pytest: bool,
+) -> dict[str, str]:
+    environment = dict(os.environ)
+    environment["COVERAGE_FILE"] = str(coverage_file)
+    environment["VLLM_CI_TEST_SELECTION_NODEIDS"] = str(node_file)
+
+    if auto_load_pytest:
+        package = __package__ or "ci_test_selection"
+        environment["VLLM_CI_TEST_SELECTION_PACKAGE"] = package
+        plugins = [
+            f"{package}.pytest_trace_plugin",
+            f"{package}.nvtx_test_ranges",
+        ]
+        configured_plugins = environment.get("PYTEST_PLUGINS")
+        if configured_plugins:
+            plugins.append(configured_plugins)
+        environment["PYTEST_PLUGINS"] = ",".join(plugins)
+
+    trace_options = (
+        "--cov=vllm --cov-context=test --cov-append --cov-report="
+        if auto_load_pytest
+        else ""
+    )
+    existing_options = environment.get("PYTEST_ADDOPTS", "")
+    environment["PYTEST_ADDOPTS"] = " ".join(
+        option for option in (existing_options, trace_options) if option
+    )
+    existing_pythonpath = environment.get("PYTHONPATH")
+    environment["PYTHONPATH"] = os.pathsep.join(
+        value for value in (str(repo_root), existing_pythonpath) if value
+    )
+    return environment
+
+
+_IMPORT_PREFLIGHT = r"""
+import importlib
+import json
+import os
+from pathlib import Path
+import sys
+
+document = {
+    "error": None,
+    "sys_executable": sys.executable,
+    "sys_path": sys.path,
+    "vllm_file": None,
+}
+try:
+    import coverage
+    import pytest
+    import pytest_cov
+
+    package = os.environ.get("VLLM_CI_TEST_SELECTION_PACKAGE")
+    if package:
+        importlib.import_module(f"{package}.pytest_trace_plugin")
+        importlib.import_module(f"{package}.nvtx_test_ranges")
+    import vllm
+
+    resolved = Path(vllm.__file__).resolve()
+    document["vllm_file"] = str(resolved)
+    checkout_value = os.environ.get("BUILDKITE_BUILD_CHECKOUT_PATH")
+    expected_root_value = os.environ.get("VLLM_CI_TEST_SELECTION_REPO_ROOT")
+    if checkout_value and expected_root_value:
+        checkout = Path(checkout_value).resolve()
+        expected_root = Path(expected_root_value).resolve()
+        try:
+            resolved.relative_to(checkout)
+        except ValueError:
+            pass
+        else:
+            if expected_root != checkout:
+                document["error"] = "image job imported vllm from checkout source"
+except Exception as error:
+    document["error"] = f"{type(error).__name__}: {error}"
+
+print(json.dumps(document, sort_keys=True, separators=(",", ":")))
+raise SystemExit(1 if document["error"] else 0)
+"""
+
+
+def validate_import_environment(
+    *,
+    command_cwd: Path,
+    environment: dict[str, str],
+    output_path: Path,
+    repo_root: Path,
+) -> int:
+    """Prove the traced command imports the image's vLLM, not checkout source."""
+
+    preflight_environment = dict(environment)
+    preflight_environment["VLLM_CI_TEST_SELECTION_REPO_ROOT"] = str(repo_root.resolve())
+    result = subprocess.run(
+        [sys.executable, "-c", _IMPORT_PREFLIGHT],
+        cwd=command_cwd,
+        env=preflight_environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    stdout = result.stdout.strip()
+    stderr = result.stderr.strip()
+    if stdout:
+        print(f"trace import preflight: {stdout}")
+    if stderr:
+        print(stderr, file=sys.stderr)
+    try:
+        document = json.loads(stdout.splitlines()[-1])
+    except (IndexError, json.JSONDecodeError):
+        document = {
+            "error": "import preflight did not emit valid JSON",
+            "stderr": stderr,
+            "stdout": stdout,
+        }
+    status = _shell_exit_code(result.returncode)
+    document["import_exit_code"] = status
+    document["pytest_plugin_exit_code"] = None
+    if status == 0:
+        pytest_environment = dict(preflight_environment)
+        # ``pytest --help`` exits before pluggy validates hooks and before
+        # pytest parses every injected option. Collect one inert test under the
+        # exact command environment so a bad plugin or unavailable option
+        # triggers the uninstrumented fallback before the production command
+        # is marked started. Keep all preflight evidence in a temporary
+        # directory so collection cannot contaminate the real trace outputs.
+        with tempfile.TemporaryDirectory(
+            prefix=".pytest-preflight-", dir=output_path.parent
+        ) as temporary_directory:
+            pytest_preflight_dir = Path(temporary_directory)
+            pytest_target = pytest_preflight_dir / "test_preflight.py"
+            pytest_target.write_text(
+                "def test_vllm_ci_test_selection_preflight():\n    pass\n",
+                encoding="utf-8",
+            )
+            pytest_environment["COVERAGE_FILE"] = str(
+                pytest_preflight_dir / ".coverage"
+            )
+            pytest_environment["VLLM_CI_TEST_SELECTION_NODEIDS"] = str(
+                pytest_preflight_dir / "pytest-nodes.json"
+            )
+            pytest_result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pytest",
+                    "--collect-only",
+                    "--quiet",
+                    str(pytest_target),
+                ],
+                cwd=command_cwd,
+                env=pytest_environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        status = _shell_exit_code(pytest_result.returncode)
+        document["pytest_plugin_exit_code"] = status
+        if status != 0:
+            stderr = pytest_result.stderr.strip()
+            document["error"] = "pytest plugin/options preflight failed"
+            document["pytest_stderr"] = stderr
+            if stderr:
+                print(stderr, file=sys.stderr)
+    document["exit_code"] = status
+    _atomic_json(output_path, document)
+    return status
+
+
+def _merge_node_documents(output_dir: Path, node_file: Path) -> dict[str, Any]:
+    documents = []
+    for path in sorted(output_dir.glob("pytest-nodes*.json")):
+        documents.append(json.loads(path.read_text(encoding="utf-8")))
+    if not documents:
+        return {"collected": [], "exit_status": None, "outcomes": {}}
+
+    collected: set[str] = set()
+    outcomes: dict[str, dict[str, str]] = {}
+    exit_statuses: list[int] = []
+    for document in documents:
+        collected.update(document.get("collected", []))
+        for node_id, phases in document.get("outcomes", {}).items():
+            outcomes.setdefault(node_id, {}).update(phases)
+        if document.get("exit_status") is not None:
+            exit_statuses.append(int(document["exit_status"]))
+
+    merged = {
+        "collected": sorted(collected),
+        "exit_status": max(exit_statuses, default=None),
+        "outcomes": {node_id: outcomes[node_id] for node_id in sorted(outcomes)},
+    }
+    _atomic_json(node_file, merged)
+    return merged
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    tests = args.tests[1:] if args.tests[:1] == ["--"] else args.tests
+    if bool(tests) == bool(args.command_base64):
+        raise SystemExit(
+            "provide exactly one of --command-base64 or pytest targets after --"
+        )
+
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    coverage_file = output_dir / ".coverage"
+    node_file = output_dir / "pytest-nodes.json"
+    trace_file = output_dir / "python-trace.jsonl"
+    job_file = output_dir / "job.json"
+    command_status_file = output_dir / "command-status.json"
+    repository_sha = _git_sha(args.repo_root)
+
+    environment = _command_environment(
+        coverage_file=coverage_file,
+        node_file=node_file,
+        repo_root=args.repo_root,
+        auto_load_pytest=bool(args.command_base64),
+    )
+    command_cwd = (args.command_cwd or args.repo_root).resolve()
+    if args.command_base64:
+        command_text = _decode_command(args.command_base64)
+        command = ["bash", "-lc", command_text]
+    else:
+        command_text = None
+        command = pytest_command(tests)
+    preflight_status = validate_import_environment(
+        command_cwd=command_cwd,
+        environment=environment,
+        output_path=output_dir / "import-environment.json",
+        repo_root=args.repo_root,
+    )
+    if preflight_status == 0:
+        _atomic_json(
+            command_status_file,
+            {
+                "command_executed": True,
+                "created_at": datetime.now(UTC).isoformat(),
+                "exit_code": None,
+                "phase": "started",
+            },
+        )
+        result = subprocess.run(
+            command,
+            cwd=command_cwd,
+            env=environment,
+            check=False,
+        )
+        command_exit_code = _shell_exit_code(result.returncode)
+        _atomic_json(
+            command_status_file,
+            {
+                "command_executed": True,
+                "created_at": datetime.now(UTC).isoformat(),
+                "exit_code": command_exit_code,
+                "phase": "finished",
+            },
+        )
+    else:
+        result = subprocess.CompletedProcess(command, preflight_status)
+        command_exit_code = preflight_status
+    command_executed = preflight_status == 0
+
+    rows = (
+        coverage_rows(
+            coverage_file,
+            args.repo_root,
+            repository_sha=repository_sha,
+            job_key=args.represented_job_key,
+        )
+        if coverage_file.exists()
+        else []
+    )
+    _atomic_jsonl(trace_file, rows)
+    node_document = _merge_node_documents(output_dir, node_file)
+    healthy = (
+        command_exit_code == 0
+        and bool(node_document["collected"])
+        and coverage_file.exists()
+    )
+    _atomic_json(
+        job_file,
+        {
+            "child_process_attribution": False,
+            "collector_version": COLLECTOR_VERSION,
+            "command_sha256": (
+                hashlib.sha256(command_text.encode("utf-8")).hexdigest()
+                if command_text is not None
+                else None
+            ),
+            "command_cwd": str(command_cwd),
+            "command_executed": command_executed,
+            "created_at": datetime.now(UTC).isoformat(),
+            "healthy": healthy,
+            "image_tag": os.environ.get("IMAGE_TAG"),
+            "import_preflight_exit_code": preflight_status,
+            "job_key": args.job_key,
+            "node_ids": node_document["collected"],
+            "pytest_exit_code": command_exit_code,
+            "python_trace": trace_file.name,
+            "python_trace_rows": len(rows),
+            "python_trace_sha256": _sha256(trace_file),
+            "repository_sha": repository_sha,
+            "represented_job_key": args.represented_job_key,
+        },
+    )
+    coverage_file.unlink(missing_ok=True)
+    return command_exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/buildkite/pipeline_generator/test_selection/collector/run_traced.sh
+++ b/buildkite/pipeline_generator/test_selection/collector/run_traced.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Capture only CUDA launches and pytest NVTX ranges, reduce them immediately to
+# an unordered kernel/test set, then delete the temporary Nsight timeline.
+set -euo pipefail
+
+NSYS_DEB_URL="https://developer.download.nvidia.com/devtools/repos/ubuntu2204/amd64/NsightSystems-linux-cli-public-2026.3.1.157-3804839.deb"
+NSYS_DEB_SHA256="3eb87ec08e5f8b8f153537847747bd5cfabb51b9c8793873b26a3c55dc813ad1"
+
+if (( $# < 3 )); then
+    echo "usage: $0 <output-dir> <represented-job-key> <command...>" >&2
+    exit 2
+fi
+
+OUT_DIR="$1"
+REPRESENTED_JOB_KEY="$2"
+shift 2
+mkdir -p "$OUT_DIR"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ ! "${BUILDKITE_COMMIT:-}" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "BUILDKITE_COMMIT must be an exact Git SHA" >&2
+    exit 2
+fi
+
+install_seconds=0
+if ! command -v nsys >/dev/null; then
+    install_start=$(date +%s)
+    deb="$(mktemp /tmp/nsys-cli-XXXX.deb)"
+    curl -fsSL -o "$deb" "$NSYS_DEB_URL"
+    echo "$NSYS_DEB_SHA256  $deb" | sha256sum -c -
+    apt-get update -qq
+    apt-get install -y -qq libglib2.0-0
+    dpkg -i "$deb"
+    rm -f "$deb"
+    install_seconds=$(( $(date +%s) - install_start ))
+fi
+
+traced_start=$(date +%s)
+set +e
+nsys profile \
+    --trace=cuda,nvtx --sample=none --cpuctxsw=none \
+    --trace-fork-before-exec=true \
+    --output "$OUT_DIR/trace" --force-overwrite=true \
+    -- "$@"
+profile_status=$?
+set -e
+traced_seconds=$(( $(date +%s) - traced_start ))
+
+parse_status=0
+created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+if [[ -s "$OUT_DIR/trace.nsys-rep" ]]; then
+    set +e
+    nsys export --type sqlite \
+        --output "$OUT_DIR/trace.sqlite" \
+        --force-overwrite=true "$OUT_DIR/trace.nsys-rep"
+    export_status=$?
+    if (( export_status == 0 )); then
+        python3 "$HERE/parse_nsys_sqlite.py" "$OUT_DIR/trace.sqlite" \
+            --job-key "$REPRESENTED_JOB_KEY" \
+            --repository-sha "$BUILDKITE_COMMIT" \
+            --created-at "$created_at" \
+            --out "$OUT_DIR/gpu-trace.jsonl" \
+            2> "$OUT_DIR/kernel-capture-summary.json"
+        parse_status=$?
+    else
+        parse_status=$export_status
+        printf '{"error":"nsys export failed","exit_code":%d}\n' \
+            "$export_status" > "$OUT_DIR/kernel-capture-summary.json"
+    fi
+    set -e
+else
+    parse_status=1
+    printf '{"error":"nsys profile produced no report","exit_code":%d}\n' \
+        "$profile_status" > "$OUT_DIR/kernel-capture-summary.json"
+fi
+
+# The selector consumes only the compact identity set. Do not upload or retain
+# the temporary profiler timeline.
+rm -f "$OUT_DIR/trace.nsys-rep" "$OUT_DIR/trace.sqlite"
+
+printf '{"collector_install_seconds":%d,"parse_exit_code":%d,"profile_exit_code":%d,"traced_wall_seconds":%d}\n' \
+    "$install_seconds" "$parse_status" "$profile_status" "$traced_seconds" \
+    > "$OUT_DIR/kernel-capture-timings.json"
+cat "$OUT_DIR/kernel-capture-summary.json" \
+    "$OUT_DIR/kernel-capture-timings.json"
+
+if (( profile_status != 0 )); then
+    exit "$profile_status"
+fi
+exit "$parse_status"

--- a/buildkite/pipeline_generator/test_selection/collector_bundle.py
+++ b/buildkite/pipeline_generator/test_selection/collector_bundle.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Build the exact minimal runtime collector shipped by pipeline generation."""
+
+from __future__ import annotations
+
+import hashlib
+from io import BytesIO
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
+
+TRACE_COLLECTOR_DOWNLOAD_ATTEMPTS = 12
+TRACE_COLLECTOR_DOWNLOAD_INTERVAL_SECONDS = 5
+
+
+def download_prelude(directory: str) -> str:
+    """Return a bounded artifact poll that never becomes a Buildkite edge."""
+
+    archive = f"{directory}/test-selection-collector.zip"
+    attempts = " ".join(
+        str(attempt) for attempt in range(1, TRACE_COLLECTOR_DOWNLOAD_ATTEMPTS + 1)
+    )
+    return (
+        "TRACE_COLLECTOR_READY=0; "
+        "if command -v buildkite-agent >/dev/null 2>&1; then "
+        f"for TRACE_COLLECTOR_ATTEMPT in {attempts}; do "
+        f'rm -f "{archive}"; '
+        'if buildkite-agent artifact download "test-selection-collector.zip" '
+        f'"{directory}"; then TRACE_COLLECTOR_READY=1; break; fi; '
+        'if [ "$$TRACE_COLLECTOR_ATTEMPT" -lt '
+        f"{TRACE_COLLECTOR_DOWNLOAD_ATTEMPTS} ]; then "
+        f"sleep {TRACE_COLLECTOR_DOWNLOAD_INTERVAL_SECONDS}; fi; "
+        "done; fi; "
+    )
+
+
+def bundle_bytes() -> bytes:
+    source = Path(__file__).with_name("collector")
+    files = sorted(
+        path
+        for path in source.iterdir()
+        if path.suffix == ".py" or path.name.endswith(".sh")
+    )
+    if not files:
+        raise RuntimeError("test-selection collector package is empty")
+
+    output = BytesIO()
+    with ZipFile(output, "w") as archive:
+        for path in files:
+            info = ZipInfo(
+                filename=f"ci_test_selection/{path.name}",
+                date_time=(1980, 1, 1, 0, 0, 0),
+            )
+            info.compress_type = ZIP_DEFLATED
+            info.external_attr = 0o644 << 16
+            archive.writestr(info, path.read_bytes(), compresslevel=9)
+    return output.getvalue()
+
+
+def bundle_sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()

--- a/buildkite/pipeline_generator/test_selection/graph.py
+++ b/buildkite/pipeline_generator/test_selection/graph.py
@@ -213,7 +213,17 @@ def _materialize(
                 document.get("healthy") is not True
                 for _path, document in summaries[key].values()
             ):
-                status, reason = "unhealthy", invalid.get(key, "collector_unhealthy")
+                summary_reasons = {
+                    str(document["failure_reason"])
+                    for _path, document in summaries[key].values()
+                    if document.get("failure_reason")
+                }
+                reason = invalid.get(key) or (
+                    next(iter(summary_reasons))
+                    if len(summary_reasons) == 1
+                    else "collector_unhealthy"
+                )
+                status = "unhealthy"
                 unhealthy.append(key)
             else:
                 try:

--- a/buildkite/pipeline_generator/test_selection/graph.py
+++ b/buildkite/pipeline_generator/test_selection/graph.py
@@ -1,0 +1,519 @@
+"""Build and query the compact file/test/job trace database."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from test_selection import SCHEMA_VERSION
+
+
+SCHEMA = """
+CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL) WITHOUT ROWID;
+CREATE TABLE evidence (
+    source_kind TEXT NOT NULL,
+    source TEXT NOT NULL,
+    test_id TEXT NOT NULL,
+    job_key TEXT NOT NULL,
+    line INTEGER NOT NULL,
+    PRIMARY KEY (source_kind, source, test_id, job_key, line)
+) WITHOUT ROWID;
+CREATE INDEX evidence_source ON evidence(source_kind, source);
+CREATE TABLE jobs (
+    job_key TEXT PRIMARY KEY,
+    status TEXT NOT NULL,
+    reason TEXT
+) WITHOUT ROWID;
+"""
+
+
+class GraphError(RuntimeError):
+    pass
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_checksum(path: Path) -> Path:
+    sidecar = path.with_suffix(path.suffix + ".sha256")
+    sidecar.write_text(sha256_file(path) + "\n", encoding="ascii")
+    return sidecar
+
+
+def verify_checksum(path: Path) -> None:
+    sidecar = path.with_suffix(path.suffix + ".sha256")
+    if not sidecar.is_file() or sidecar.read_text(
+        encoding="ascii"
+    ).strip() != sha256_file(path):
+        raise GraphError("graph checksum mismatch")
+
+
+def _json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise GraphError(f"cannot read {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise GraphError(f"{path} must contain a JSON object")
+    return value
+
+
+def _jsonl(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                row = json.loads(line)
+                if not isinstance(row, dict):
+                    raise GraphError(f"{path} contains a non-object row")
+                rows.append(row)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise GraphError(f"cannot read {path}: {error}") from error
+    return rows
+
+
+def _timestamp(value: Any) -> datetime:
+    try:
+        result = datetime.fromisoformat(str(value))
+    except ValueError as error:
+        raise GraphError("trace timestamp is invalid") from error
+    if result.tzinfo is None:
+        raise GraphError("trace timestamp has no timezone")
+    return result.astimezone(timezone.utc)
+
+
+def _sha(value: Any) -> str:
+    value = str(value)
+    if not re.fullmatch(r"[0-9a-f]{40}", value):
+        raise GraphError("repository SHA must be exact lowercase 40-hex")
+    return value
+
+
+def _insert_python(
+    connection: sqlite3.Connection,
+    manifest_path: Path,
+    repository_sha: str,
+    job_key: str,
+) -> None:
+    manifest = _json(manifest_path)
+    if manifest.get("repository_sha") != repository_sha:
+        raise GraphError(f"{manifest_path} repository SHA mismatch")
+    if manifest.get("represented_job_key") != job_key or not manifest.get("healthy"):
+        raise GraphError(f"{manifest_path} is not healthy evidence for {job_key}")
+    trace = manifest_path.parent / str(manifest.get("python_trace", ""))
+    if not trace.is_file() or sha256_file(trace) != manifest.get("python_trace_sha256"):
+        raise GraphError(f"{manifest_path} Python trace checksum mismatch")
+    rows = _jsonl(trace)
+    if not rows:
+        raise GraphError(f"{trace} contains no Python evidence")
+    for row in rows:
+        if row.get("repository_sha") != repository_sha or row.get("job_key") != job_key:
+            raise GraphError(f"{trace} identity mismatch")
+        connection.execute(
+            "INSERT OR IGNORE INTO evidence VALUES ('file', ?, ?, ?, ?)",
+            (str(row["file"]), str(row["test_id"]), job_key, int(row["line"])),
+        )
+    for test_id in sorted(set(manifest.get("node_ids", []))):
+        connection.execute(
+            "INSERT OR IGNORE INTO evidence VALUES ('file', ?, ?, ?, -1)",
+            (str(test_id).split("::", 1)[0], str(test_id), job_key),
+        )
+
+
+def _insert_gpu(
+    connection: sqlite3.Connection,
+    directory: Path,
+    repository_sha: str,
+    job_key: str,
+) -> int:
+    count = 0
+    for path in sorted(directory.rglob("gpu-trace.jsonl")):
+        for row in _jsonl(path):
+            if (
+                row.get("repository_sha") != repository_sha
+                or row.get("job_key") != job_key
+            ):
+                raise GraphError(f"{path} identity mismatch")
+            destination_kind = row.get("destination_kind")
+            destination = str(row.get("destination", ""))
+            test_id = destination if destination_kind == "test" else ""
+            connection.execute(
+                "INSERT OR IGNORE INTO evidence VALUES ('kernel', ?, ?, ?, -1)",
+                (str(row["source"]), test_id, job_key),
+            )
+            count += 1
+    return count
+
+
+def _materialize(
+    input_dir: Path,
+    output: Path,
+    inventory: dict[str, Any],
+) -> dict[str, Any]:
+    repository_sha = _sha(inventory.get("repository_sha"))
+    collector_sha = str(inventory.get("collector_sha256", ""))
+    policies = {str(row["key"]): row for row in inventory.get("jobs", [])}
+    if not policies:
+        raise GraphError("trace inventory contains no jobs")
+    wait_results = inventory.get("wait_results", {})
+    summaries: dict[str, dict[int, tuple[Path, dict[str, Any]]]] = {
+        key: {} for key in policies
+    }
+    invalid: dict[str, str] = {}
+    for path in sorted(input_dir.rglob("trace-job.json")):
+        document = _json(path)
+        key = str(document.get("represented_job_key", ""))
+        if key not in policies:
+            continue
+        shard = document.get("parallel_job")
+        expected = policies[key].get("expected_shards")
+        if (
+            document.get("repository_sha") != repository_sha
+            or document.get("collector_sha256") != collector_sha
+            or not isinstance(shard, int)
+            or document.get("parallel_job_count") != expected
+            or shard in summaries[key]
+        ):
+            invalid[key] = "invalid_summary"
+            continue
+        summaries[key][shard] = (path, document)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_suffix(output.suffix + ".tmp")
+    temporary.unlink(missing_ok=True)
+    connection = sqlite3.connect(temporary)
+    healthy = []
+    missing = []
+    unhealthy = []
+    reasons: dict[str, str] = {}
+    evidence_times = []
+    try:
+        connection.executescript(SCHEMA)
+        for key, policy in sorted(policies.items()):
+            expected = set(range(int(policy["expected_shards"])))
+            actual = set(summaries[key])
+            wait = wait_results.get(key, {})
+            if wait.get("status") == "poll_timeout" or actual != expected:
+                status, reason = "missing", "poll_timeout" if wait else "missing_shard"
+                missing.append(key)
+            elif key in invalid or any(
+                document.get("healthy") is not True
+                for _path, document in summaries[key].values()
+            ):
+                status, reason = "unhealthy", invalid.get(key, "collector_unhealthy")
+                unhealthy.append(key)
+            else:
+                try:
+                    connection.execute("SAVEPOINT job")
+                    for summary_path, document in summaries[key].values():
+                        evidence_times.append(_timestamp(document.get("created_at")))
+                        for manifest in sorted(summary_path.parent.rglob("job.json")):
+                            _insert_python(connection, manifest, repository_sha, key)
+                        if policy.get("mode") == "kernel-set" and not _insert_gpu(
+                            connection, summary_path.parent, repository_sha, key
+                        ):
+                            raise GraphError("GPU job produced no kernel evidence")
+                    count = connection.execute(
+                        "SELECT COUNT(*) FROM evidence WHERE job_key = ?", (key,)
+                    ).fetchone()[0]
+                    if not count:
+                        raise GraphError("job produced no compact evidence")
+                    connection.execute("RELEASE job")
+                except Exception as error:
+                    connection.execute("ROLLBACK TO job")
+                    connection.execute("RELEASE job")
+                    status, reason = "unhealthy", type(error).__name__
+                    unhealthy.append(key)
+                else:
+                    status, reason = "healthy", None
+                    healthy.append(key)
+            reasons[key] = reason or ""
+            connection.execute(
+                "INSERT INTO jobs VALUES (?, ?, ?)", (key, status, reason)
+            )
+
+        if not healthy:
+            raise GraphError("trace generation contains no healthy jobs")
+        data_through = min(evidence_times).isoformat()
+        metadata = {
+            "always_run": inventory.get("always_run", []),
+            "ci_infra_revision": inventory.get("ci_infra_revision"),
+            "collector_sha256": collector_sha,
+            "created_at": data_through,
+            "data_through": data_through,
+            "expected_jobs": sorted(policies),
+            "healthy_jobs": sorted(healthy),
+            "missing_jobs": sorted(missing),
+            "missing_reasons": {key: reasons[key] for key in sorted(missing)},
+            "repository_sha": repository_sha,
+            "schema_version": SCHEMA_VERSION,
+            "unhealthy_jobs": sorted(unhealthy),
+            "unhealthy_reasons": {key: reasons[key] for key in sorted(unhealthy)},
+            "wait_results": wait_results,
+        }
+        for key, value in sorted(metadata.items()):
+            connection.execute(
+                "INSERT INTO metadata VALUES (?, ?)",
+                (key, json.dumps(value, sort_keys=True, separators=(",", ":"))),
+            )
+        connection.commit()
+        if connection.execute("PRAGMA integrity_check").fetchone() != ("ok",):
+            raise GraphError("SQLite integrity check failed")
+    except Exception:
+        connection.close()
+        temporary.unlink(missing_ok=True)
+        raise
+    connection.close()
+    temporary.replace(output)
+    write_checksum(output)
+    return metadata
+
+
+def build_fleet_graph(input_dir: Path, inventory: Path, output: Path) -> dict[str, Any]:
+    return _materialize(input_dir.resolve(), output.resolve(), _json(inventory))
+
+
+def build_graph(input_dir: Path, output: Path) -> dict[str, Any]:
+    summaries = [_json(path) for path in sorted(input_dir.rglob("trace-job.json"))]
+    if not summaries:
+        raise GraphError("input contains no trace-job summaries")
+    first = summaries[0]
+    jobs = {}
+    for document in summaries:
+        key = str(document.get("represented_job_key", ""))
+        jobs[key] = {
+            "expected_shards": document.get("parallel_job_count", 1),
+            "key": key,
+            "mode": "kernel-set"
+            if document.get("capture_mode") == "gpu"
+            else "python-only",
+        }
+    inventory = {
+        "always_run": [],
+        "ci_infra_revision": "local",
+        "collector_sha256": first.get("collector_sha256"),
+        "jobs": list(jobs.values()),
+        "repository_sha": first.get("repository_sha"),
+        "wait_results": {},
+    }
+    return _materialize(input_dir.resolve(), output.resolve(), inventory)
+
+
+def _connect(graph: Path) -> sqlite3.Connection:
+    verify_checksum(graph)
+    return sqlite3.connect(f"file:{graph.resolve()}?mode=ro", uri=True)
+
+
+def graph_metadata(graph: Path) -> dict[str, Any]:
+    with _connect(graph) as connection:
+        result = {
+            key: json.loads(value)
+            for key, value in connection.execute("SELECT key, value FROM metadata")
+        }
+    if result.get("schema_version") != SCHEMA_VERSION:
+        raise GraphError("unsupported graph schema")
+    return result
+
+
+def paths_to_jobs(graph: Path, source: str) -> list[list[dict[str, Any]]]:
+    with _connect(graph) as connection:
+        rows = connection.execute(
+            """SELECT DISTINCT test_id, job_key FROM evidence
+               WHERE source_kind = 'file' AND source = ? ORDER BY job_key, test_id""",
+            (source,),
+        ).fetchall()
+    return [
+        [
+            {"kind": "file", "name": source},
+            {"edge": "executed_by", "kind": "test", "name": test_id},
+            {"edge": "run_by", "kind": "job", "name": job_key},
+        ]
+        for test_id, job_key in rows
+    ]
+
+
+def changed_files(repo: Path, base: str, head: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACDMRTUXB", base, head],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return sorted(set(result.stdout.splitlines()))
+
+
+def read_current_jobs(path: Path) -> set[str]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError:
+        value = [line.strip() for line in text.splitlines() if line.strip()]
+    if not isinstance(value, list) or not all(
+        isinstance(item, str) and item for item in value
+    ):
+        raise GraphError("current jobs must be a JSON array or newline list")
+    if len(value) != len(set(value)):
+        raise GraphError("current jobs contain duplicates")
+    return set(value)
+
+
+def current_jobs_from_pipeline(path: Path) -> list[str]:
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict) or not isinstance(document.get("steps"), list):
+        raise GraphError("rendered pipeline must contain steps")
+    keys = []
+    for item in document["steps"]:
+        for step in item.get("steps", [item]) if isinstance(item, dict) else []:
+            if isinstance(step, dict) and step.get("key") and "commands" in step:
+                keys.append(str(step["key"]))
+    if not keys or len(keys) != len(set(keys)):
+        raise GraphError("rendered pipeline has missing or duplicate command keys")
+    return sorted(keys)
+
+
+def _healthy_jobs(graph: Path) -> set[str]:
+    with _connect(graph) as connection:
+        return {
+            str(row[0])
+            for row in connection.execute(
+                "SELECT job_key FROM jobs WHERE status='healthy'"
+            )
+        }
+
+
+def job_coverage(graph: Path, current_jobs_path: Path) -> dict[str, Any]:
+    current = read_current_jobs(current_jobs_path)
+    healthy = _healthy_jobs(graph)
+    return {
+        "covered_step_keys": sorted(current & healthy),
+        "current_count": len(current),
+        "dead_graph_step_keys": sorted(healthy - current),
+        "graph_count": len(healthy),
+        "uncovered_step_keys": sorted(current - healthy),
+    }
+
+
+def _docs_only(paths: list[str]) -> bool:
+    return bool(paths) and all(
+        path.startswith("docs/")
+        or path.endswith(".md")
+        or path in {"mkdocs.yml", "mkdocs.yaml"}
+        for path in paths
+    )
+
+
+def select_jobs(
+    graph: Path,
+    repo: Path,
+    base: str,
+    head: str,
+    current_jobs_path: Path,
+    max_snapshot_age_days: int = 11,
+) -> dict[str, Any]:
+    files = changed_files(repo, base, head)
+    current = read_current_jobs(current_jobs_path)
+    if not files:
+        return {
+            "changed_files": [],
+            "fallback": True,
+            "fallback_reason": "empty_diff",
+            "reasons": [],
+            "status": "fallback",
+            "step_keys": [],
+        }
+    if _docs_only(files):
+        return {
+            "changed_files": files,
+            "fallback": False,
+            "reasons": [],
+            "status": "docs_only",
+            "step_keys": [],
+            "uncovered_step_keys": sorted(current),
+        }
+
+    metadata = graph_metadata(graph)
+    snapshot_sha = str(metadata["repository_sha"])
+    ancestry = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", snapshot_sha, base],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if ancestry.returncode:
+        reason = "snapshot_not_ancestor"
+    else:
+        age = datetime.now(timezone.utc) - _timestamp(metadata["data_through"])
+        reason = (
+            "snapshot_stale" if age > timedelta(days=max_snapshot_age_days) else None
+        )
+    if reason:
+        return {
+            "changed_files": files,
+            "fallback": True,
+            "fallback_reason": reason,
+            "reasons": [],
+            "status": "fallback",
+            "step_keys": [],
+        }
+
+    selected = set()
+    reasons = []
+    unmapped = []
+    for filename in files:
+        paths = [
+            path
+            for path in paths_to_jobs(graph, filename)
+            if path[-1]["name"] in current
+        ]
+        if not paths:
+            unmapped.append(filename)
+            continue
+        for path in paths:
+            job = str(path[-1]["name"])
+            selected.add(job)
+            reasons.append(
+                {
+                    "analysis": "trace_presence",
+                    "changed_file": filename,
+                    "job": job,
+                    "path": [row["kind"] for row in path],
+                    "test": path[-2]["name"],
+                }
+            )
+    if unmapped:
+        return {
+            "changed_files": files,
+            "fallback": True,
+            "fallback_reason": "unmapped_changed_file",
+            "reasons": reasons,
+            "status": "fallback",
+            "step_keys": [],
+            "unmapped_files": sorted(unmapped),
+        }
+    uncovered = current - _healthy_jobs(graph)
+    selected.update(uncovered)
+    return {
+        "changed_files": files,
+        "fallback": False,
+        "reasons": sorted(
+            reasons, key=lambda row: (row["job"], row["changed_file"], row["test"])
+        ),
+        "status": "selected",
+        "step_keys": sorted(selected),
+        "uncovered_step_keys": sorted(uncovered),
+    }

--- a/buildkite/pipeline_generator/test_selection/snapshot.py
+++ b/buildkite/pipeline_generator/test_selection/snapshot.py
@@ -1,0 +1,531 @@
+"""Build, publish, and fetch immutable fleet trace snapshots."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional, Protocol
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+from test_selection.graph import (
+    GraphError,
+    build_fleet_graph,
+    graph_metadata,
+    sha256_file,
+    verify_checksum,
+)
+
+
+class ObjectStore(Protocol):
+    def head(self, key: str) -> Optional[dict[str, Any]]: ...
+
+    def download(self, key: str, destination: Path) -> None: ...
+
+    def upload(
+        self,
+        key: str,
+        source: Path,
+        *,
+        sha256: str,
+        if_match: Optional[str] = None,
+        if_none_match: bool = False,
+    ) -> None: ...
+
+
+class Boto3ObjectStore:
+    """S3 client shared by snapshot publication and fetch."""
+
+    def __init__(
+        self,
+        bucket: str,
+        *,
+        session=None,
+        client=None,
+    ):
+        if not re.fullmatch(r"[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]", bucket):
+            raise GraphError("invalid S3 bucket name")
+        self.bucket = bucket
+        self.session = session or boto3.session.Session()
+        self.client = client or self.session.client("s3")
+
+    @staticmethod
+    def _raise(operation: str, error: Exception) -> None:
+        if isinstance(error, ClientError):
+            code = str(error.response.get("Error", {}).get("Code", "unknown"))
+        else:
+            code = type(error).__name__
+        raise GraphError(f"AWS {operation} failed: {code}") from error
+
+    def head(self, key: str) -> Optional[dict[str, Any]]:
+        try:
+            document = self.client.head_object(Bucket=self.bucket, Key=key)
+        except ClientError as error:
+            code = str(error.response.get("Error", {}).get("Code", ""))
+            if code in ("404", "NoSuchKey", "NotFound"):
+                return None
+            self._raise("s3:HeadObject", error)
+        except BotoCoreError as error:
+            self._raise("s3:HeadObject", error)
+        return {
+            "etag": str(document.get("ETag", "")).strip('"'),
+            "metadata": document.get("Metadata", {}),
+            "size": document.get("ContentLength"),
+        }
+
+    def download(self, key: str, destination: Path) -> None:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = destination.with_suffix(destination.suffix + ".tmp")
+        try:
+            document = self.client.get_object(Bucket=self.bucket, Key=key)
+            body = document["Body"]
+            try:
+                with temporary.open("wb") as output:
+                    shutil.copyfileobj(body, output)
+            finally:
+                body.close()
+            os.replace(temporary, destination)
+        except (BotoCoreError, ClientError, KeyError, OSError) as error:
+            temporary.unlink(missing_ok=True)
+            if isinstance(error, (BotoCoreError, ClientError)):
+                self._raise("s3:GetObject", error)
+            raise GraphError("S3 get-object returned an invalid response") from error
+
+    def upload(
+        self,
+        key: str,
+        source: Path,
+        *,
+        sha256: str,
+        if_match: Optional[str] = None,
+        if_none_match: bool = False,
+    ) -> None:
+        arguments: dict[str, Any] = {
+            "Bucket": self.bucket,
+            "Key": key,
+            "Metadata": {"sha256": sha256},
+        }
+        if if_match:
+            arguments["IfMatch"] = if_match
+        if if_none_match:
+            arguments["IfNoneMatch"] = "*"
+        try:
+            with source.open("rb") as body:
+                self.client.put_object(Body=body, **arguments)
+        except (BotoCoreError, ClientError, OSError) as error:
+            if isinstance(error, (BotoCoreError, ClientError)):
+                self._raise("s3:PutObject", error)
+            raise GraphError("S3 put-object could not read its source") from error
+
+
+def _atomic_json(path: Path, document: dict[str, Any]) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def _prefix(value: str) -> str:
+    value = value.strip("/")
+    if not value or not re.fullmatch(r"[a-zA-Z0-9._/-]+", value):
+        raise GraphError("invalid snapshot prefix")
+    if any(part in ("", ".", "..") for part in value.split("/")):
+        raise GraphError("invalid snapshot prefix")
+    return value
+
+
+def build_snapshot_manifest(graph: Path, output: Path) -> dict[str, Any]:
+    verify_checksum(graph)
+    metadata = graph_metadata(graph)
+    checksum = sha256_file(graph)
+    document = {
+        "always_run": metadata.get("always_run", []),
+        "ci_infra_revision": metadata["ci_infra_revision"],
+        # A retry of the same generation must produce byte-identical immutable
+        # objects, so use the evidence watermark rather than wall-clock time.
+        "created_at": metadata["data_through"],
+        "data_through": metadata["data_through"],
+        "expected_jobs": metadata["expected_jobs"],
+        "files": {
+            "graph.sqlite": {
+                "bytes": graph.stat().st_size,
+                "sha256": checksum,
+            },
+            "graph.sqlite.sha256": {
+                "bytes": graph.with_suffix(graph.suffix + ".sha256").stat().st_size,
+                "sha256": sha256_file(graph.with_suffix(graph.suffix + ".sha256")),
+            },
+        },
+        "healthy_jobs": metadata["healthy_jobs"],
+        "kind": "vllm-test-selection-snapshot",
+        "missing_jobs": metadata.get("missing_jobs", []),
+        "missing_reasons": metadata.get("missing_reasons", {}),
+        "repository_sha": metadata["repository_sha"],
+        "schema_version": 1,
+        "unhealthy_jobs": metadata.get("unhealthy_jobs", []),
+        "unhealthy_reasons": metadata.get("unhealthy_reasons", {}),
+        "wait_results": metadata.get("wait_results", {}),
+    }
+    _atomic_json(output, document)
+    return document
+
+
+def _read_index(store: ObjectStore, key: str, directory: Path):
+    path = directory / "current-index.json"
+    for attempt in range(2):
+        head = store.head(key)
+        if head is None:
+            return {"schema_version": 1, "snapshots": []}, None
+        store.download(key, path)
+        if head.get("size") == path.stat().st_size and head.get("metadata", {}).get(
+            "sha256"
+        ) == sha256_file(path):
+            break
+        if attempt == 1:
+            raise GraphError("snapshot index object checksum mismatch")
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise GraphError("snapshot index is not valid JSON") from error
+    if document.get("schema_version") != 1 or not isinstance(
+        document.get("snapshots"), list
+    ):
+        raise GraphError("unsupported snapshot index schema")
+    for entry in document["snapshots"]:
+        _validate_index_entry(entry, require_manifest_checksum=True)
+    etag = head.get("etag")
+    if not isinstance(etag, str) or not etag:
+        raise GraphError("snapshot index object has no ETag")
+    return document, etag
+
+
+def _validate_index_entry(
+    entry: Any, *, require_manifest_checksum: bool = False
+) -> None:
+    if not isinstance(entry, dict):
+        raise GraphError("snapshot index entry is invalid")
+    repository_sha = entry.get("repository_sha")
+    if not isinstance(repository_sha, str) or not re.fullmatch(
+        r"[0-9a-f]{40}", repository_sha
+    ):
+        raise GraphError("snapshot index repository SHA is invalid")
+    for field in ("created_at", "data_through"):
+        if not isinstance(entry.get(field), str):
+            raise GraphError(f"snapshot index {field} is invalid")
+        _timestamp(entry[field])
+    manifest_key = entry.get("manifest_key")
+    if not isinstance(manifest_key, str) or not manifest_key:
+        raise GraphError("snapshot index manifest key is invalid")
+    if require_manifest_checksum:
+        if not re.fullmatch(r"[0-9a-f]{64}", str(entry.get("manifest_sha256", ""))):
+            raise GraphError("snapshot index manifest checksum is invalid")
+        if (
+            not isinstance(entry.get("manifest_bytes"), int)
+            or entry["manifest_bytes"] < 1
+        ):
+            raise GraphError("snapshot index manifest byte count is invalid")
+
+
+def _validate_file_record(document: Any, path: Path, label: str) -> None:
+    if not isinstance(document, dict):
+        raise GraphError(f"snapshot manifest {label} record is invalid")
+    if document.get("bytes") != path.stat().st_size:
+        raise GraphError(f"snapshot manifest {label} byte count mismatch")
+    if document.get("sha256") != sha256_file(path):
+        raise GraphError(f"snapshot manifest {label} checksum mismatch")
+
+
+def _publish_immutable(
+    store: ObjectStore, key: str, source: Path, checksum: str
+) -> None:
+    existing = store.head(key)
+    if existing is not None:
+        metadata = existing.get("metadata", {})
+        if (
+            metadata.get("sha256") != checksum
+            or existing.get("size") != source.stat().st_size
+        ):
+            raise GraphError(
+                "immutable snapshot object already exists with different bytes"
+            )
+        return
+    try:
+        store.upload(key, source, sha256=checksum, if_none_match=True)
+    except GraphError:
+        existing = store.head(key)
+        metadata = existing.get("metadata", {}) if existing else {}
+        if (
+            existing is not None
+            and metadata.get("sha256") == checksum
+            and existing.get("size") == source.stat().st_size
+        ):
+            return
+        raise
+
+
+def publish_snapshot(
+    store: ObjectStore,
+    prefix: str,
+    graph: Path,
+    manifest_path: Path,
+) -> dict[str, Any]:
+    prefix = _prefix(prefix)
+    verify_checksum(graph)
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise GraphError("snapshot manifest is not valid JSON") from error
+    if (
+        manifest.get("kind") != "vllm-test-selection-snapshot"
+        or manifest.get("schema_version") != 1
+    ):
+        raise GraphError("unsupported snapshot manifest schema")
+    repository_sha = str(manifest.get("repository_sha", ""))
+    if not re.fullmatch(r"[0-9a-f]{40}", repository_sha):
+        raise GraphError("snapshot manifest repository_sha is invalid")
+    metadata = graph_metadata(graph)
+    if metadata["repository_sha"] != repository_sha:
+        raise GraphError("snapshot graph and manifest repository SHA disagree")
+    sidecar = graph.with_suffix(graph.suffix + ".sha256")
+    files = manifest.get("files")
+    if not isinstance(files, dict):
+        raise GraphError("snapshot manifest files are invalid")
+    _validate_file_record(files.get("graph.sqlite"), graph, "graph")
+    _validate_file_record(files.get("graph.sqlite.sha256"), sidecar, "checksum sidecar")
+    if manifest.get("data_through") != metadata["data_through"]:
+        raise GraphError("snapshot graph and manifest evidence watermark disagree")
+    for field in ("created_at", "data_through"):
+        if not isinstance(manifest.get(field), str):
+            raise GraphError(f"snapshot manifest {field} is invalid")
+        _timestamp(manifest[field])
+    root = f"{prefix}/snapshots/{repository_sha}"
+    objects = {
+        f"{root}/graph.sqlite": graph,
+        f"{root}/graph.sqlite.sha256": sidecar,
+        f"{root}/manifest.json": manifest_path,
+    }
+    for key, source in objects.items():
+        _publish_immutable(store, key, source, sha256_file(source))
+
+    with tempfile.TemporaryDirectory(prefix="snapshot-index-") as directory_name:
+        directory = Path(directory_name)
+        index_key = f"{prefix}/index.json"
+        entry = {
+            "created_at": manifest["created_at"],
+            "data_through": manifest["data_through"],
+            "manifest_bytes": manifest_path.stat().st_size,
+            "manifest_key": f"{root}/manifest.json",
+            "manifest_sha256": sha256_file(manifest_path),
+            "repository_sha": repository_sha,
+        }
+        index_path = directory / "index.json"
+        for attempt in range(3):
+            index, etag = _read_index(store, index_key, directory)
+            snapshots = [
+                row
+                for row in index["snapshots"]
+                if row.get("repository_sha") != repository_sha
+            ]
+            snapshots.append(entry)
+            snapshots.sort(key=lambda row: row["created_at"], reverse=True)
+            updated = {"schema_version": 1, "snapshots": snapshots}
+            _atomic_json(index_path, updated)
+            try:
+                store.upload(
+                    index_key,
+                    index_path,
+                    sha256=sha256_file(index_path),
+                    if_match=etag,
+                    if_none_match=etag is None,
+                )
+            except GraphError:
+                if attempt == 2:
+                    raise
+            else:
+                break
+        published_manifest = directory / "published-manifest.json"
+        manifest_head = store.head(entry["manifest_key"])
+        if (
+            manifest_head is None
+            or manifest_head.get("size") != entry["manifest_bytes"]
+            or manifest_head.get("metadata", {}).get("sha256")
+            != entry["manifest_sha256"]
+        ):
+            raise GraphError("published snapshot manifest metadata mismatch")
+        store.download(entry["manifest_key"], published_manifest)
+        if published_manifest.read_bytes() != manifest_path.read_bytes():
+            raise GraphError("published snapshot manifest read-back mismatch")
+        published_index, _etag = _read_index(store, index_key, directory)
+        if entry not in published_index["snapshots"]:
+            raise GraphError("published snapshot is missing from index read-back")
+    print(
+        "Snapshot index promoted and round-trip verified: key=%s entries=%d "
+        "manifest=%s sha256=%s"
+        % (
+            index_key,
+            len(published_index["snapshots"]),
+            entry["manifest_key"],
+            entry["manifest_sha256"],
+        )
+    )
+    return entry
+
+
+def _timestamp(value: Any) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except ValueError as error:
+        raise GraphError("snapshot index timestamp is invalid") from error
+    if parsed.tzinfo is None:
+        raise GraphError("snapshot index timestamp has no timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def select_snapshot(
+    index: dict[str, Any],
+    repo: Path,
+    base: str,
+    *,
+    max_age_days: int = 11,
+    now: Optional[datetime] = None,
+) -> dict[str, Any]:
+    now = now or datetime.now(timezone.utc)
+    if max_age_days < 1:
+        raise GraphError("snapshot maximum age must be at least one day")
+    snapshots = index.get("snapshots")
+    if not isinstance(snapshots, list):
+        raise GraphError("snapshot index snapshots must be a list")
+    for entry in sorted(
+        (row for row in snapshots if isinstance(row, dict)),
+        key=lambda row: str(row.get("created_at", "")),
+        reverse=True,
+    ):
+        repository_sha = str(entry.get("repository_sha", ""))
+        if not re.fullmatch(r"[0-9a-f]{40}", repository_sha):
+            continue
+        data_through = _timestamp(entry.get("data_through"))
+        if data_through > now + timedelta(minutes=5):
+            continue
+        if now - data_through > timedelta(days=max_age_days):
+            continue
+        ancestry = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", repository_sha, base],
+            cwd=repo,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if ancestry.returncode == 0:
+            return entry
+    raise GraphError("no fresh ancestral test-selection snapshot is available")
+
+
+def fetch_snapshot(
+    store: ObjectStore,
+    prefix: str,
+    repo: Path,
+    base: str,
+    output: Path,
+    *,
+    max_age_days: int = 11,
+) -> dict[str, Any]:
+    prefix = _prefix(prefix)
+    output = output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        prefix="snapshot-fetch-", dir=output.parent
+    ) as directory_name:
+        directory = Path(directory_name)
+        index_key = f"{prefix}/index.json"
+        index, _etag = _read_index(store, index_key, directory)
+        if not index["snapshots"]:
+            raise GraphError("snapshot index does not exist")
+        entry = select_snapshot(index, repo, base, max_age_days=max_age_days)
+        expected_manifest_key = (
+            f"{prefix}/snapshots/{entry['repository_sha']}/manifest.json"
+        )
+        if entry.get("manifest_key") != expected_manifest_key:
+            raise GraphError("snapshot index manifest key is invalid")
+        manifest_path = directory / "manifest.json"
+        manifest_head = store.head(entry["manifest_key"])
+        if manifest_head is None:
+            raise GraphError("snapshot manifest does not exist")
+        store.download(entry["manifest_key"], manifest_path)
+        if (
+            manifest_path.stat().st_size != entry["manifest_bytes"]
+            or manifest_head.get("size") != entry["manifest_bytes"]
+            or sha256_file(manifest_path) != entry["manifest_sha256"]
+            or manifest_head.get("metadata", {}).get("sha256")
+            != entry["manifest_sha256"]
+        ):
+            raise GraphError("snapshot manifest object checksum mismatch")
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as error:
+            raise GraphError("snapshot manifest is not valid JSON") from error
+        if (
+            manifest.get("kind") != "vllm-test-selection-snapshot"
+            or manifest.get("schema_version") != 1
+        ):
+            raise GraphError("unsupported snapshot manifest schema")
+        if manifest.get("repository_sha") != entry["repository_sha"]:
+            raise GraphError("snapshot manifest disagrees with index")
+        if any(
+            manifest.get(field) != entry[field]
+            for field in ("created_at", "data_through")
+        ):
+            raise GraphError("snapshot manifest watermark disagrees with index")
+        root = entry["manifest_key"].removesuffix("/manifest.json")
+        graph = directory / "graph.sqlite"
+        sidecar = directory / "graph.sqlite.sha256"
+        store.download(f"{root}/graph.sqlite", graph)
+        store.download(f"{root}/graph.sqlite.sha256", sidecar)
+        files = manifest.get("files")
+        if not isinstance(files, dict):
+            raise GraphError("snapshot manifest files are invalid")
+        expected = files.get("graph.sqlite", {})
+        expected_sidecar = files.get("graph.sqlite.sha256", {})
+        if not isinstance(expected, dict) or not isinstance(expected_sidecar, dict):
+            raise GraphError("snapshot manifest file records are invalid")
+        if graph.stat().st_size != expected.get("bytes"):
+            raise GraphError("downloaded graph byte count mismatch")
+        if sha256_file(graph) != expected.get("sha256"):
+            raise GraphError("downloaded graph checksum mismatch")
+        if sidecar.stat().st_size != expected_sidecar.get("bytes"):
+            raise GraphError("downloaded checksum sidecar byte count mismatch")
+        if sha256_file(sidecar) != expected_sidecar.get("sha256"):
+            raise GraphError("downloaded checksum sidecar mismatch")
+        verify_checksum(graph)
+        metadata = graph_metadata(graph)
+        if metadata["repository_sha"] != entry["repository_sha"]:
+            raise GraphError("downloaded graph repository SHA mismatch")
+        if metadata["data_through"] != manifest.get("data_through"):
+            raise GraphError("downloaded graph evidence watermark mismatch")
+        os.replace(graph, output)
+        os.replace(sidecar, output.with_suffix(output.suffix + ".sha256"))
+    return entry
+
+
+def build_and_publish(
+    input_dir: Path,
+    inventory: Path,
+    store: ObjectStore,
+    prefix: str,
+) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="fleet-snapshot-") as directory_name:
+        directory = Path(directory_name)
+        graph = directory / "graph.sqlite"
+        metadata = build_fleet_graph(input_dir, inventory, graph)
+        manifest_path = directory / "manifest.json"
+        build_snapshot_manifest(graph, manifest_path)
+        entry = publish_snapshot(store, prefix, graph, manifest_path)
+    return {"metadata": metadata, "snapshot": entry}

--- a/buildkite/pipeline_generator/test_selection/snapshot.py
+++ b/buildkite/pipeline_generator/test_selection/snapshot.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gzip
 import json
 import os
 import re
@@ -22,6 +23,10 @@ from test_selection.graph import (
     sha256_file,
     verify_checksum,
 )
+
+
+S3_SINGLE_PUT_MAX_BYTES = 5 * 1024**3
+SNAPSHOT_MANIFEST_SCHEMA_VERSION = 2
 
 
 class ObjectStore(Protocol):
@@ -143,10 +148,70 @@ def _prefix(value: str) -> str:
     return value
 
 
+def _compressed_graph_path(graph: Path) -> Path:
+    return graph.with_suffix(graph.suffix + ".gz")
+
+
+def _compress_graph(graph: Path, output: Path) -> None:
+    """Write a byte-deterministic gzip stream for the immutable graph."""
+    temporary = output.with_suffix(output.suffix + ".tmp")
+    try:
+        with graph.open("rb") as source, temporary.open("wb") as destination:
+            with gzip.GzipFile(
+                filename="",
+                mode="wb",
+                compresslevel=6,
+                fileobj=destination,
+                mtime=0,
+            ) as compressed:
+                shutil.copyfileobj(source, compressed, length=1024 * 1024)
+        os.replace(temporary, output)
+    except OSError as error:
+        temporary.unlink(missing_ok=True)
+        raise GraphError("snapshot graph compression failed") from error
+
+
+def _decompress_graph(
+    source: Path,
+    output: Path,
+    *,
+    expected_bytes: int,
+    expected_sha256: str,
+) -> None:
+    """Expand a verified gzip object with bounds and logical checks."""
+    temporary = output.with_suffix(output.suffix + ".tmp")
+    written = 0
+    try:
+        with gzip.open(source, "rb") as compressed, temporary.open("wb") as graph:
+            while True:
+                chunk = compressed.read(1024 * 1024)
+                if not chunk:
+                    break
+                written += len(chunk)
+                if written > expected_bytes:
+                    raise GraphError(
+                        "decompressed snapshot graph exceeds declared byte count"
+                    )
+                graph.write(chunk)
+        if written != expected_bytes:
+            raise GraphError("decompressed snapshot graph byte count mismatch")
+        if sha256_file(temporary) != expected_sha256:
+            raise GraphError("decompressed snapshot graph checksum mismatch")
+        os.replace(temporary, output)
+    except (OSError, EOFError) as error:
+        temporary.unlink(missing_ok=True)
+        raise GraphError("snapshot graph decompression failed") from error
+    except GraphError:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
 def build_snapshot_manifest(graph: Path, output: Path) -> dict[str, Any]:
     verify_checksum(graph)
     metadata = graph_metadata(graph)
     checksum = sha256_file(graph)
+    compressed_graph = _compressed_graph_path(graph)
+    _compress_graph(graph, compressed_graph)
     document = {
         "always_run": metadata.get("always_run", []),
         "ci_infra_revision": metadata["ci_infra_revision"],
@@ -156,9 +221,12 @@ def build_snapshot_manifest(graph: Path, output: Path) -> dict[str, Any]:
         "data_through": metadata["data_through"],
         "expected_jobs": metadata["expected_jobs"],
         "files": {
-            "graph.sqlite": {
-                "bytes": graph.stat().st_size,
-                "sha256": checksum,
+            "graph.sqlite.gz": {
+                "bytes": compressed_graph.stat().st_size,
+                "compression": "gzip",
+                "content_bytes": graph.stat().st_size,
+                "content_sha256": checksum,
+                "sha256": sha256_file(compressed_graph),
             },
             "graph.sqlite.sha256": {
                 "bytes": graph.with_suffix(graph.suffix + ".sha256").stat().st_size,
@@ -170,7 +238,7 @@ def build_snapshot_manifest(graph: Path, output: Path) -> dict[str, Any]:
         "missing_jobs": metadata.get("missing_jobs", []),
         "missing_reasons": metadata.get("missing_reasons", {}),
         "repository_sha": metadata["repository_sha"],
-        "schema_version": 1,
+        "schema_version": SNAPSHOT_MANIFEST_SCHEMA_VERSION,
         "unhealthy_jobs": metadata.get("unhealthy_jobs", []),
         "unhealthy_reasons": metadata.get("unhealthy_reasons", {}),
         "wait_results": metadata.get("wait_results", {}),
@@ -238,6 +306,8 @@ def _validate_index_entry(
 def _validate_file_record(document: Any, path: Path, label: str) -> None:
     if not isinstance(document, dict):
         raise GraphError(f"snapshot manifest {label} record is invalid")
+    if not path.is_file():
+        raise GraphError(f"snapshot manifest {label} file is missing")
     if document.get("bytes") != path.stat().st_size:
         raise GraphError(f"snapshot manifest {label} byte count mismatch")
     if document.get("sha256") != sha256_file(path):
@@ -258,6 +328,8 @@ def _publish_immutable(
                 "immutable snapshot object already exists with different bytes"
             )
         return
+    if source.stat().st_size > S3_SINGLE_PUT_MAX_BYTES:
+        raise GraphError("immutable snapshot object exceeds S3 single-PUT size limit")
     try:
         store.upload(key, source, sha256=checksum, if_none_match=True)
     except GraphError:
@@ -284,10 +356,9 @@ def publish_snapshot(
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as error:
         raise GraphError("snapshot manifest is not valid JSON") from error
-    if (
-        manifest.get("kind") != "vllm-test-selection-snapshot"
-        or manifest.get("schema_version") != 1
-    ):
+    if manifest.get("kind") != "vllm-test-selection-snapshot" or manifest.get(
+        "schema_version"
+    ) not in (1, 2):
         raise GraphError("unsupported snapshot manifest schema")
     repository_sha = str(manifest.get("repository_sha", ""))
     if not re.fullmatch(r"[0-9a-f]{40}", repository_sha):
@@ -299,17 +370,30 @@ def publish_snapshot(
     files = manifest.get("files")
     if not isinstance(files, dict):
         raise GraphError("snapshot manifest files are invalid")
-    _validate_file_record(files.get("graph.sqlite"), graph, "graph")
+    root = f"{prefix}/snapshots/{repository_sha}"
     _validate_file_record(files.get("graph.sqlite.sha256"), sidecar, "checksum sidecar")
+    if manifest["schema_version"] == 1:
+        _validate_file_record(files.get("graph.sqlite"), graph, "graph")
+        graph_objects = {f"{root}/graph.sqlite": graph}
+    else:
+        compressed_graph = _compressed_graph_path(graph)
+        graph_record = files.get("graph.sqlite.gz")
+        _validate_file_record(graph_record, compressed_graph, "compressed graph")
+        if (
+            graph_record.get("compression") != "gzip"
+            or graph_record.get("content_bytes") != graph.stat().st_size
+            or graph_record.get("content_sha256") != sha256_file(graph)
+        ):
+            raise GraphError("snapshot manifest compressed graph content is invalid")
+        graph_objects = {f"{root}/graph.sqlite.gz": compressed_graph}
     if manifest.get("data_through") != metadata["data_through"]:
         raise GraphError("snapshot graph and manifest evidence watermark disagree")
     for field in ("created_at", "data_through"):
         if not isinstance(manifest.get(field), str):
             raise GraphError(f"snapshot manifest {field} is invalid")
         _timestamp(manifest[field])
-    root = f"{prefix}/snapshots/{repository_sha}"
     objects = {
-        f"{root}/graph.sqlite": graph,
+        **graph_objects,
         f"{root}/graph.sqlite.sha256": sidecar,
         f"{root}/manifest.json": manifest_path,
     }
@@ -472,10 +556,9 @@ def fetch_snapshot(
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError as error:
             raise GraphError("snapshot manifest is not valid JSON") from error
-        if (
-            manifest.get("kind") != "vllm-test-selection-snapshot"
-            or manifest.get("schema_version") != 1
-        ):
+        if manifest.get("kind") != "vllm-test-selection-snapshot" or manifest.get(
+            "schema_version"
+        ) not in (1, 2):
             raise GraphError("unsupported snapshot manifest schema")
         if manifest.get("repository_sha") != entry["repository_sha"]:
             raise GraphError("snapshot manifest disagrees with index")
@@ -487,23 +570,50 @@ def fetch_snapshot(
         root = entry["manifest_key"].removesuffix("/manifest.json")
         graph = directory / "graph.sqlite"
         sidecar = directory / "graph.sqlite.sha256"
-        store.download(f"{root}/graph.sqlite", graph)
         store.download(f"{root}/graph.sqlite.sha256", sidecar)
         files = manifest.get("files")
         if not isinstance(files, dict):
             raise GraphError("snapshot manifest files are invalid")
-        expected = files.get("graph.sqlite", {})
         expected_sidecar = files.get("graph.sqlite.sha256", {})
-        if not isinstance(expected, dict) or not isinstance(expected_sidecar, dict):
+        if not isinstance(expected_sidecar, dict):
             raise GraphError("snapshot manifest file records are invalid")
-        if graph.stat().st_size != expected.get("bytes"):
-            raise GraphError("downloaded graph byte count mismatch")
-        if sha256_file(graph) != expected.get("sha256"):
-            raise GraphError("downloaded graph checksum mismatch")
         if sidecar.stat().st_size != expected_sidecar.get("bytes"):
             raise GraphError("downloaded checksum sidecar byte count mismatch")
         if sha256_file(sidecar) != expected_sidecar.get("sha256"):
             raise GraphError("downloaded checksum sidecar mismatch")
+        if manifest["schema_version"] == 1:
+            expected = files.get("graph.sqlite", {})
+            if not isinstance(expected, dict):
+                raise GraphError("snapshot manifest graph record is invalid")
+            store.download(f"{root}/graph.sqlite", graph)
+            if graph.stat().st_size != expected.get("bytes"):
+                raise GraphError("downloaded graph byte count mismatch")
+            if sha256_file(graph) != expected.get("sha256"):
+                raise GraphError("downloaded graph checksum mismatch")
+        else:
+            expected = files.get("graph.sqlite.gz", {})
+            if (
+                not isinstance(expected, dict)
+                or expected.get("compression") != "gzip"
+                or not isinstance(expected.get("content_bytes"), int)
+                or expected["content_bytes"] < 1
+                or not re.fullmatch(
+                    r"[0-9a-f]{64}", str(expected.get("content_sha256", ""))
+                )
+            ):
+                raise GraphError("snapshot manifest compressed graph record is invalid")
+            compressed_graph = directory / "graph.sqlite.gz"
+            store.download(f"{root}/graph.sqlite.gz", compressed_graph)
+            if compressed_graph.stat().st_size != expected.get("bytes"):
+                raise GraphError("downloaded compressed graph byte count mismatch")
+            if sha256_file(compressed_graph) != expected.get("sha256"):
+                raise GraphError("downloaded compressed graph checksum mismatch")
+            _decompress_graph(
+                compressed_graph,
+                graph,
+                expected_bytes=expected["content_bytes"],
+                expected_sha256=expected["content_sha256"],
+            )
         verify_checksum(graph)
         metadata = graph_metadata(graph)
         if metadata["repository_sha"] != entry["repository_sha"]:

--- a/buildkite/pipeline_generator/test_selection/wait.py
+++ b/buildkite/pipeline_generator/test_selection/wait.py
@@ -1,0 +1,201 @@
+"""Bounded Buildkite step polling for the fleet snapshot publisher."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+
+STEP_STATES = {
+    "ignored",
+    "waiting_for_dependencies",
+    "ready",
+    "running",
+    "failing",
+    "finished",
+    "canceled",
+}
+STEP_OUTCOMES = {
+    "neutral",
+    "passed",
+    "soft_failed",
+    "hard_failed",
+    "errored",
+}
+TERMINAL_STEP_STATES = {"finished", "ignored", "canceled"}
+
+
+class StepLookupError(RuntimeError):
+    """Raised when the Buildkite Agent API cannot return a valid step."""
+
+
+def query_step(key: str) -> tuple[str, str | None]:
+    """Return Buildkite's aggregate state/outcome for one command-step key."""
+
+    result = subprocess.run(
+        [
+            "buildkite-agent",
+            "step",
+            "get",
+            "--format",
+            "json",
+            "--step",
+            key,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise StepLookupError(f"Buildkite step lookup failed for {key}")
+    try:
+        document = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise StepLookupError(
+            f"Buildkite step lookup returned invalid JSON for {key}"
+        ) from error
+    if not isinstance(document, dict):
+        raise StepLookupError(f"Buildkite step lookup returned a non-object for {key}")
+    state = document.get("state")
+    outcome = document.get("outcome")
+    if state not in STEP_STATES:
+        raise StepLookupError(
+            f"Buildkite step lookup returned an invalid state for {key}: {state!r}"
+        )
+    if outcome is not None and outcome not in STEP_OUTCOMES:
+        raise StepLookupError(
+            f"Buildkite step lookup returned an invalid outcome for {key}: "
+            f"state={state!r} outcome={outcome!r}"
+        )
+    if state == "canceled" and outcome not in (None, "neutral"):
+        raise StepLookupError(
+            f"Buildkite step lookup returned an invalid canceled outcome for {key}: "
+            f"{outcome!r}"
+        )
+    return state, outcome
+
+
+def _inventory_keys(document: dict[str, Any]) -> list[str]:
+    jobs = document.get("jobs")
+    if not isinstance(jobs, list) or not jobs:
+        raise ValueError("trace inventory must contain jobs")
+    keys: list[str] = []
+    for row in jobs:
+        if not isinstance(row, dict) or not isinstance(row.get("key"), str):
+            raise ValueError("trace inventory job key is invalid")
+        key = row["key"]
+        if not key or key in keys:
+            raise ValueError("trace inventory job keys must be nonempty and unique")
+        keys.append(key)
+    return sorted(keys)
+
+
+def _write_json(path: Path, document: dict[str, Any]) -> None:
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def wait_for_steps(
+    inventory_path: Path,
+    *,
+    timeout_seconds: float,
+    poll_seconds: float,
+    query: Callable[[str], tuple[str, str | None]] = query_step,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    """Wait for stable terminal step states, then record a fail-closed cutoff.
+
+    A terminal state must be returned by two consecutive polls. This re-waits
+    when Buildkite moves a step back to ready/running for an automatic retry.
+    At the hard deadline, every remaining key is explicitly marked
+    ``poll_timeout`` so the materializer excludes even late-arriving artifacts.
+    Lookup failures are retried and become bounded missing evidence rather than
+    silently suppressing snapshot publication.
+    """
+
+    if timeout_seconds < 0:
+        raise ValueError("step wait timeout must be nonnegative")
+    if poll_seconds <= 0:
+        raise ValueError("step wait poll interval must be positive")
+    document = json.loads(inventory_path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise ValueError("trace inventory must be an object")
+    keys = _inventory_keys(document)
+    pending = set(keys)
+    observations: dict[str, dict[str, Any]] = {
+        key: {"outcome": None, "state": None, "lookup_error": False} for key in keys
+    }
+    terminal_candidates: dict[str, tuple[str, str]] = {}
+    wait_results: dict[str, dict[str, Any]] = {}
+    deadline = monotonic() + timeout_seconds
+
+    while pending:
+        for key in sorted(pending):
+            try:
+                state, outcome = query(key)
+            except StepLookupError as error:
+                print(f"Waiting for trace step {key}: {error}")
+                observations[key]["lookup_error"] = True
+                terminal_candidates.pop(key, None)
+                continue
+            observations[key] = {
+                "outcome": outcome,
+                "state": state,
+                "lookup_error": False,
+            }
+            print(f"Trace step {key}: state={state} outcome={outcome}")
+            if state in TERMINAL_STEP_STATES and outcome in STEP_OUTCOMES:
+                candidate = (state, outcome)
+                if terminal_candidates.get(key) == candidate:
+                    wait_results[key] = {
+                        "outcome": outcome,
+                        "state": state,
+                        "status": "terminal",
+                    }
+                    pending.remove(key)
+                else:
+                    terminal_candidates[key] = candidate
+            else:
+                terminal_candidates.pop(key, None)
+        if not pending:
+            break
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            break
+        sleep(min(poll_seconds, remaining))
+
+    for key in sorted(pending):
+        observation = observations[key]
+        wait_results[key] = {
+            "lookup_error": observation["lookup_error"],
+            "outcome": observation["outcome"],
+            "state": observation["state"],
+            "status": "poll_timeout",
+        }
+        print(
+            "Trace step %s reached the bounded poll cutoff: state=%s outcome=%s "
+            "lookup_error=%s"
+            % (
+                key,
+                observation["state"],
+                observation["outcome"],
+                observation["lookup_error"],
+            )
+        )
+
+    document["wait_results"] = wait_results
+    _write_json(inventory_path, document)
+    timed_out = sorted(pending)
+    return {
+        "poll_timeout": timed_out,
+        "terminal": sorted(set(keys) - set(timed_out)),
+        "wait_results": wait_results,
+    }

--- a/buildkite/tests/pipeline_generator/test_global_config.py
+++ b/buildkite/tests/pipeline_generator/test_global_config.py
@@ -4,6 +4,7 @@ from unittest.mock import mock_open, patch
 import pytest
 
 from buildkite.pipeline_generator.global_config import (
+    DEFAULT_VLLM_TRACE_BUCKET,
     ONLY_STEP_KEYS_ENV_VAR,
     _parse_only_step_keys,
     _validate_pipeline_config,
@@ -143,6 +144,40 @@ def test_init_global_config_reads_only_step_keys(
         init_global_config("dummy_path")
 
     assert global_config.config["only_step_keys"] == frozenset({"selected-step"})
+
+
+@patch(
+    "buildkite.pipeline_generator.global_config.get_merge_base_commit",
+    return_value="sha",
+)
+@patch(
+    "buildkite.pipeline_generator.global_config.get_list_file_diff",
+    return_value=[],
+)
+@patch("buildkite.pipeline_generator.global_config.get_pr_labels", return_value=[])
+@patch(
+    "builtins.open",
+    new_callable=mock_open,
+    read_data="name: test\njob_dirs: [/tmp]\nregistries: reg\nrepositories: {main: repo}",
+)
+@patch("os.path.exists", return_value=True)
+def test_main_nightly_uses_the_ci_infra_owned_trace_bucket(
+    mock_exists, mock_open, mock_pr_labels, mock_diff, mock_mb
+):
+    import buildkite.pipeline_generator.global_config as global_config
+
+    with patch.dict(
+        os.environ,
+        {
+            "BUILDKITE_BRANCH": "main",
+            "BUILDKITE_PULL_REQUEST": "false",
+            "NIGHTLY": "1",
+        },
+        clear=True,
+    ):
+        init_global_config("dummy_path")
+
+    assert global_config.config["trace_s3_bucket"] == DEFAULT_VLLM_TRACE_BUCKET
 
 
 def test_validate_pipeline_config_valid_repo():

--- a/buildkite/tests/pipeline_generator/test_test_selection.py
+++ b/buildkite/tests/pipeline_generator/test_test_selection.py
@@ -13,6 +13,7 @@ from pipeline_generator import (
     PipelineGenerator,
     REPUBLISH_INVENTORY_ENV,
     REPUBLISH_SOURCE_BUILD_ENV,
+    REPUBLISH_SOURCE_BUILD_ID_ENV,
     REPUBLISH_TRIALS_ENV,
     configure_test_tracing,
     create_snapshot_republish_group_step,
@@ -60,6 +61,10 @@ def _set_republish_env(monkeypatch):
     raw = (json.dumps(inventory, sort_keys=True, separators=(",", ":")) + "\n").encode()
     monkeypatch.setenv(REPUBLISH_INVENTORY_ENV, base64.b64encode(raw).decode())
     monkeypatch.setenv(REPUBLISH_SOURCE_BUILD_ENV, "84585")
+    monkeypatch.setenv(
+        REPUBLISH_SOURCE_BUILD_ID_ENV,
+        "01a0199a-ca8a-44c4-89cc-f387790befd5",
+    )
     monkeypatch.setenv(
         REPUBLISH_TRIALS_ENV,
         json.dumps(
@@ -113,7 +118,10 @@ def test_republish_renders_exactly_one_pinned_step(
     assert step["timeout_in_minutes"] == 180
     command = step["commands"][0]
     assert "wait-for-steps" not in command
-    assert "--build 84585" in command
+    assert "--build 01a0199a-ca8a-44c4-89cc-f387790befd5" in command
+    assert "--build 84585" not in command
+    assert "source-build.txt" in command
+    assert "source-build-id.txt" in command
     assert "@" + "f" * 40 in command
     assert base64.b64encode(raw).decode() in command
     assert "refs/pull/50227/head" in command
@@ -138,6 +146,11 @@ def test_republish_rejects_malformed_or_untrusted_inputs(
     _set_republish_env(monkeypatch)
     with pytest.raises(ValueError, match="trusted vLLM main nightly"):
         create_snapshot_republish_group_step({**config, "branch": "feature"})
+
+    _set_republish_env(monkeypatch)
+    monkeypatch.setenv(REPUBLISH_SOURCE_BUILD_ID_ENV, "84585")
+    with pytest.raises(ValueError, match="SOURCE_BUILD_ID.*build UUID"):
+        create_snapshot_republish_group_step(config)
 
 
 def test_republish_rejects_incomplete_wait_accounting(fake_global_config, monkeypatch):

--- a/buildkite/tests/pipeline_generator/test_test_selection.py
+++ b/buildkite/tests/pipeline_generator/test_test_selection.py
@@ -1,0 +1,141 @@
+import base64
+import json
+import re
+
+import pytest
+
+import buildkite_step
+from constants import DeviceType
+from pipeline_generator import configure_test_tracing, should_trace_nightly
+from step import Step
+
+
+pytestmark = pytest.mark.usefixtures("fake_global_config")
+
+
+def test_only_trusted_vllm_main_nightly_traces(fake_global_config):
+    config = {
+        **fake_global_config,
+        "branch": "main",
+        "nightly": "1",
+        "trace_s3_bucket": "vllm-ci-test-selection",
+    }
+    assert should_trace_nightly(config)
+
+    for field, value in (
+        ("branch", "feature"),
+        ("nightly", "0"),
+        ("pull_request", "123"),
+        ("trace_s3_bucket", None),
+    ):
+        assert not should_trace_nightly({**config, field: value})
+
+
+def test_test_area_pytest_jobs_are_enrolled_without_yaml_trace_policy():
+    steps = [
+        Step(
+            label="CPU",
+            key="cpu-tests",
+            commands=["export FOO=bar", "pytest tests/unit"],
+        ),
+        Step(
+            label="GPU",
+            key="gpu-tests",
+            commands=["pytest tests/kernels"],
+            device=DeviceType.H100,
+        ),
+        Step(label="Script", key="script", commands=["bash smoke.sh"]),
+    ]
+
+    _steps, inventory = configure_test_tracing(
+        steps,
+        {"cpu-tests", "gpu-tests", "script"},
+        "a" * 40,
+        "b" * 40,
+        "c" * 64,
+    )
+
+    assert [(row["key"], row["mode"]) for row in inventory["jobs"]] == [
+        ("cpu-tests", "python-only"),
+        ("gpu-tests", "kernel-set"),
+    ]
+    assert inventory["always_run"] == [
+        {"key": "script", "reason": "not_plain_pytest_commands"}
+    ]
+    assert steps[0].trace_represented_job_key == "cpu-tests"
+    assert steps[1].trace_gpu is True
+
+
+def test_automatic_nightly_preserves_evidence_based_fleet_carve_outs():
+    steps = [
+        Step(
+            label="Previously collector incompatible",
+            key="kernels-fp8-moe-test-2xh100",
+            commands=["pytest tests/kernels"],
+            device=DeviceType.H100,
+        ),
+        Step(
+            label="Automatically enrolled forked-CUDA incompatible",
+            key="multi-modal-models-extended-generation-2",
+            commands=["pytest tests/models"],
+            device=DeviceType.H200,
+        ),
+        Step(
+            label="Coverage overhead",
+            key="engine-1-gpu",
+            commands=["pytest tests/engine"],
+            device=DeviceType.H100,
+        ),
+        Step(
+            label="Traceable",
+            key="gpu-tests",
+            commands=["pytest tests/kernels"],
+            device=DeviceType.H100,
+        ),
+    ]
+
+    _steps, inventory = configure_test_tracing(
+        steps,
+        {step.key for step in steps},
+        "a" * 40,
+        "b" * 40,
+        "c" * 64,
+    )
+
+    assert inventory["jobs"] == [
+        {"expected_shards": 1, "key": "gpu-tests", "mode": "kernel-set"}
+    ]
+    assert inventory["always_run"] == [
+        {"key": "engine-1-gpu", "reason": "cpu_overhead_policy"},
+        {
+            "key": "kernels-fp8-moe-test-2xh100",
+            "reason": "collector_compatibility_policy",
+        },
+        {
+            "key": "multi-modal-models-extended-generation-2",
+            "reason": "collector_compatibility_policy",
+        },
+    ]
+    assert steps[0].trace_represented_job_key is None
+    assert steps[1].trace_represented_job_key is None
+
+
+def test_trace_wrapper_preserves_the_original_command_list_as_one_script(
+    fake_global_config,
+):
+    step = Step(
+        label="Tests",
+        key="tests",
+        commands=["export FOO=bar", 'test "$FOO" = bar && pytest tests/unit'],
+        trace_represented_job_key="tests",
+        trace_collector_sha256="c" * 64,
+    )
+
+    rendered = buildkite_step._prepare_commands(step, {})
+    wrapper = rendered[-1]
+    match = re.search(r"--commands-base64 ([A-Za-z0-9+/=]+)", wrapper)
+    assert match is not None
+    commands = json.loads(base64.b64decode(match.group(1)))
+    assert commands == [
+        'set -e\nexport FOO=bar\ntest "$FOO" = bar && pytest tests/unit'
+    ]

--- a/buildkite/tests/pipeline_generator/test_test_selection.py
+++ b/buildkite/tests/pipeline_generator/test_test_selection.py
@@ -1,16 +1,75 @@
 import base64
 import json
 import re
+import subprocess
 
 import pytest
+import yaml
 
 import buildkite_step
 from constants import DeviceType
-from pipeline_generator import configure_test_tracing, should_trace_nightly
+import pipeline_generator as pipeline_module
+from pipeline_generator import (
+    PipelineGenerator,
+    REPUBLISH_INVENTORY_ENV,
+    REPUBLISH_SOURCE_BUILD_ENV,
+    REPUBLISH_TRIALS_ENV,
+    configure_test_tracing,
+    create_snapshot_republish_group_step,
+    should_trace_nightly,
+)
 from step import Step
 
 
 pytestmark = pytest.mark.usefixtures("fake_global_config")
+
+
+def _republish_config(fake_global_config):
+    return {
+        **fake_global_config,
+        "branch": "main",
+        "commit": "a" * 40,
+        "nightly": "1",
+        "trace_s3_bucket": "vllm-ci-test-selection",
+        "trace_s3_prefix": "test-selection/vllm",
+    }
+
+
+def _set_republish_env(monkeypatch):
+    inventory = {
+        "always_run": [{"key": "plain-job", "reason": "policy"}],
+        "ci_infra_revision": "b" * 40,
+        "collector_sha256": "c" * 64,
+        "jobs": [
+            {
+                "expected_shards": 1,
+                "key": "traced-job",
+                "mode": "python-only",
+            }
+        ],
+        "repository_sha": "a" * 40,
+        "schema_version": 1,
+        "wait_results": {
+            "traced-job": {
+                "outcome": "passed",
+                "state": "finished",
+                "status": "terminal",
+            }
+        },
+    }
+    raw = (json.dumps(inventory, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    monkeypatch.setenv(REPUBLISH_INVENTORY_ENV, base64.b64encode(raw).decode())
+    monkeypatch.setenv(REPUBLISH_SOURCE_BUILD_ENV, "84585")
+    monkeypatch.setenv(
+        REPUBLISH_TRIALS_ENV,
+        json.dumps(
+            [
+                {"head": "d" * 40, "pull_request": 50227},
+                {"head": "e" * 40, "pull_request": 48939},
+            ]
+        ),
+    )
+    return raw
 
 
 def test_only_trusted_vllm_main_nightly_traces(fake_global_config):
@@ -29,6 +88,70 @@ def test_only_trusted_vllm_main_nightly_traces(fake_global_config):
         ("trace_s3_bucket", None),
     ):
         assert not should_trace_nightly({**config, field: value})
+
+
+def test_republish_renders_exactly_one_pinned_step(
+    fake_global_config, monkeypatch, tmp_path
+):
+    config = _republish_config(fake_global_config)
+    raw = _set_republish_env(monkeypatch)
+    monkeypatch.setattr(pipeline_module, "_ci_infra_revision", lambda: "f" * 40)
+    monkeypatch.setattr(pipeline_module, "get_global_config", lambda: config)
+    output = tmp_path / "pipeline.yaml"
+    generator = PipelineGenerator.__new__(PipelineGenerator)
+    generator.output_file_path = str(output)
+
+    generator.generate()
+
+    document = yaml.safe_load(output.read_text())
+    assert len(document["steps"]) == 1
+    group = document["steps"][0]
+    assert group["group"] == "Test selection snapshot republish"
+    assert len(group["steps"]) == 1
+    step = group["steps"][0]
+    assert step["agents"] == {"queue": "cpu_queue_postmerge_us_east_1"}
+    assert step["timeout_in_minutes"] == 180
+    command = step["commands"][0]
+    assert "wait-for-steps" not in command
+    assert "--build 84585" in command
+    assert "@" + "f" * 40 in command
+    assert base64.b64encode(raw).decode() in command
+    assert "refs/pull/50227/head" in command
+    assert "refs/pull/48939/head" in command
+    subprocess.run(
+        ["bash", "-n"],
+        input=command.replace("$$", "$"),
+        check=True,
+        text=True,
+    )
+
+
+def test_republish_rejects_malformed_or_untrusted_inputs(
+    fake_global_config, monkeypatch
+):
+    config = _republish_config(fake_global_config)
+    _set_republish_env(monkeypatch)
+    monkeypatch.setenv(REPUBLISH_INVENTORY_ENV, "not-base64")
+    with pytest.raises(ValueError, match="INVENTORY.*invalid"):
+        create_snapshot_republish_group_step(config)
+
+    _set_republish_env(monkeypatch)
+    with pytest.raises(ValueError, match="trusted vLLM main nightly"):
+        create_snapshot_republish_group_step({**config, "branch": "feature"})
+
+
+def test_republish_rejects_incomplete_wait_accounting(fake_global_config, monkeypatch):
+    config = _republish_config(fake_global_config)
+    raw = _set_republish_env(monkeypatch)
+    inventory = json.loads(raw)
+    inventory["wait_results"] = {}
+    invalid = (
+        json.dumps(inventory, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode()
+    monkeypatch.setenv(REPUBLISH_INVENTORY_ENV, base64.b64encode(invalid).decode())
+
+    with pytest.raises(ValueError, match="wait results are incomplete"):
+        create_snapshot_republish_group_step(config)
 
 
 def test_test_area_pytest_jobs_are_enrolled_without_yaml_trace_policy():

--- a/buildkite/tests/test_selection/collector/test_parse_nsys_sqlite.py
+++ b/buildkite/tests/test_selection/collector/test_parse_nsys_sqlite.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Tests for reducing CUDA/NVTX timelines to unordered kernel/test sets."""
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[3]
+    / "pipeline_generator/test_selection/collector/parse_nsys_sqlite.py"
+)
+REPOSITORY_SHA = "a" * 40
+CREATED_AT = "2026-08-19T00:00:00Z"
+K_INNER = "_ZinnerK"
+K_OUTER = "_ZouterK"
+K_SETUP = "_ZsetupK"
+K_ORPHAN = "_ZorphanK"
+K_PROC2 = "_Zproc2K"
+K_TEMPORAL = "_ZtemporalK"
+PID1 = 5
+PID2 = 6
+TID1 = (PID1 << 24) | 7
+GPID1 = PID1 << 24
+
+
+def _build_fixture(path: Path) -> None:
+    connection = sqlite3.connect(path)
+    connection.execute("CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT)")
+    connection.execute(
+        "CREATE TABLE NVTX_EVENTS (start INT, end INT, "
+        "globalTid INT, text TEXT, textId INT)"
+    )
+    connection.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME (start INT, end INT, "
+        "correlationId INT, globalTid INT)"
+    )
+    connection.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL (start INT, end INT, "
+        "correlationId INT, mangledName INT, globalPid INT)"
+    )
+    connection.executemany(
+        "INSERT INTO StringIds VALUES (?, ?)",
+        {
+            1: K_INNER,
+            2: K_OUTER,
+            3: K_SETUP,
+            4: K_ORPHAN,
+            5: K_PROC2,
+            6: K_TEMPORAL,
+        }.items(),
+    )
+    connection.executemany(
+        "INSERT INTO NVTX_EVENTS VALUES (?, ?, ?, ?, ?)",
+        [
+            (100, 900, TID1, "citest-setup::tests/a.py::test_x", None),
+            (1000, 5000, TID1, "citest::tests/a.py::test_x", None),
+            (2000, 3000, TID1, "citest::tests/a.py::test_x_inner", None),
+            (6000, 9000, TID1, "citest::tests/a.py::test_y", None),
+            (0, 99999, TID1, "torch-internal", None),
+        ],
+    )
+    connection.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (?, ?, ?, ?)",
+        [
+            (150, 160, 11, TID1),
+            (2500, 2510, 12, TID1),
+            (4900, 4910, 13, TID1),
+            (5500, 5510, 14, TID1),
+        ],
+    )
+    connection.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (?, ?, ?, ?, ?)",
+        [
+            (200, 300, 11, 3, GPID1),
+            (2600, 2700, 12, 1, GPID1),
+            (7000, 8000, 13, 2, GPID1),
+            (5600, 5700, 14, 4, GPID1),
+        ],
+    )
+    connection.commit()
+    connection.close()
+
+
+@pytest.fixture
+def trace_files(tmp_path: Path) -> tuple[Path, Path]:
+    database = tmp_path / "trace.sqlite"
+    output = tmp_path / "edges.jsonl"
+    _build_fixture(database)
+    return database, output
+
+
+def _run_parser(
+    database: Path, output: Path, *, check: bool = True
+) -> tuple[subprocess.CompletedProcess[str], list[dict], dict]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            str(database),
+            "--out",
+            str(output),
+            "--job-key",
+            "kernels-flashmla-test-h100",
+            "--repository-sha",
+            REPOSITORY_SHA,
+            "--created-at",
+            CREATED_AT,
+        ],
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+    rows = (
+        [json.loads(line) for line in output.read_text().splitlines()]
+        if output.exists() and result.returncode == 0
+        else []
+    )
+    summary = json.loads(result.stderr) if result.returncode == 0 else {}
+    return result, rows, summary
+
+
+def test_reduces_to_kernel_test_and_conservative_job_sets(trace_files):
+    database, output = trace_files
+
+    _result, rows, summary = _run_parser(database, output)
+
+    by_kernel = {row["source"]: row for row in rows}
+    assert by_kernel[K_SETUP]["destination"] == "tests/a.py::test_x"
+    assert by_kernel[K_SETUP]["phase"] == "citest-setup"
+    assert by_kernel[K_INNER]["destination"] == "tests/a.py::test_x_inner"
+    assert by_kernel[K_OUTER]["destination"] == "tests/a.py::test_x"
+    assert by_kernel[K_ORPHAN]["destination_kind"] == "job"
+    assert by_kernel[K_ORPHAN]["attribution_mode"] == "job_union"
+    assert summary["outside_any_test_range"] == 1
+    assert summary["kernel_rows"] == 4
+    assert summary["unique_kernel_destination_pairs"] == 4
+    assert summary["mangled_identity"] is True
+    assert all(row["repository_sha"] == REPOSITORY_SHA for row in rows)
+    assert all(row["created_at"] == CREATED_AT for row in rows)
+    assert not any("artifact_class" in row for row in rows)
+
+
+def test_child_launch_thread_uses_unambiguous_temporal_range(trace_files):
+    database, output = trace_files
+    child_tid = (PID1 << 24) | 19
+    connection = sqlite3.connect(database)
+    connection.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (4000, 4010, 21, ?)",
+        (child_tid,),
+    )
+    connection.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (4100, 4200, 21, 6, ?)",
+        (GPID1,),
+    )
+    connection.commit()
+    connection.close()
+
+    _result, rows, summary = _run_parser(database, output)
+
+    temporal = next(row for row in rows if row["source"] == K_TEMPORAL)
+    assert temporal["destination"] == "tests/a.py::test_x"
+    assert temporal["attribution_mode"] == "temporal_test"
+    assert summary["attribution_temporal_test"] == 1
+
+
+def test_ambiguous_temporal_range_falls_back_to_job(trace_files):
+    database, output = trace_files
+    child_tid = (PID1 << 24) | 19
+    concurrent_tid = (PID1 << 24) | 20
+    connection = sqlite3.connect(database)
+    connection.execute(
+        "INSERT INTO NVTX_EVENTS VALUES "
+        "(3500, 4500, ?, 'citest::tests/b.py::test_concurrent', NULL)",
+        (concurrent_tid,),
+    )
+    connection.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (4000, 4010, 21, ?)",
+        (child_tid,),
+    )
+    connection.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (4100, 4200, 21, 6, ?)",
+        (GPID1,),
+    )
+    connection.commit()
+    connection.close()
+
+    _result, rows, summary = _run_parser(database, output)
+
+    fallback = next(row for row in rows if row["source"] == K_TEMPORAL)
+    assert fallback["destination_kind"] == "job"
+    assert fallback["attribution_mode"] == "job_union"
+    assert summary["ambiguous_active_test_ranges"] == 1
+
+
+def test_repeated_launches_are_deduplicated_as_a_set(trace_files):
+    database, output = trace_files
+    connection = sqlite3.connect(database)
+    connection.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (2520, 2530, 15, ?)",
+        (TID1,),
+    )
+    connection.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (2800, 2900, 15, 1, ?)",
+        (GPID1,),
+    )
+    connection.commit()
+    connection.close()
+
+    _result, rows, summary = _run_parser(database, output)
+
+    assert len([row for row in rows if row["source"] == K_INNER]) == 1
+    assert summary["kernel_rows"] == 5
+
+
+def test_process_scoped_correlation_ids_do_not_cross_attribute(trace_files):
+    database, output = trace_files
+    tid2 = (PID2 << 24) | 9
+    gpid2 = PID2 << 24
+    connection = sqlite3.connect(database)
+    connection.execute(
+        "INSERT INTO NVTX_EVENTS VALUES "
+        "(2000, 3000, ?, 'citest::tests/b.py::test_p2', NULL)",
+        (tid2,),
+    )
+    connection.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (2400, 2410, 12, ?)",
+        (tid2,),
+    )
+    connection.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (2650, 2750, 12, 5, ?)",
+        (gpid2,),
+    )
+    connection.commit()
+    connection.close()
+
+    _result, rows, summary = _run_parser(database, output)
+
+    by_kernel = {row["source"]: row for row in rows}
+    assert by_kernel[K_PROC2]["destination"] == "tests/b.py::test_p2"
+    assert by_kernel[K_INNER]["destination"] == "tests/a.py::test_x_inner"
+    assert summary["process_scoped_join"] is True
+
+
+def test_duplicate_correlation_in_one_process_fails_without_overwriting(trace_files):
+    database, output = trace_files
+    output.write_text("last-good\n", encoding="utf-8")
+    connection = sqlite3.connect(database)
+    connection.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (2400, 2410, 12, ?)",
+        (TID1,),
+    )
+    connection.commit()
+    connection.close()
+
+    result, _rows, _summary = _run_parser(database, output, check=False)
+
+    assert result.returncode != 0
+    assert output.read_text() == "last-good\n"
+
+
+def test_versioned_cuda_api_alias_is_soundly_deduplicated(trace_files):
+    database, output = trace_files
+    connection = sqlite3.connect(database)
+    connection.execute("ALTER TABLE CUPTI_ACTIVITY_KIND_RUNTIME ADD COLUMN nameId INT")
+    connection.execute(
+        "ALTER TABLE CUPTI_ACTIVITY_KIND_RUNTIME ADD COLUMN callchainId INT"
+    )
+    connection.executemany(
+        "INSERT INTO StringIds VALUES (?, ?)",
+        [(30, "cudaLaunchKernel"), (31, "cudaLaunchKernel_v7000")],
+    )
+    connection.execute(
+        "UPDATE CUPTI_ACTIVITY_KIND_RUNTIME SET nameId=30, callchainId=7 "
+        "WHERE correlationId=12"
+    )
+    connection.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME "
+        "(start, end, correlationId, globalTid, nameId, callchainId) "
+        "VALUES (2501, 2509, 12, ?, 31, NULL)",
+        (TID1,),
+    )
+    connection.commit()
+    connection.close()
+
+    _result, rows, summary = _run_parser(database, output)
+
+    inner = next(row for row in rows if row["source"] == K_INNER)
+    assert inner["destination"] == "tests/a.py::test_x_inner"
+    assert summary["runtime_alias_rows_deduplicated"] == 1

--- a/buildkite/tests/test_selection/collector/test_run_job_trace.py
+++ b/buildkite/tests/test_selection/collector/test_run_job_trace.py
@@ -2,18 +2,21 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import base64
+import io
 import json
 import os
 import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from zipfile import ZipFile
 
 import pytest
 
 import test_selection.collector.nvtx_test_ranges as nvtx_test_ranges
 import test_selection.collector.pytest_trace_plugin as pytest_trace_plugin
 import test_selection.collector.run_job_trace as run_job_trace
+from test_selection.collector_bundle import bundle_bytes
 from test_selection.collector.nvtx_test_ranges import _configured_nvtx
 from test_selection.collector.run_job_trace import decode_commands
 
@@ -146,6 +149,78 @@ def test_python_only_job_collects_unordered_lines_and_exact_collector(
     assert summary["healthy"] is True
 
 
+def test_command_local_pythonpath_keeps_pytest_plugins_importable(tmp_path: Path):
+    repo = tmp_path / "repo"
+    package = repo / "vllm"
+    tests = repo / "tests"
+    package.mkdir(parents=True)
+    tests.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "sample.py").write_text(
+        "def answer():\n    return 42\n", encoding="utf-8"
+    )
+    (tests / "test_first.py").write_text(
+        "from vllm.sample import answer\n\n"
+        "def test_first():\n    assert answer() == 42\n",
+        encoding="utf-8",
+    )
+    (tests / "test_second.py").write_text(
+        "from vllm.sample import answer\n\n"
+        "def test_second():\n    assert answer() == 42\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "trace"
+    collector_root = tmp_path / "collector"
+    with ZipFile(io.BytesIO(bundle_bytes())) as archive:
+        archive.extractall(collector_root)
+    environment = dict(os.environ)
+    environment.update(
+        {
+            "BUILDKITE_COMMIT": "b" * 40,
+            "PATH": f"{Path(sys.executable).parent}:{environment['PATH']}",
+            "PYTHONPATH": str(collector_root),
+        }
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ci_test_selection.run_job_trace",
+            "--output-dir",
+            str(output),
+            "--job-key",
+            "unit",
+            "--represented-job-key",
+            "unit",
+            "--commands-base64",
+            _payload(
+                [
+                    "pytest -q tests/test_first.py",
+                    f"PYTHONPATH={repo} pytest -q tests/test_second.py",
+                ]
+            ),
+            "--repo-root",
+            str(repo),
+            "--python-only",
+            "--preserve-command-exit-code",
+        ],
+        cwd=repo,
+        env=environment,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    summary = json.loads((output / "trace-job.json").read_text())
+    assert summary["healthy"] is True
+    assert summary["failure_reason"] is None
+    assert [row["healthy"] for row in summary["command_results"]] == [True, True]
+    assert [row["fallback_uninstrumented"] for row in summary["command_results"]] == [
+        False,
+        False,
+    ]
+
+
 @pytest.mark.parametrize(
     "command,expected_status",
     [("echo original-command-ran", 0), ("exit 7", 7)],
@@ -230,6 +305,10 @@ def test_in_place_collection_falls_back_only_before_command_start(tmp_path: Path
     assert (repo / "original-ran").is_file()
     summary = json.loads((output / "trace-job.json").read_text())
     assert summary["command_results"][0]["fallback_uninstrumented"] is True
+    assert summary["command_results"][0]["failure_reason"] == (
+        "collector_import_failed"
+    )
+    assert summary["failure_reason"] == "collector_import_failed"
 
 
 def test_finished_command_is_not_rerun_after_collector_failure(

--- a/buildkite/tests/test_selection/collector/test_run_job_trace.py
+++ b/buildkite/tests/test_selection/collector/test_run_job_trace.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import base64
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import test_selection.collector.nvtx_test_ranges as nvtx_test_ranges
+import test_selection.collector.pytest_trace_plugin as pytest_trace_plugin
+import test_selection.collector.run_job_trace as run_job_trace
+from test_selection.collector.nvtx_test_ranges import _configured_nvtx
+from test_selection.collector.run_job_trace import decode_commands
+
+
+def _payload(commands: list[str]) -> str:
+    return base64.b64encode(json.dumps(commands).encode()).decode()
+
+
+def _module_root() -> Path:
+    return Path(__file__).resolve().parents[3] / "pipeline_generator"
+
+
+def test_decode_commands_round_trip():
+    commands = ["pytest -q tests/test_one.py", "python -m pytest tests/test_two.py"]
+
+    assert decode_commands(_payload(commands)) == commands
+
+
+@pytest.mark.parametrize("document", [[], [""], {"command": "pytest"}, [1]])
+def test_decode_commands_rejects_invalid_documents(document):
+    with pytest.raises(SystemExit):
+        decode_commands(base64.b64encode(json.dumps(document).encode()).decode())
+
+
+def test_python_only_nvtx_gate_does_not_initialize_cuda(monkeypatch):
+    def fail_if_called():
+        raise AssertionError("python-only collection touched CUDA")
+
+    fake_torch = SimpleNamespace(cuda=SimpleNamespace(is_available=fail_if_called))
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setenv("VLLM_CI_TEST_SELECTION_NVTX", "0")
+
+    assert _configured_nvtx() is None
+
+
+@pytest.mark.parametrize("failure", ["push", "pop"])
+def test_nvtx_tooling_failure_does_not_escape_pytest_hook(monkeypatch, failure):
+    class BrokenNvtx:
+        def range_push(self, _label):
+            if failure == "push":
+                raise RuntimeError("broken push")
+
+        def range_pop(self):
+            if failure == "pop":
+                raise RuntimeError("broken pop")
+
+    monkeypatch.setattr(nvtx_test_ranges, "_nvtx", BrokenNvtx())
+    wrapper = nvtx_test_ranges._wrap("call", SimpleNamespace(nodeid="test_node"))
+
+    next(wrapper)
+    with pytest.raises(StopIteration):
+        next(wrapper)
+
+
+def test_node_export_failure_does_not_change_pytest_result(
+    tmp_path: Path, monkeypatch, capsys
+):
+    blocker = tmp_path / "not-a-directory"
+    blocker.write_text("block", encoding="utf-8")
+    monkeypatch.setenv("VLLM_CI_TEST_SELECTION_NODEIDS", str(blocker / "nodes.json"))
+
+    pytest_trace_plugin.pytest_sessionfinish(SimpleNamespace(), 0)
+
+    assert "node/outcome export failed" in capsys.readouterr().err
+
+
+def test_python_only_job_collects_unordered_lines_and_exact_collector(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    source = repo / "vllm" / "sample.py"
+    test_file = repo / "tests" / "test_sample.py"
+    source.parent.mkdir(parents=True)
+    test_file.parent.mkdir(parents=True)
+    (repo / "vllm" / "__init__.py").write_text("", encoding="utf-8")
+    source.write_text("def answer():\n    return 42\n", encoding="utf-8")
+    test_file.write_text(
+        "from vllm.sample import answer\n\n"
+        "def test_answer():\n"
+        "    assert answer() == 42\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "trace"
+    collector_sha256 = "c" * 64
+    environment = dict(os.environ)
+    environment.update(
+        {
+            "BUILDKITE_COMMIT": "a" * 40,
+            "PATH": f"{Path(sys.executable).parent}:{environment['PATH']}",
+            "PYTHONPATH": str(_module_root()),
+            "VLLM_CI_TEST_SELECTION_COLLECTOR_SHA256": collector_sha256,
+        }
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "test_selection.collector.run_job_trace",
+            "--output-dir",
+            str(output),
+            "--job-key",
+            "unit",
+            "--represented-job-key",
+            "unit",
+            "--commands-base64",
+            _payload(["pytest -q tests/test_sample.py"]),
+            "--repo-root",
+            str(repo),
+            "--python-only",
+        ],
+        cwd=repo,
+        env=environment,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    shard = output / "commands" / "000"
+    trace_rows = [
+        json.loads(line)
+        for line in (shard / "python-trace.jsonl").read_text().splitlines()
+    ]
+    assert {row["file"] for row in trace_rows} == {"vllm/sample.py"}
+    assert {row["test_id"] for row in trace_rows} == {
+        "tests/test_sample.py::test_answer"
+    }
+    summary = json.loads((output / "trace-job.json").read_text())
+    assert summary["capture_mode"] == "python-only"
+    assert summary["collector_sha256"] == collector_sha256
+    assert summary["healthy"] is True
+
+
+@pytest.mark.parametrize(
+    "command,expected_status",
+    [("echo original-command-ran", 0), ("exit 7", 7)],
+)
+def test_in_place_collection_preserves_original_command_status(
+    tmp_path: Path, command: str, expected_status: int
+):
+    repo = tmp_path / "repo"
+    package = repo / "vllm"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    output = tmp_path / "trace"
+    environment = dict(os.environ)
+    environment["BUILDKITE_COMMIT"] = "c" * 40
+    environment["PYTHONPATH"] = str(_module_root())
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "test_selection.collector.run_job_trace",
+            "--output-dir",
+            str(output),
+            "--job-key",
+            "unit",
+            "--represented-job-key",
+            "unit",
+            "--commands-base64",
+            _payload([command]),
+            "--repo-root",
+            str(repo),
+            "--python-only",
+            "--preserve-command-exit-code",
+        ],
+        cwd=repo,
+        env=environment,
+        check=False,
+    )
+
+    assert result.returncode == expected_status
+    summary = json.loads((output / "trace-job.json").read_text())
+    assert summary["command_results"][0]["command_exit_code"] == expected_status
+    assert summary["healthy"] is False
+
+
+def test_in_place_collection_falls_back_only_before_command_start(tmp_path: Path):
+    repo = tmp_path / "repo"
+    package = repo / "vllm"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text(
+        "raise RuntimeError('preflight failure')\n", encoding="utf-8"
+    )
+    output = tmp_path / "trace"
+    environment = dict(os.environ)
+    environment["BUILDKITE_COMMIT"] = "d" * 40
+    environment["PYTHONPATH"] = str(_module_root())
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "test_selection.collector.run_job_trace",
+            "--output-dir",
+            str(output),
+            "--job-key",
+            "unit",
+            "--represented-job-key",
+            "unit",
+            "--commands-base64",
+            _payload(["touch original-ran"]),
+            "--repo-root",
+            str(repo),
+            "--python-only",
+            "--preserve-command-exit-code",
+        ],
+        cwd=repo,
+        env=environment,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert (repo / "original-ran").is_file()
+    summary = json.loads((output / "trace-job.json").read_text())
+    assert summary["command_results"][0]["fallback_uninstrumented"] is True
+
+
+def test_finished_command_is_not_rerun_after_collector_failure(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    output = tmp_path / "trace"
+
+    def fake_run_command(*_args, command_index, output_dir, **_kwargs):
+        command_output = output_dir / "commands" / f"{command_index:03d}"
+        command_output.mkdir(parents=True)
+        (command_output / "command-status.json").write_text(
+            json.dumps({"command_executed": True, "exit_code": 0, "phase": "finished"}),
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess([], 13)
+
+    def unexpected_fallback(*_args, **_kwargs):
+        raise AssertionError("a completed command was rerun")
+
+    monkeypatch.setattr(run_job_trace, "_run_command", fake_run_command)
+    monkeypatch.setattr(run_job_trace, "_run_uninstrumented", unexpected_fallback)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_job_trace",
+            "--output-dir",
+            str(output),
+            "--job-key",
+            "unit",
+            "--represented-job-key",
+            "unit",
+            "--commands-base64",
+            _payload(["pytest tests/test_one.py"]),
+            "--repo-root",
+            str(repo),
+            "--python-only",
+            "--preserve-command-exit-code",
+        ],
+    )
+
+    assert run_job_trace.main() == 0
+    summary = json.loads((output / "trace-job.json").read_text())
+    assert summary["command_results"][0]["collector_exit_code"] == 13
+    assert summary["command_results"][0]["command_exit_code"] == 0
+    assert summary["command_results"][0]["fallback_uninstrumented"] is False

--- a/buildkite/tests/test_selection/collector/test_run_trace.py
+++ b/buildkite/tests/test_selection/collector/test_run_trace.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+import os
+from pathlib import Path
+
+from coverage import CoverageData
+
+from test_selection.collector.run_trace import (
+    _command_environment,
+    coverage_rows,
+    normalize_repository_path,
+    pytest_command,
+    validate_import_environment,
+)
+
+
+def test_normalize_repository_path_from_checkout(tmp_path: Path):
+    repo = tmp_path / "repo"
+    source = repo / "vllm" / "attention" / "ops.py"
+
+    assert normalize_repository_path(str(source), repo) == "vllm/attention/ops.py"
+
+
+def test_normalize_repository_path_from_site_packages(tmp_path: Path):
+    repo = tmp_path / "repo"
+    source = tmp_path / "venv" / "site-packages" / "vllm" / "attention" / "ops.py"
+
+    assert normalize_repository_path(str(source), repo) == "vllm/attention/ops.py"
+
+
+def test_normalize_repository_path_rejects_non_vllm(tmp_path: Path):
+    assert (
+        normalize_repository_path(str(tmp_path / "torch" / "ops.py"), tmp_path) is None
+    )
+
+
+def test_coverage_rows_are_unordered_per_test_line_sets(tmp_path: Path):
+    repo = tmp_path / "repo"
+    source = repo / "vllm" / "attention" / "ops.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("one = 1\ntwo = 2\n", encoding="utf-8")
+    coverage_file = tmp_path / ".coverage"
+    data = CoverageData(basename=str(coverage_file))
+    data.set_context("tests/kernels/test_ops.py::test_one|run")
+    data.add_lines({str(source): {1, 2}})
+    data.set_context("tests/kernels/test_ops.py::test_two|run")
+    data.add_lines({str(source): {2}})
+    data.write()
+
+    rows = coverage_rows(
+        coverage_file,
+        repo,
+        repository_sha="a" * 40,
+        job_key="kernels-ops",
+    )
+
+    assert [(row["test_id"], row["line"]) for row in rows] == [
+        ("tests/kernels/test_ops.py::test_one", 1),
+        ("tests/kernels/test_ops.py::test_one", 2),
+        ("tests/kernels/test_ops.py::test_two", 2),
+    ]
+    assert all(row["file"] == "vllm/attention/ops.py" for row in rows)
+
+
+def test_pytest_command_loads_python_and_nvtx_plugins():
+    command = pytest_command(["tests/kernels/test_ops.py"])
+
+    assert "test_selection.collector.pytest_trace_plugin" in command
+    assert "test_selection.collector.nvtx_test_ranges" in command
+    assert command[-1] == "tests/kernels/test_ops.py"
+
+
+def test_command_environment_adds_only_unordered_coverage_options(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setenv("PYTEST_ADDOPTS", "-ra")
+
+    environment = _command_environment(
+        coverage_file=tmp_path / ".coverage",
+        node_file=tmp_path / "nodes.json",
+        repo_root=tmp_path,
+        auto_load_pytest=True,
+    )
+
+    assert environment["PYTEST_ADDOPTS"].split() == [
+        "-ra",
+        "--cov=vllm",
+        "--cov-context=test",
+        "--cov-append",
+        "--cov-report=",
+    ]
+    assert environment["VLLM_CI_TEST_SELECTION_PACKAGE"] == ("test_selection.collector")
+
+
+def test_import_preflight_rejects_checkout_source_for_image_job(tmp_path: Path):
+    checkout = tmp_path / "checkout"
+    source_package = checkout / "vllm"
+    source_package.mkdir(parents=True)
+    (source_package / "__init__.py").write_text("", encoding="utf-8")
+    output = tmp_path / "import-environment.json"
+    environment = {
+        **os.environ,
+        "BUILDKITE_BUILD_CHECKOUT_PATH": str(checkout),
+        "PYTHONPATH": str(checkout),
+    }
+
+    status = validate_import_environment(
+        command_cwd=tmp_path,
+        environment=environment,
+        output_path=output,
+        repo_root=tmp_path / "image-workspace",
+    )
+
+    document = json.loads(output.read_text(encoding="utf-8"))
+    assert status == 1
+    assert document["error"] == "image job imported vllm from checkout source"
+
+
+def test_import_preflight_accepts_installed_package_outside_checkout(tmp_path: Path):
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    installed_package = tmp_path / "site-packages" / "vllm"
+    installed_package.mkdir(parents=True)
+    (installed_package / "__init__.py").write_text("", encoding="utf-8")
+    output = tmp_path / "import-environment.json"
+    environment = {
+        **os.environ,
+        "BUILDKITE_BUILD_CHECKOUT_PATH": str(checkout),
+        "PYTHONPATH": str(installed_package.parent),
+    }
+
+    status = validate_import_environment(
+        command_cwd=tmp_path,
+        environment=environment,
+        output_path=output,
+        repo_root=tmp_path / "image-workspace",
+    )
+
+    document = json.loads(output.read_text(encoding="utf-8"))
+    assert status == 0
+    assert document["error"] is None
+
+
+def test_import_preflight_rejects_broken_pytest_plugin_registration(tmp_path: Path):
+    installed_package = tmp_path / "site-packages" / "vllm"
+    installed_package.mkdir(parents=True)
+    (installed_package / "__init__.py").write_text("", encoding="utf-8")
+    output = tmp_path / "import-environment.json"
+    environment = {
+        **os.environ,
+        "PYTHONPATH": str(installed_package.parent),
+        "PYTEST_PLUGINS": "missing_test_selection_plugin",
+    }
+
+    status = validate_import_environment(
+        command_cwd=tmp_path,
+        environment=environment,
+        output_path=output,
+        repo_root=tmp_path / "image-workspace",
+    )
+
+    document = json.loads(output.read_text(encoding="utf-8"))
+    assert status != 0
+    assert document["error"] == "pytest plugin/options preflight failed"
+
+
+def test_import_preflight_rejects_unknown_pytest_option(tmp_path: Path):
+    installed_package = tmp_path / "site-packages" / "vllm"
+    installed_package.mkdir(parents=True)
+    (installed_package / "__init__.py").write_text("", encoding="utf-8")
+    output = tmp_path / "import-environment.json"
+    environment = {
+        **os.environ,
+        "PYTHONPATH": os.fspath(installed_package.parent),
+        "PYTEST_ADDOPTS": "--vllm-ci-unsupported-option",
+    }
+
+    status = validate_import_environment(
+        command_cwd=tmp_path,
+        environment=environment,
+        output_path=output,
+        repo_root=tmp_path / "image-workspace",
+    )
+
+    document = json.loads(output.read_text(encoding="utf-8"))
+    assert status != 0
+    assert document["error"] == "pytest plugin/options preflight failed"

--- a/buildkite/tests/test_selection/test_cli.py
+++ b/buildkite/tests/test_selection/test_cli.py
@@ -1,0 +1,20 @@
+import sys
+
+from test_selection import cli
+
+
+def test_cli_converts_unexpected_selector_exception_to_fallback_exit(
+    monkeypatch, capsys
+):
+    def broken_metadata(_graph):
+        raise KeyError("repository_sha")
+
+    monkeypatch.setattr(cli, "graph_metadata", broken_metadata)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["vllm-test-selection", "inspect-graph", "--graph", "missing.sqlite"],
+    )
+
+    assert cli.main() == 2
+    assert "repository_sha" in capsys.readouterr().err

--- a/buildkite/tests/test_selection/test_collector_bundle.py
+++ b/buildkite/tests/test_selection/test_collector_bundle.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from io import BytesIO
+from zipfile import ZipFile
+
+from pipeline_generator import create_collector_group_step
+from test_selection.collector_bundle import bundle_bytes, bundle_sha256
+
+
+def test_collector_bundle_is_deterministic_and_minimal():
+    first = bundle_bytes()
+    second = bundle_bytes()
+
+    assert first == second
+    assert len(bundle_sha256(first)) == 64
+    with ZipFile(BytesIO(first)) as archive:
+        names = set(archive.namelist())
+        assert "ci_test_selection/run_job_trace.py" in names
+        assert "ci_test_selection/run_trace.py" in names
+        assert "ci_test_selection/parse_nsys_sqlite.py" in names
+        assert "ci_test_selection/run_traced.sh" in names
+        assert not any("deep" in name for name in names)
+
+
+def test_collector_step_publishes_the_exact_checksum_once():
+    collector = bundle_bytes()
+    checksum = bundle_sha256(collector)
+
+    group = create_collector_group_step(collector, checksum)
+    step = group.steps[0]
+
+    assert step.key == "test-selection-collector"
+    assert step.soft_fail is True
+    assert checksum in step.commands[0]
+    assert step.commands[0].count("artifact upload") == 1

--- a/buildkite/tests/test_selection/test_graph.py
+++ b/buildkite/tests/test_selection/test_graph.py
@@ -30,7 +30,14 @@ def _write(path: Path, value) -> None:
     path.write_text(text, encoding="utf-8")
 
 
-def _job(root: Path, key: str, *, healthy: bool = True, shard: int = 0) -> None:
+def _job(
+    root: Path,
+    key: str,
+    *,
+    healthy: bool = True,
+    shard: int = 0,
+    failure_reason: str | None = None,
+) -> None:
     directory = root / key / str(shard)
     trace = directory / "commands/000/python-trace.jsonl"
     rows = [
@@ -47,6 +54,7 @@ def _job(root: Path, key: str, *, healthy: bool = True, shard: int = 0) -> None:
         directory / "commands/000/job.json",
         {
             "created_at": CREATED,
+            "failure_reason": failure_reason,
             "healthy": healthy,
             "node_ids": ["tests/test_model.py::test_forward"],
             "python_trace": trace.name,
@@ -61,6 +69,7 @@ def _job(root: Path, key: str, *, healthy: bool = True, shard: int = 0) -> None:
             "capture_mode": "python-only",
             "collector_sha256": COLLECTOR,
             "created_at": CREATED,
+            "failure_reason": failure_reason,
             "healthy": healthy,
             "parallel_job": shard,
             "parallel_job_count": 1,
@@ -140,6 +149,25 @@ def test_missing_job_is_recorded_and_always_runs(tmp_path: Path):
 
     assert metadata["missing_jobs"] == ["missing"]
     assert job_coverage(graph, current)["uncovered_step_keys"] == ["missing"]
+
+
+def test_unhealthy_summary_preserves_specific_failure_reason(tmp_path: Path):
+    evidence = tmp_path / "evidence"
+    _job(evidence, "healthy")
+    _job(
+        evidence,
+        "import-failed",
+        healthy=False,
+        failure_reason="collector_import_failed",
+    )
+
+    metadata = build_fleet_graph(
+        evidence,
+        _inventory(tmp_path / "inventory.json", "healthy", "import-failed"),
+        tmp_path / "graph.sqlite",
+    )
+
+    assert metadata["unhealthy_reasons"] == {"import-failed": "collector_import_failed"}
 
 
 def test_bad_checksum_fails_closed(tmp_path: Path):

--- a/buildkite/tests/test_selection/test_graph.py
+++ b/buildkite/tests/test_selection/test_graph.py
@@ -1,0 +1,207 @@
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from test_selection.graph import (
+    GraphError,
+    build_fleet_graph,
+    current_jobs_from_pipeline,
+    graph_metadata,
+    job_coverage,
+    paths_to_jobs,
+    select_jobs,
+)
+
+
+SHA = "a" * 40
+COLLECTOR = "b" * 64
+CREATED = "2026-08-19T09:00:00+00:00"
+
+
+def _write(path: Path, value) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(value, list):
+        text = "".join(json.dumps(row, sort_keys=True) + "\n" for row in value)
+    else:
+        text = json.dumps(value, sort_keys=True) + "\n"
+    path.write_text(text, encoding="utf-8")
+
+
+def _job(root: Path, key: str, *, healthy: bool = True, shard: int = 0) -> None:
+    directory = root / key / str(shard)
+    trace = directory / "commands/000/python-trace.jsonl"
+    rows = [
+        {
+            "file": "vllm/model.py",
+            "job_key": key,
+            "line": 7,
+            "repository_sha": SHA,
+            "test_id": "tests/test_model.py::test_forward",
+        }
+    ]
+    _write(trace, rows)
+    _write(
+        directory / "commands/000/job.json",
+        {
+            "created_at": CREATED,
+            "healthy": healthy,
+            "node_ids": ["tests/test_model.py::test_forward"],
+            "python_trace": trace.name,
+            "python_trace_sha256": hashlib.sha256(trace.read_bytes()).hexdigest(),
+            "repository_sha": SHA,
+            "represented_job_key": key,
+        },
+    )
+    _write(
+        directory / "trace-job.json",
+        {
+            "capture_mode": "python-only",
+            "collector_sha256": COLLECTOR,
+            "created_at": CREATED,
+            "healthy": healthy,
+            "parallel_job": shard,
+            "parallel_job_count": 1,
+            "repository_sha": SHA,
+            "represented_job_key": key,
+        },
+    )
+
+
+def _inventory(path: Path, *keys: str) -> Path:
+    _write(
+        path,
+        {
+            "always_run": [],
+            "ci_infra_revision": "c" * 40,
+            "collector_sha256": COLLECTOR,
+            "jobs": [
+                {"expected_shards": 1, "key": key, "mode": "python-only"}
+                for key in keys
+            ],
+            "repository_sha": SHA,
+            "wait_results": {},
+        },
+    )
+    return path
+
+
+def _graph(tmp_path: Path, *keys: str) -> Path:
+    evidence = tmp_path / "evidence"
+    for key in keys:
+        _job(evidence, key)
+    graph = tmp_path / "graph.sqlite"
+    build_fleet_graph(evidence, _inventory(tmp_path / "inventory.json", *keys), graph)
+    return graph
+
+
+def _git(command: list[str], repo: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _repo(tmp_path: Path, *, unknown: bool = False) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["git", "init", "-q"], repo)
+    _git(["git", "config", "user.name", "Test"], repo)
+    _git(["git", "config", "user.email", "test@example.com"], repo)
+    path = repo / "vllm/model.py"
+    path.parent.mkdir()
+    path.write_text("VALUE = 1\n", encoding="utf-8")
+    _git(["git", "add", "."], repo)
+    _git(["git", "commit", "-qm", "base"], repo)
+    if unknown:
+        (repo / "unknown.txt").write_text("new\n", encoding="utf-8")
+    else:
+        path.write_text("VALUE = 2\n", encoding="utf-8")
+    _git(["git", "add", "."], repo)
+    _git(["git", "commit", "-qm", "head"], repo)
+    return repo
+
+
+def test_builds_compact_graph_and_explains_file_to_job(tmp_path: Path):
+    graph = _graph(tmp_path, "unit-tests")
+
+    assert graph_metadata(graph)["healthy_jobs"] == ["unit-tests"]
+    assert paths_to_jobs(graph, "vllm/model.py")[0][-1]["name"] == "unit-tests"
+
+
+def test_missing_job_is_recorded_and_always_runs(tmp_path: Path):
+    evidence = tmp_path / "evidence"
+    _job(evidence, "healthy")
+    graph = tmp_path / "graph.sqlite"
+    inventory = _inventory(tmp_path / "inventory.json", "healthy", "missing")
+
+    metadata = build_fleet_graph(evidence, inventory, graph)
+    current = tmp_path / "jobs.json"
+    current.write_text('["healthy","missing"]\n', encoding="utf-8")
+
+    assert metadata["missing_jobs"] == ["missing"]
+    assert job_coverage(graph, current)["uncovered_step_keys"] == ["missing"]
+
+
+def test_bad_checksum_fails_closed(tmp_path: Path):
+    graph = _graph(tmp_path, "unit-tests")
+    graph.write_bytes(graph.read_bytes() + b"corrupt")
+    with pytest.raises(GraphError, match="checksum"):
+        graph_metadata(graph)
+
+
+def test_selector_maps_changed_file_and_adds_uncovered_jobs(tmp_path: Path):
+    graph = _graph(tmp_path, "unit-tests")
+    repo = _repo(tmp_path)
+    current = tmp_path / "jobs.json"
+    current.write_text('["unit-tests","new-job"]\n', encoding="utf-8")
+    # Make the fixture graph's snapshot SHA the real base commit.
+    base = _git(["git", "rev-parse", "HEAD~1"], repo).stdout.strip()
+    import sqlite3
+
+    connection = sqlite3.connect(graph)
+    connection.execute(
+        "UPDATE metadata SET value=? WHERE key='repository_sha'", (json.dumps(base),)
+    )
+    connection.commit()
+    connection.close()
+    from test_selection.graph import write_checksum
+
+    write_checksum(graph)
+
+    result = select_jobs(graph, repo, base, "HEAD", current, 10000)
+
+    assert result["fallback"] is False
+    assert result["step_keys"] == ["new-job", "unit-tests"]
+    assert result["reasons"][0]["analysis"] == "trace_presence"
+
+
+def test_selector_falls_back_for_unmapped_change(tmp_path: Path):
+    graph = _graph(tmp_path, "unit-tests")
+    repo = _repo(tmp_path, unknown=True)
+    current = tmp_path / "jobs.json"
+    current.write_text('["unit-tests"]\n', encoding="utf-8")
+    base = _git(["git", "rev-parse", "HEAD~1"], repo).stdout.strip()
+    import sqlite3
+
+    connection = sqlite3.connect(graph)
+    connection.execute(
+        "UPDATE metadata SET value=? WHERE key='repository_sha'", (json.dumps(base),)
+    )
+    connection.commit()
+    connection.close()
+    from test_selection.graph import write_checksum
+
+    write_checksum(graph)
+
+    result = select_jobs(graph, repo, base, "HEAD", current, 10000)
+    assert result["fallback"] is True
+    assert result["fallback_reason"] == "unmapped_changed_file"
+
+
+def test_reads_current_jobs_from_rendered_pipeline(tmp_path: Path):
+    pipeline = tmp_path / "pipeline.yaml"
+    pipeline.write_text(
+        "steps:\n- group: Tests\n  steps:\n  - key: unit-tests\n    commands: [pytest]\n",
+        encoding="utf-8",
+    )
+    assert current_jobs_from_pipeline(pipeline) == ["unit-tests"]

--- a/buildkite/tests/test_selection/test_snapshot.py
+++ b/buildkite/tests/test_selection/test_snapshot.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+import test_selection.snapshot as snapshot
 from test_selection.graph import GraphError, SCHEMA, write_checksum
 from test_selection.snapshot import (
     build_snapshot_manifest,
@@ -120,6 +121,56 @@ def test_publish_and_fetch_round_trip(tmp_path: Path):
     assert fetched == entry
     assert output.read_bytes() == graph.read_bytes()
     assert output.with_suffix(".sqlite.sha256").is_file()
+    assert json.loads(manifest.read_text())["schema_version"] == 2
+    root = f"test-selection/vllm/snapshots/{repository_sha}"
+    assert f"{root}/graph.sqlite.gz" in store.objects
+    assert f"{root}/graph.sqlite" not in store.objects
+
+
+def test_compressed_graph_is_byte_deterministic(tmp_path: Path):
+    graph = _graph(tmp_path / "graph.sqlite")
+    first_manifest = tmp_path / "first-manifest.json"
+    second_manifest = tmp_path / "second-manifest.json"
+
+    build_snapshot_manifest(graph, first_manifest)
+    first_bytes = graph.with_suffix(".sqlite.gz").read_bytes()
+    graph.with_suffix(".sqlite.gz").unlink()
+    build_snapshot_manifest(graph, second_manifest)
+
+    assert graph.with_suffix(".sqlite.gz").read_bytes() == first_bytes
+    assert first_manifest.read_bytes() == second_manifest.read_bytes()
+
+
+def test_compression_keeps_large_logical_graph_under_single_put_limit(
+    tmp_path: Path, monkeypatch
+):
+    graph = _graph(tmp_path / "graph.sqlite")
+    connection = sqlite3.connect(graph)
+    connection.execute("CREATE TABLE padding (value BLOB NOT NULL)")
+    connection.execute("INSERT INTO padding VALUES (zeroblob(2097152))")
+    connection.commit()
+    connection.close()
+    write_checksum(graph)
+    manifest = tmp_path / "manifest.json"
+    build_snapshot_manifest(graph, manifest)
+    compressed = graph.with_suffix(".sqlite.gz")
+    assert graph.stat().st_size > 1024 * 1024
+    assert compressed.stat().st_size < 1024 * 1024
+    monkeypatch.setattr(snapshot, "S3_SINGLE_PUT_MAX_BYTES", 1024 * 1024)
+
+    publish_snapshot(MemoryStore(), "test-selection/vllm", graph, manifest)
+
+
+def test_publish_rejects_compressed_graph_over_single_put_limit(
+    tmp_path: Path, monkeypatch
+):
+    graph = _graph(tmp_path / "graph.sqlite")
+    manifest = tmp_path / "manifest.json"
+    build_snapshot_manifest(graph, manifest)
+    monkeypatch.setattr(snapshot, "S3_SINGLE_PUT_MAX_BYTES", 1)
+
+    with pytest.raises(GraphError, match="single-PUT size limit"):
+        publish_snapshot(MemoryStore(), "test-selection/vllm", graph, manifest)
 
 
 def test_publish_rejects_conflicting_immutable_graph(tmp_path: Path):
@@ -128,11 +179,87 @@ def test_publish_rejects_conflicting_immutable_graph(tmp_path: Path):
     build_snapshot_manifest(graph, manifest)
     store = MemoryStore()
     publish_snapshot(store, "test-selection/vllm", graph, manifest)
-    key = f"test-selection/vllm/snapshots/{SHA}/graph.sqlite"
+    key = f"test-selection/vllm/snapshots/{SHA}/graph.sqlite.gz"
     store.objects[key]["data"] += b"corrupt"
 
     with pytest.raises(GraphError, match="immutable"):
         publish_snapshot(store, "test-selection/vllm", graph, manifest)
+
+
+def test_fetch_verifies_compressed_bytes_before_decompression(
+    tmp_path: Path, monkeypatch
+):
+    repo, repository_sha = _repo(tmp_path)
+    graph = _graph(tmp_path / "graph.sqlite", repository_sha)
+    manifest = tmp_path / "manifest.json"
+    build_snapshot_manifest(graph, manifest)
+    store = MemoryStore()
+    publish_snapshot(store, "test-selection/vllm", graph, manifest)
+    key = f"test-selection/vllm/snapshots/{repository_sha}/graph.sqlite.gz"
+    corrupt = bytearray(store.objects[key]["data"])
+    corrupt[-1] ^= 1
+    store.objects[key]["data"] = bytes(corrupt)
+    monkeypatch.setattr(
+        snapshot,
+        "_decompress_graph",
+        lambda *_args, **_kwargs: pytest.fail("unverified object was decompressed"),
+    )
+
+    with pytest.raises(GraphError, match="compressed graph checksum mismatch"):
+        fetch_snapshot(
+            store,
+            "test-selection/vllm",
+            repo,
+            repository_sha,
+            tmp_path / "out.sqlite",
+        )
+
+
+def test_decompression_verifies_logical_checksum(tmp_path: Path):
+    graph = _graph(tmp_path / "graph.sqlite")
+    manifest = tmp_path / "manifest.json"
+    build_snapshot_manifest(graph, manifest)
+
+    with pytest.raises(GraphError, match="decompressed snapshot graph checksum"):
+        snapshot._decompress_graph(
+            graph.with_suffix(".sqlite.gz"),
+            tmp_path / "out.sqlite",
+            expected_bytes=graph.stat().st_size,
+            expected_sha256="0" * 64,
+        )
+
+
+def test_fetch_supports_legacy_uncompressed_manifest(tmp_path: Path):
+    repo, repository_sha = _repo(tmp_path)
+    graph = _graph(tmp_path / "graph.sqlite", repository_sha)
+    generated = tmp_path / "generated-manifest.json"
+    manifest = tmp_path / "manifest.json"
+    document = build_snapshot_manifest(graph, generated)
+    document["schema_version"] = 1
+    document["files"].pop("graph.sqlite.gz")
+    document["files"]["graph.sqlite"] = {
+        "bytes": graph.stat().st_size,
+        "sha256": snapshot.sha256_file(graph),
+    }
+    manifest.write_text(
+        json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    store = MemoryStore()
+    entry = publish_snapshot(store, "test-selection/vllm", graph, manifest)
+
+    output = tmp_path / "legacy.sqlite"
+    assert (
+        fetch_snapshot(
+            store,
+            "test-selection/vllm",
+            repo,
+            repository_sha,
+            output,
+        )
+        == entry
+    )
+    assert output.read_bytes() == graph.read_bytes()
 
 
 def test_fetch_rejects_corrupt_manifest(tmp_path: Path):

--- a/buildkite/tests/test_selection/test_snapshot.py
+++ b/buildkite/tests/test_selection/test_snapshot.py
@@ -1,0 +1,173 @@
+import hashlib
+import json
+import sqlite3
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from test_selection.graph import GraphError, SCHEMA, write_checksum
+from test_selection.snapshot import (
+    build_snapshot_manifest,
+    fetch_snapshot,
+    publish_snapshot,
+    select_snapshot,
+)
+
+
+SHA = "a" * 40
+NOW = datetime.now(timezone.utc)
+
+
+class MemoryStore:
+    def __init__(self):
+        self.objects = {}
+
+    def head(self, key):
+        item = self.objects.get(key)
+        if item is None:
+            return None
+        return {
+            "etag": item["etag"],
+            "metadata": {"sha256": item["sha256"]},
+            "size": len(item["data"]),
+        }
+
+    def download(self, key, destination):
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(self.objects[key]["data"])
+
+    def upload(self, key, source, *, sha256, if_match=None, if_none_match=False):
+        existing = self.objects.get(key)
+        if if_none_match and existing is not None:
+            raise GraphError("precondition failed")
+        if if_match and (existing is None or existing["etag"] != if_match):
+            raise GraphError("precondition failed")
+        data = source.read_bytes()
+        self.objects[key] = {
+            "data": data,
+            "etag": hashlib.md5(data).hexdigest(),  # nosec: fake S3 ETag
+            "sha256": sha256,
+        }
+
+
+def _graph(path: Path, repository_sha: str = SHA) -> Path:
+    connection = sqlite3.connect(path)
+    connection.executescript(SCHEMA)
+    timestamp = NOW.isoformat()
+    metadata = {
+        "always_run": [],
+        "ci_infra_revision": "b" * 40,
+        "collector_sha256": "c" * 64,
+        "created_at": timestamp,
+        "data_through": timestamp,
+        "expected_jobs": ["unit-tests"],
+        "healthy_jobs": ["unit-tests"],
+        "missing_jobs": [],
+        "missing_reasons": {},
+        "repository_sha": repository_sha,
+        "schema_version": 1,
+        "unhealthy_jobs": [],
+        "unhealthy_reasons": {},
+        "wait_results": {},
+    }
+    for key, value in metadata.items():
+        connection.execute(
+            "INSERT INTO metadata VALUES (?, ?)", (key, json.dumps(value))
+        )
+    connection.execute("INSERT INTO jobs VALUES ('unit-tests', 'healthy', NULL)")
+    connection.commit()
+    connection.close()
+    write_checksum(path)
+    return path
+
+
+def _git(command, repo):
+    return subprocess.run(command, cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _repo(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["git", "init", "-q"], repo)
+    _git(["git", "config", "user.name", "Test"], repo)
+    _git(["git", "config", "user.email", "test@example.com"], repo)
+    (repo / "file").write_text("base\n", encoding="utf-8")
+    _git(["git", "add", "."], repo)
+    _git(["git", "commit", "-qm", "base"], repo)
+    return repo, _git(["git", "rev-parse", "HEAD"], repo).stdout.strip()
+
+
+def test_publish_and_fetch_round_trip(tmp_path: Path):
+    repo, repository_sha = _repo(tmp_path)
+    graph = _graph(tmp_path / "graph.sqlite", repository_sha)
+    manifest = tmp_path / "manifest.json"
+    build_snapshot_manifest(graph, manifest)
+    store = MemoryStore()
+
+    entry = publish_snapshot(store, "test-selection/vllm", graph, manifest)
+    output = tmp_path / "downloaded.sqlite"
+    fetched = fetch_snapshot(
+        store,
+        "test-selection/vllm",
+        repo,
+        repository_sha,
+        output,
+        max_age_days=1,
+    )
+
+    assert fetched == entry
+    assert output.read_bytes() == graph.read_bytes()
+    assert output.with_suffix(".sqlite.sha256").is_file()
+
+
+def test_publish_rejects_conflicting_immutable_graph(tmp_path: Path):
+    graph = _graph(tmp_path / "graph.sqlite")
+    manifest = tmp_path / "manifest.json"
+    build_snapshot_manifest(graph, manifest)
+    store = MemoryStore()
+    publish_snapshot(store, "test-selection/vllm", graph, manifest)
+    key = f"test-selection/vllm/snapshots/{SHA}/graph.sqlite"
+    store.objects[key]["data"] += b"corrupt"
+
+    with pytest.raises(GraphError, match="immutable"):
+        publish_snapshot(store, "test-selection/vllm", graph, manifest)
+
+
+def test_fetch_rejects_corrupt_manifest(tmp_path: Path):
+    repo, repository_sha = _repo(tmp_path)
+    graph = _graph(tmp_path / "graph.sqlite", repository_sha)
+    manifest = tmp_path / "manifest.json"
+    build_snapshot_manifest(graph, manifest)
+    store = MemoryStore()
+    entry = publish_snapshot(store, "test-selection/vllm", graph, manifest)
+    store.objects[entry["manifest_key"]]["data"] += b"corrupt"
+
+    with pytest.raises(GraphError, match="manifest object checksum"):
+        fetch_snapshot(
+            store,
+            "test-selection/vllm",
+            repo,
+            repository_sha,
+            tmp_path / "out.sqlite",
+        )
+
+
+def test_select_snapshot_requires_fresh_ancestor(tmp_path: Path):
+    repo, repository_sha = _repo(tmp_path)
+    fresh = {
+        "created_at": NOW.isoformat(),
+        "data_through": NOW.isoformat(),
+        "manifest_key": "manifest.json",
+        "repository_sha": repository_sha,
+    }
+    stale = {
+        **fresh,
+        "created_at": (NOW - timedelta(days=20)).isoformat(),
+        "data_through": (NOW - timedelta(days=20)).isoformat(),
+    }
+
+    assert select_snapshot({"snapshots": [stale, fresh]}, repo, repository_sha) == fresh
+    with pytest.raises(GraphError, match="no fresh ancestral"):
+        select_snapshot({"snapshots": [stale]}, repo, repository_sha)

--- a/buildkite/tests/test_selection/test_wait.py
+++ b/buildkite/tests/test_selection/test_wait.py
@@ -1,0 +1,183 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from test_selection.wait import StepLookupError, query_step, wait_for_steps
+
+
+def _inventory(path: Path, *keys: str) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {"expected_shards": 1, "key": key, "mode": "python-only"}
+                    for key in keys
+                ],
+                "schema_version": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def monotonic(self) -> float:
+        return self.value
+
+    def sleep(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def test_wait_rechecks_retry_transition_and_lookup_error(tmp_path: Path):
+    inventory = tmp_path / "inventory.json"
+    _inventory(inventory, "retry", "canceled", "expired")
+    clock = Clock()
+    responses = {
+        "retry": iter(
+            [
+                ("running", None),
+                ("finished", "hard_failed"),
+                ("ready", None),
+                ("finished", "passed"),
+                ("finished", "passed"),
+            ]
+        ),
+        "canceled": iter(
+            [
+                StepLookupError("temporary Agent API failure"),
+                ("canceled", "neutral"),
+                ("canceled", "neutral"),
+            ]
+        ),
+        "expired": iter(
+            [
+                ("finished", "errored"),
+                ("finished", "errored"),
+            ]
+        ),
+    }
+
+    def query(key: str):
+        response = next(responses[key])
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    result = wait_for_steps(
+        inventory,
+        timeout_seconds=10,
+        poll_seconds=1,
+        query=query,
+        monotonic=clock.monotonic,
+        sleep=clock.sleep,
+    )
+
+    assert result["terminal"] == ["canceled", "expired", "retry"]
+    assert result["poll_timeout"] == []
+    assert result["wait_results"] == {
+        "canceled": {
+            "outcome": "neutral",
+            "state": "canceled",
+            "status": "terminal",
+        },
+        "expired": {
+            "outcome": "errored",
+            "state": "finished",
+            "status": "terminal",
+        },
+        "retry": {
+            "outcome": "passed",
+            "state": "finished",
+            "status": "terminal",
+        },
+    }
+    assert json.loads(inventory.read_text())["wait_results"] == result["wait_results"]
+
+
+def test_wait_timeout_accounts_nonterminal_and_lookup_failure(tmp_path: Path):
+    inventory = tmp_path / "inventory.json"
+    _inventory(inventory, "healthy", "slow", "unknown")
+    clock = Clock()
+
+    def query(key: str):
+        if key == "healthy":
+            return "finished", "passed"
+        if key == "slow":
+            return "running", None
+        raise StepLookupError("unknown key or Agent API unavailable")
+
+    result = wait_for_steps(
+        inventory,
+        timeout_seconds=2,
+        poll_seconds=1,
+        query=query,
+        monotonic=clock.monotonic,
+        sleep=clock.sleep,
+    )
+
+    assert result["terminal"] == ["healthy"]
+    assert result["poll_timeout"] == ["slow", "unknown"]
+    assert result["wait_results"]["slow"] == {
+        "lookup_error": False,
+        "outcome": None,
+        "state": "running",
+        "status": "poll_timeout",
+    }
+    assert result["wait_results"]["unknown"] == {
+        "lookup_error": True,
+        "outcome": None,
+        "state": None,
+        "status": "poll_timeout",
+    }
+
+
+def test_query_step_rejects_invalid_agent_response(monkeypatch):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='{"state":"mystery"}', stderr=""
+        ),
+    )
+
+    with pytest.raises(StepLookupError, match="invalid state.*'mystery'"):
+        query_step("unit")
+
+
+def test_query_step_reports_invalid_outcome_with_state(monkeypatch):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"state":"finished","outcome":"mystery"}',
+            stderr="",
+        ),
+    )
+
+    with pytest.raises(
+        StepLookupError,
+        match="invalid outcome.*state='finished' outcome='mystery'",
+    ):
+        query_step("unit")
+
+
+def test_query_step_rejects_non_neutral_canceled_outcome(monkeypatch):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"state":"canceled","outcome":"errored"}',
+            stderr="",
+        ),
+    )
+
+    with pytest.raises(StepLookupError, match="invalid canceled outcome.*'errored'"):
+        query_step("unit")


### PR DESCRIPTION
## What changed

- Automatically trace pytest jobs declared under vLLM's `.buildkite/test_areas` on trusted `main` nightlies.
- Collect per-test repository Python file/line presence for CPU jobs and the same Python evidence plus mangled CUDA kernel identities for eligible NVIDIA jobs.
- Preserve evidence-backed exact-key firewalls: 46 collector-compatibility jobs and 5 prohibitive Python-coverage-overhead jobs stay visible but uninstrumented/always-run.
- Publish one checksum-pinned collector bundle without making production jobs depend on it; collector failures preserve the original command result and mark evidence unhealthy.
- Build and publish a compact immutable SQLite graph, deterministic gzip-v2 object, checksum sidecar, and conditional S3 index.
- Keep missing, unhealthy, incompatible, stale, non-ancestral, and unmapped coverage conservatively always-run/fallback.
- Expose an advisory selector with file → test → job why-chains.
- Add a fail-closed, operator-only recovery gate that renders one CPU postmerge republisher instead of rerunning the fleet.

There are no per-job tracing declarations, retained Nsight timelines, AST symbol indexes, static source-to-kernel export steps, or production PR skip behavior in this draft.

## Why

The repository layout is the enrollment contract: pytest jobs under `.buildkite/test_areas` should produce evidence automatically. Keeping policy in ci-infra removes duplicated YAML knobs and lets an unchanged vLLM `main` tree collect trace evidence.

The first selector is deliberately conservative. Python changes may use observed file/line presence. Native/kernel source changes and any unmapped file fall back until an independently validated source-to-kernel mapping exists.

## Safety properties

- Tracing activates only for `vllm-project/vllm`, `NIGHTLY=1`, branch `main`, and a non-PR build.
- The production S3 bucket default exists only inside that trusted gate.
- The collector step is soft-failing and has no hard production dependents.
- Traced jobs preserve their original command order and exit status; missing/invalid/import-failed collectors run the original production command exactly once.
- The publisher polls terminal step state with an eight-hour bound; missing/timeout evidence becomes always-run.
- Snapshot identity binds the exact vLLM SHA, ci-infra revision, collector SHA, inventory, shard count, artifacts, and checksums.
- Readers verify compressed bytes before bounded decompression, then verify the logical SQLite checksum.
- Recovery inputs require a canonical inventory bound to the build commit, complete wait accounting, numeric source-build provenance, and the Buildkite source UUID. Any recovery env replaces the full generated fleet with one recovery step; never set it on a normal nightly.
- The selector is shadow-only. This PR does not make production skip decisions.

## Validation

### Local and GitHub

- Final exact head: `605214b63275ba4ebdbe0ee81861e0f1d6e5dc39`.
- `175 passed` across `buildkite/tests`.
- Applicable pre-commit hooks and `git diff --check` pass.
- GitHub Pipeline generator tests and DCO pass.
- Exact vLLM seed render at `eac636a7fa476983cdae34b45a984e9852aad375`: 307 unique production command keys = 121 traced + 186 always-run.
- Trace modes: 25 Python-only + 96 NVIDIA kernel-set, 144 expected shards.
- Exactly 46 compatibility-policy + 5 CPU-overhead-policy rows remain always-run.
- All 2,101 rendered shell commands parse after Buildkite dollar normalization; no duplicate command keys or collector dependencies.

### Production evidence

- Seed build [#84585](https://buildkite.com/vllm/ci/builds/84585) produced the frozen fleet evidence.
- Final inventory: 36,052 bytes, SHA-256 `8b22e49c058651312e90703807d3714eaa8555999f95039040b1967352e2889c`.
- Current jobs: 307 keys, SHA-256 `93e823241c21935490c615f0cb98348090b116b533486ab0e512e6dd9bf22eff`.
- Fan-in accounting: 121 traced = 80 healthy + 8 missing + 33 unhealthy; 186 additional jobs remain always-run.
- Recovery build [#84672](https://buildkite.com/vllm/ci/builds/84672) downloaded all 1,136 artifacts (28.05 GiB), materialized and published gzip-v2, CAS-promoted the production index, and completed a fresh read-back.
- Manifest SHA-256: `4c09961b5b5a5fa16f3a3a280a35dd6f5f5108309c27a933cf34f0ee5a1d460c`.
- Read-back SQLite SHA-256: `df68c3f2efca9fdf982d01df3a21be0fd20bdc35ee5d164996a3139f0bcd31e9`.
- Exact-seed shadow trial PR #50227 (one `llama4.py` change): selected 235/307 = 227 uncovered/fail-closed + 8 evidence-backed; safely skipped 72 jobs (~23%) with 96 inspectable why-chain rows.
- Exact-seed shadow trial PR #48939: `tests/quantization/test_quark.py` was unmapped, so selection fell back to run-all exactly as designed.

The #84672 child reports failed only because the dedicated trial gate deliberately exits nonzero when any shadow trial falls back; publication, read-back, both trial outputs, and result artifact upload completed first.

## Known limits

This validates the collector/publisher/selector MVP for **shadow-only** use, not enforcement. On the representative #50227 trial, 227/307 jobs remained uncovered or fail-closed. Coverage must expand and false-negative audits must remain clean before any production skipping is considered.

## Contribution notes

AI assistance was used in implementation and validation. The human submitter must review every changed line and understand the design before moving this PR out of draft.