### PR TITLE
Keep gpu_4_queue at 10 minimum with demand scaling to 40

### DIFF
--- a/terraform/aws/cloudformation_stack.tf
+++ b/terraform/aws/cloudformation_stack.tf
@@ -213,8 +213,8 @@ locals {
       BuildkiteAgentTokenParameterStorePath = data.aws_ssm_parameter.bk_agent_token_cluster_ci.name
       BuildkiteQueue                       = "gpu_4_queue"
       InstanceTypes                        = "g6.12xlarge" # 4 Nvidia L4 GPUs, 192GB memory
-      MinSize                              = 40
-      MaxSize                              = 40
+      MinSize                              = 10
+      MaxSize                              = 10
       ECRAccessPolicy                      = "readonly"
       InstanceOperatingSystem              = "linux"
       OnDemandPercentage                   = 100

--- a/terraform/aws/cloudformation_stack.tf
+++ b/terraform/aws/cloudformation_stack.tf
@@ -213,14 +213,15 @@ locals {
       BuildkiteAgentTokenParameterStorePath = data.aws_ssm_parameter.bk_agent_token_cluster_ci.name
       BuildkiteQueue                       = "gpu_4_queue"
       InstanceTypes                        = "g6.12xlarge" # 4 Nvidia L4 GPUs, 192GB memory
-      MaxSize                              = 64
+      MinSize                              = 40
+      MaxSize                              = 40
       ECRAccessPolicy                      = "readonly"
       InstanceOperatingSystem              = "linux"
       OnDemandPercentage                   = 100
       ImageId                              = "ami-040f1b73b7a7c7453" # Custom AMI with Nvidia driver 570.133.20
       BootstrapScriptUrl                   = "https://vllm-ci.s3.us-west-2.amazonaws.com/bootstrap.sh"
-      # Recycle each GPU instance after a single job completes.
-      BuildkiteTerminateInstanceAfterJob   = true
+      # Keep scarce GPU capacity once AWS fulfills it.
+      BuildkiteTerminateInstanceAfterJob   = false
     }
   }
 
@@ -373,7 +374,9 @@ resource "aws_cloudformation_stack" "bk_queue_ci_gpu" {
   name       = "bk-${each.key}"
   parameters = { for k, v in each.value : k => v if k != "elastic_ci_stack_version" }
 
-  template_url = "https://s3.amazonaws.com/buildkite-aws-stack/v${each.value["elastic_ci_stack_version"]}/aws-stack.yml"
+  # v6.21.0 forces a blue/green ASG replacement for parameter updates. That
+  # cannot converge for gpu_4_queue when scarce capacity is already in use.
+  template_url = each.key == "gpu-4-queue-ci" ? "https://vllm-ci.s3.us-west-2.amazonaws.com/infra/buildkite-aws-stack/v6.21.0/aws-stack-fixed-capacity-b77222719ba6.yml" : "https://s3.amazonaws.com/buildkite-aws-stack/v${each.value["elastic_ci_stack_version"]}/aws-stack.yml"
   capabilities = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
 
   lifecycle {

--- a/terraform/aws/cloudformation_stack.tf
+++ b/terraform/aws/cloudformation_stack.tf
@@ -214,13 +214,13 @@ locals {
       BuildkiteQueue                       = "gpu_4_queue"
       InstanceTypes                        = "g6.12xlarge" # 4 Nvidia L4 GPUs, 192GB memory
       MinSize                              = 10
-      MaxSize                              = 10
+      MaxSize                              = 40
       ECRAccessPolicy                      = "readonly"
       InstanceOperatingSystem              = "linux"
       OnDemandPercentage                   = 100
       ImageId                              = "ami-040f1b73b7a7c7453" # Custom AMI with Nvidia driver 570.133.20
       BootstrapScriptUrl                   = "https://vllm-ci.s3.us-west-2.amazonaws.com/bootstrap.sh"
-      # Keep scarce GPU capacity once AWS fulfills it.
+      # Keep a persistent baseline while allowing demand-based scale-out.
       BuildkiteTerminateInstanceAfterJob   = false
     }
   }


### PR DESCRIPTION
## What changed

- keep `gpu_4_queue` at `MinSize = 10` with `MaxSize = 40`
- disable `BuildkiteTerminateInstanceAfterJob` so scarce `g6.12xlarge` capacity is retained between jobs
- enable the standard Buildkite queue autoscaler by making the stack variable-sized
- use a content-addressed copy of the exact Buildkite v6.21.0 template for this stack only; it removes forced blue/green ASG replacement and the fixed-size creation-signal wait

## Behavior

- ten instances are the protected baseline and desired capacity remains 10 without additional demand
- the queue autoscaler polls Buildkite every minute and may increase desired capacity up to 40
- automatic scale-in remains disabled for persistent agents, so reducing capacity above 10 is an explicit drain and scale-down operation

## Why

AWS was returning `InsufficientInstanceCapacity` for `g6.12xlarge` across all four `us-west-2` availability zones. Recycling each instance after one job lost capacity that could not reliably be reacquired. The upstream v6.21.0 template also forces a second ASG for parameter changes, which cannot converge while existing scarce capacity remains allocated.

The patched template keeps the existing physical ASG and prevents the baseline capacity from disappearing, while still allowing demand-based scale-out when more agents are needed.

## Validation

- `terraform validate`
- `git diff --check`
- CloudFormation change set reports `AgentAutoScaleGroup` as `Modify` with `Replacement: False` and `MaxSize` requiring no recreation
- the only added resource is the standard `Autoscaling` nested stack
- retained `bk-gpu-4-queue-ci-AgentAutoScaleGroup-OEQAPNeflt32`
- CloudFormation reached `UPDATE_COMPLETE` with `MinSize=10`, `MaxSize=40`, and `BuildkiteTerminateInstanceAfterJob=false`
- live ASG initially remained desired/in-service 10 with all ten instances protected from scale-in
- autoscaler EventBridge rule is enabled at `rate(1 minute)` and its first polls capped desired capacity at the ten-instance minimum
- targeted Terraform plan reports `0 to add, 1 to change, 0 to destroy`; the remaining in-place change is the known template URL state drift
