### PR TITLE
Enable command and pytest tracing centrally

### DIFF
--- a/buildkite/pipeline_generator/README.md
+++ b/buildkite/pipeline_generator/README.md
@@ -97,6 +97,12 @@ trusted `vllm-project/vllm` main-branch builds. It injects the helpers in
 emits one `pytest.test` child span per test. Job YAML does not need an opt-in
 field.
 
+Command and pytest spans are written to an ephemeral local spool while tests
+run. An `EXIT` trap uploads the complete job batch once, preserving the job's
+original exit status. The exporter has a three-second total network deadline
+and the shell enforces a four-second hard stop, so an unavailable telemetry
+receiver cannot add an unbounded delay to every command.
+
 Pull-request containers are deliberately excluded from this fine-grained
 instrumentation because exporting spans currently requires access to the
 Buildkite agent binary to mint a short-lived OIDC token. Mounting that binary

--- a/buildkite/pipeline_generator/README.md
+++ b/buildkite/pipeline_generator/README.md
@@ -87,3 +87,20 @@ Kubernetes-backed test jobs read `BUILDKITE_ANALYTICS_TOKEN` from the
 The Secret is optional, so missing credentials do not prevent jobs from running.
 Provision it in a Buildkite job namespace with
 `infra-k8s/create-buildkite-analytics-secret.sh` to enable test result uploads.
+
+## OpenTelemetry command and test timing
+
+The generator automatically instruments every standard NVIDIA and CPU job in
+trusted `vllm-project/vllm` main-branch builds. It injects the helpers in
+`otel_helpers/`, emits one
+`ci.command` span for each configured command, and loads a pytest plugin that
+emits one `pytest.test` child span per test. Job YAML does not need an opt-in
+field.
+
+Pull-request containers are deliberately excluded from this fine-grained
+instrumentation because exporting spans currently requires access to the
+Buildkite agent binary to mint a short-lived OIDC token. Mounting that binary
+into a container running untrusted PR code would cross the CI trust boundary.
+AMD mirrors are also excluded because their remote runtime does not expose the
+agent binary. Native Buildkite agent tracing can still cover job phases for
+both cases when it is enabled on those agents.

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -7,6 +7,7 @@ import gzip
 from io import BytesIO
 import os
 from pathlib import Path
+import re
 import tarfile
 
 from amd import (
@@ -438,8 +439,21 @@ def _prepare_commands(
                 # Buildkite's final command rendering rewrites single quotes,
                 # so shell quoting is not stable here. Base64 keeps arbitrary
                 # command text opaque until ci_otel_run evaluates it in-job.
+                # Inject generator-owned variables before encoding because the
+                # final replacement pass cannot see inside base64. Buildkite's
+                # $$ escaping is unnecessary inside the encoded payload and
+                # would expand to the shell PID when ci_otel_run evaluates it.
+                traced_command = cmd
+                for variable, value in variables_to_inject.items():
+                    if not value:
+                        continue
+                    pattern = re.escape(variable)
+                    runtime_value = value.replace("$$", "$")
+                    traced_command = re.sub(
+                        pattern + r"\b", runtime_value, traced_command
+                    )
                 encoded_preview = base64.b64encode(preview.encode()).decode()
-                encoded_command = base64.b64encode(cmd.encode()).decode()
+                encoded_command = base64.b64encode(traced_command.encode()).decode()
                 prepared_command = "ci_otel_run {} {} {}".format(
                     i + 1,
                     encoded_preview,
@@ -465,8 +479,6 @@ def _prepare_commands(
             if not value:
                 continue
             # Use regex to only replace whole variable matches (not substrings)
-            import re
-
             # Escape variable (may have $ or special characters)
             pattern = re.escape(variable)
             command = re.sub(pattern + r"\b", value, command)

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 from typing import Dict, List, Optional, Any, Union, Literal
 from copy import deepcopy
+import base64
 import os
 
 from amd import (
@@ -376,6 +377,13 @@ def _prepare_commands(
 ) -> List[str]:
     """Prepare step commands with variables injected and default setup commands."""
     commands = _get_setup_commands(step, setup_profile)
+    # AMD mirrors use a different runtime and do not mount the agent binary
+    # that mints the short-lived upload credential.
+    trace_commands = step.otel_tracing_enabled() and setup_profile != "amd"
+    if trace_commands:
+        commands.append(
+            "source /vllm-workspace/.buildkite/scripts/ci_otel.sh"
+        )
 
     continue_on_failure = os.getenv("CONTINUE_ON_FAILURE") == "1"
 
@@ -389,12 +397,26 @@ def _prepare_commands(
             commands.append(
                 f"echo '+++ :test_tube: Command ({i + 1}/{len(step.commands)}): {preview}'"
             )
+            prepared_command = cmd
+            if trace_commands:
+                # Buildkite's final command rendering rewrites single quotes,
+                # so shell quoting is not stable here. Base64 keeps arbitrary
+                # command text opaque until ci_otel_run evaluates it in-job.
+                encoded_preview = base64.b64encode(preview.encode()).decode()
+                encoded_command = base64.b64encode(cmd.encode()).decode()
+                prepared_command = "ci_otel_run {} {} {}".format(
+                    i + 1,
+                    encoded_preview,
+                    encoded_command,
+                )
             if continue_on_failure:
                 # Note: We don't use a subshell here to preserve environment changes between commands
                 # (export, cd, etc).
-                commands.append(f"{{ {cmd}\n}} || CI_OVERALL_STATUS=1")
+                commands.append(
+                    f"{{ {prepared_command}\n}} || CI_OVERALL_STATUS=1"
+                )
             else:
-                commands.append(cmd)
+                commands.append(prepared_command)
 
     if continue_on_failure:
         commands.append("exit $$CI_OVERALL_STATUS")

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -2,7 +2,12 @@ from pydantic import BaseModel
 from typing import Dict, List, Optional, Any, Union, Literal
 from copy import deepcopy
 import base64
+from functools import lru_cache
+import gzip
+from io import BytesIO
 import os
+from pathlib import Path
+import tarfile
 
 from amd import (
     AMD_ALWAYS_RUN_STEP_KEYS,
@@ -37,6 +42,38 @@ PRECOMMIT_WAIT_INTERVAL = 60
 
 SKIP_TIMEOUT_ENV_VAR = "SKIP_TIMEOUT"
 EXIT_STATUS_NEGATIVE_ONE_RETRY = {"exit_status": -1, "limit": 1}
+
+OTEL_HELPERS_DIR = Path(__file__).resolve().parent / "otel_helpers"
+OTEL_HELPER_FILES = ("ci_otel.py", "ci_otel.sh", "ci_pytest_otel.py")
+
+
+@lru_cache(maxsize=1)
+def _otel_helpers_bundle() -> str:
+    """Return a deterministic compressed bundle for injection into CI jobs."""
+    archive = BytesIO()
+    with gzip.GzipFile(
+        fileobj=archive, mode="wb", compresslevel=9, mtime=0
+    ) as compressed:
+        with tarfile.open(fileobj=compressed, mode="w") as bundle:
+            for name in OTEL_HELPER_FILES:
+                contents = (OTEL_HELPERS_DIR / name).read_bytes()
+                info = tarfile.TarInfo(name=name)
+                info.size = len(contents)
+                info.mode = 0o755 if name.endswith(".sh") else 0o644
+                info.mtime = 0
+                bundle.addfile(info, BytesIO(contents))
+    return base64.b64encode(archive.getvalue()).decode()
+
+
+def _otel_setup_command() -> str:
+    """Install ci-infra-owned tracing helpers in an ephemeral job directory."""
+    bundle = _otel_helpers_bundle()
+    return (
+        "export VLLM_CI_OTEL_DIR=$$(mktemp -d) && "
+        f'printf "%s" "{bundle}" | base64 --decode | '
+        'tar -xz -C "$$VLLM_CI_OTEL_DIR" && '
+        'source "$$VLLM_CI_OTEL_DIR/ci_otel.sh"'
+    )
 
 
 # Self-contained poll of the pre-commit GitHub Actions check run. Baked with the
@@ -377,13 +414,12 @@ def _prepare_commands(
 ) -> List[str]:
     """Prepare step commands with variables injected and default setup commands."""
     commands = _get_setup_commands(step, setup_profile)
-    # AMD mirrors use a different runtime and do not mount the agent binary
-    # that mints the short-lived upload credential.
+    # AMD mirrors use a separate runtime and do not expose the agent binary
+    # needed to mint the short-lived upload credential. Native agent tracing
+    # still covers those jobs; command/test spans are injected elsewhere.
     trace_commands = step.otel_tracing_enabled() and setup_profile != "amd"
     if trace_commands:
-        commands.append(
-            "source /vllm-workspace/.buildkite/scripts/ci_otel.sh"
-        )
+        commands.append(_otel_setup_command())
 
     continue_on_failure = os.getenv("CONTINUE_ON_FAILURE") == "1"
 

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -67,13 +67,18 @@ def _otel_helpers_bundle() -> str:
 
 
 def _otel_setup_command() -> str:
-    """Install ci-infra-owned tracing helpers in an ephemeral job directory."""
+    """Best-effort install of ci-infra-owned tracing helpers."""
     bundle = _otel_helpers_bundle()
     return (
-        "export VLLM_CI_OTEL_DIR=$$(mktemp -d) && "
+        "VLLM_CI_OTEL_READY=0; export VLLM_CI_OTEL_READY; "
+        "if VLLM_CI_OTEL_DIR=$$(mktemp -d 2>/dev/null) && "
+        "export VLLM_CI_OTEL_DIR && "
         f'printf "%s" "{bundle}" | base64 --decode | '
         'tar -xz -C "$$VLLM_CI_OTEL_DIR" && '
-        '. "$$VLLM_CI_OTEL_DIR/ci_otel.sh"'
+        'sh -n "$$VLLM_CI_OTEL_DIR/ci_otel.sh" && '
+        '. "$$VLLM_CI_OTEL_DIR/ci_otel.sh"; then :; else '
+        'echo "vLLM CI OTel: tracing setup skipped" >&2 || :; '
+        "VLLM_CI_OTEL_READY=0; export VLLM_CI_OTEL_READY; fi; :"
     )
 
 
@@ -436,28 +441,19 @@ def _prepare_commands(
             )
             prepared_command = cmd
             if trace_commands:
-                # Buildkite's final command rendering rewrites single quotes,
-                # so shell quoting is not stable here. Base64 keeps arbitrary
-                # command text opaque until ci_otel_run evaluates it in-job.
-                # Inject generator-owned variables before encoding because the
-                # final replacement pass cannot see inside base64. Buildkite's
-                # $$ escaping is unnecessary inside the encoded payload and
-                # would expand to the shell PID when ci_otel_run evaluates it.
-                traced_command = cmd
-                for variable, value in variables_to_inject.items():
-                    if not value:
-                        continue
-                    pattern = re.escape(variable)
-                    runtime_value = value.replace("$$", "$")
-                    traced_command = re.sub(
-                        pattern + r"\b", runtime_value, traced_command
-                    )
+                # Run the original command directly. Tracing only brackets it
+                # with best-effort start/finish calls, so OTel never owns command
+                # execution and cannot change shell state or failure semantics.
                 encoded_preview = base64.b64encode(preview.encode()).decode()
-                encoded_command = base64.b64encode(traced_command.encode()).decode()
-                prepared_command = "ci_otel_run {} {} {}".format(
-                    i + 1,
-                    encoded_preview,
-                    encoded_command,
+                prepared_command = (
+                    'if [ "$${VLLM_CI_OTEL_READY:-0}" = "1" ] && '
+                    "command -v ci_otel_start >/dev/null 2>&1; then "
+                    f"ci_otel_start {i + 1} {encoded_preview} || :; fi\n"
+                    f"{cmd}\n"
+                    "_VLLM_CI_OTEL_COMMAND_STATUS=$$?\n"
+                    "if command -v ci_otel_finish >/dev/null 2>&1; then "
+                    "ci_otel_finish $$_VLLM_CI_OTEL_COMMAND_STATUS || :; fi\n"
+                    "(exit $$_VLLM_CI_OTEL_COMMAND_STATUS)"
                 )
             if continue_on_failure:
                 # Note: We don't use a subshell here to preserve environment changes between commands

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -73,7 +73,7 @@ def _otel_setup_command() -> str:
         "export VLLM_CI_OTEL_DIR=$$(mktemp -d) && "
         f'printf "%s" "{bundle}" | base64 --decode | '
         'tar -xz -C "$$VLLM_CI_OTEL_DIR" && '
-        'source "$$VLLM_CI_OTEL_DIR/ci_otel.sh"'
+        '. "$$VLLM_CI_OTEL_DIR/ci_otel.sh"'
     )
 
 

--- a/buildkite/pipeline_generator/otel_helpers/__init__.py
+++ b/buildkite/pipeline_generator/otel_helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime helpers injected into trusted vLLM CI jobs."""

--- a/buildkite/pipeline_generator/otel_helpers/ci_otel.py
+++ b/buildkite/pipeline_generator/otel_helpers/ci_otel.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
@@ -8,19 +7,23 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 import os
 import secrets
 import struct
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.request
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+from pathlib import Path
 
 ENDPOINT = os.getenv("VLLM_CI_OTEL_ENDPOINT", "https://ci.vllm.ai/api/otel/v1/traces")
 AUDIENCE = os.getenv("VLLM_CI_OTEL_AUDIENCE", "https://ci.vllm.ai/api/otel")
-MAX_BATCH_SIZE = 250
+MAX_BATCH_SIZE = 2_000
+UPLOAD_TIMEOUT_SECONDS = float(os.getenv("VLLM_CI_OTEL_UPLOAD_TIMEOUT", "3"))
 
 
 @dataclass(frozen=True)
@@ -156,7 +159,54 @@ def new_context() -> tuple[str, str, str | None]:
     return trace_id, secrets.token_hex(8), parent_span_id
 
 
-def _oidc_token() -> str:
+def _spool_dir() -> Path | None:
+    value = os.getenv("VLLM_CI_OTEL_SPOOL_DIR")
+    return Path(value) if value else None
+
+
+def record_spans(spans: Iterable[Span]) -> bool:
+    """Append spans to a process-local spool file without doing network I/O."""
+    spool_dir = _spool_dir()
+    records = [json.dumps(asdict(span), separators=(",", ":")) for span in spans]
+    if spool_dir is None or not records:
+        return False
+    try:
+        spool_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        spool_file = spool_dir / f"spans-{os.getpid()}.jsonl"
+        with spool_file.open("a", encoding="utf-8") as output:
+            output.write("\n".join(records) + "\n")
+        return True
+    except OSError as error:
+        print(f"CI timing spool skipped: {error}", file=sys.stderr)
+        return False
+
+
+def load_spans() -> list[Span]:
+    spool_dir = _spool_dir()
+    if spool_dir is None or not spool_dir.is_dir():
+        return []
+    spans: list[Span] = []
+    for spool_file in sorted(spool_dir.glob("spans-*.jsonl")):
+        try:
+            with spool_file.open(encoding="utf-8") as records:
+                for record in records:
+                    if record.strip():
+                        spans.append(Span(**json.loads(record)))
+        except (OSError, TypeError, ValueError, json.JSONDecodeError) as error:
+            print(
+                f"CI timing spool ignored {spool_file.name}: {error}", file=sys.stderr
+            )
+    return spans
+
+
+def _remaining_seconds(deadline: float) -> float:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise TimeoutError("CI timing upload deadline exceeded")
+    return remaining
+
+
+def _oidc_token(deadline: float) -> str:
     result = subprocess.run(
         [
             "buildkite-agent",
@@ -172,12 +222,14 @@ def _oidc_token() -> str:
         check=True,
         capture_output=True,
         text=True,
-        timeout=20,
+        timeout=_remaining_seconds(deadline),
     )
     return result.stdout.strip()
 
 
-def export_spans(spans: list[Span]) -> bool:
+def export_spans(
+    spans: list[Span], timeout_seconds: float = UPLOAD_TIMEOUT_SECONDS
+) -> bool:
     if not spans or os.getenv("BUILDKITE", "") != "true":
         return False
     required = (
@@ -192,7 +244,8 @@ def export_spans(spans: list[Span]) -> bool:
         return False
 
     try:
-        token = _oidc_token()
+        deadline = time.monotonic() + max(timeout_seconds, 0.1)
+        token = _oidc_token(deadline)
         for offset in range(0, len(spans), MAX_BATCH_SIZE):
             payload = encode_request(spans[offset : offset + MAX_BATCH_SIZE])
             request = urllib.request.Request(
@@ -205,7 +258,9 @@ def export_spans(spans: list[Span]) -> bool:
                     "User-Agent": "vllm-ci-otel/1",
                 },
             )
-            with urllib.request.urlopen(request, timeout=20) as response:
+            with urllib.request.urlopen(
+                request, timeout=_remaining_seconds(deadline)
+            ) as response:
                 if response.status != 200:
                     raise RuntimeError(f"OTLP endpoint returned {response.status}")
         return True
@@ -213,6 +268,7 @@ def export_spans(spans: list[Span]) -> bool:
         OSError,
         RuntimeError,
         subprocess.SubprocessError,
+        TimeoutError,
         urllib.error.URLError,
     ) as error:
         print(f"CI timing upload skipped: {error}", file=sys.stderr)
@@ -242,7 +298,8 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("new-context")
-    command = subparsers.add_parser("command")
+    subparsers.add_parser("flush")
+    command = subparsers.add_parser("record-command")
     command.add_argument("--trace-id", required=True)
     command.add_argument("--span-id", required=True)
     command.add_argument("--parent-span-id", default="")
@@ -257,7 +314,12 @@ def main() -> int:
         trace_id, span_id, parent_span_id = new_context()
         print(trace_id, span_id, parent_span_id or "-")
         return 0
-    export_spans([_command_span(args)])
+    if args.command == "record-command":
+        record_spans([_command_span(args)])
+        return 0
+    if args.command == "flush":
+        export_spans(load_spans())
+        return 0
     return 0
 
 

--- a/buildkite/pipeline_generator/otel_helpers/ci_otel.py
+++ b/buildkite/pipeline_generator/otel_helpers/ci_otel.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Dependency-free OTLP exporter for command and pytest CI spans."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import secrets
+import struct
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+ENDPOINT = os.getenv("VLLM_CI_OTEL_ENDPOINT", "https://ci.vllm.ai/api/otel/v1/traces")
+AUDIENCE = os.getenv("VLLM_CI_OTEL_AUDIENCE", "https://ci.vllm.ai/api/otel")
+MAX_BATCH_SIZE = 250
+
+
+@dataclass(frozen=True)
+class Span:
+    trace_id: str
+    span_id: str
+    parent_span_id: str | None
+    name: str
+    start_ns: int
+    end_ns: int
+    attributes: dict[str, str | int | bool]
+    status_code: int = 1
+
+
+def _varint(value: int) -> bytes:
+    if value < 0:
+        value += 1 << 64
+    encoded = bytearray()
+    while value > 0x7F:
+        encoded.append((value & 0x7F) | 0x80)
+        value >>= 7
+    encoded.append(value)
+    return bytes(encoded)
+
+
+def _key(field: int, wire_type: int) -> bytes:
+    return _varint((field << 3) | wire_type)
+
+
+def _bytes_field(field: int, value: bytes) -> bytes:
+    return _key(field, 2) + _varint(len(value)) + value
+
+
+def _string_field(field: int, value: str) -> bytes:
+    return _bytes_field(field, value.encode())
+
+
+def _varint_field(field: int, value: int) -> bytes:
+    return _key(field, 0) + _varint(value)
+
+
+def _fixed64_field(field: int, value: int) -> bytes:
+    return _key(field, 1) + struct.pack("<Q", value)
+
+
+def _fixed32_field(field: int, value: int) -> bytes:
+    return _key(field, 5) + struct.pack("<I", value)
+
+
+def _any_value(value: str | int | bool) -> bytes:
+    if isinstance(value, bool):
+        return _varint_field(2, int(value))
+    if isinstance(value, int):
+        return _varint_field(3, value)
+    return _string_field(1, value)
+
+
+def _attribute(key: str, value: str | int | bool) -> bytes:
+    return _string_field(1, key) + _bytes_field(2, _any_value(value))
+
+
+def _resource_attributes() -> dict[str, str | int | bool]:
+    build_number = os.getenv("BUILDKITE_BUILD_NUMBER", "0")
+    attributes: dict[str, str | int | bool] = {
+        "service.name": "vllm-ci",
+        "buildkite.organization.slug": os.getenv("BUILDKITE_ORGANIZATION_SLUG", ""),
+        "buildkite.pipeline.slug": os.getenv("BUILDKITE_PIPELINE_SLUG", ""),
+        "buildkite.build.id": os.getenv("BUILDKITE_BUILD_ID", ""),
+        "buildkite.build.number": int(build_number) if build_number.isdigit() else 0,
+        "buildkite.build.branch": os.getenv("BUILDKITE_BRANCH", ""),
+        "buildkite.build.commit": os.getenv("BUILDKITE_COMMIT", ""),
+        "buildkite.job.id": os.getenv("BUILDKITE_JOB_ID", ""),
+        "buildkite.job.label": os.getenv("BUILDKITE_LABEL", ""),
+        "buildkite.step.key": os.getenv("BUILDKITE_STEP_KEY", ""),
+        "buildkite.agent.queue": os.getenv("BUILDKITE_AGENT_META_DATA_QUEUE", ""),
+    }
+    return {key: value for key, value in attributes.items() if value != ""}
+
+
+def _encode_span(span: Span) -> bytes:
+    encoded = b"".join(
+        [
+            _bytes_field(1, bytes.fromhex(span.trace_id)),
+            _bytes_field(2, bytes.fromhex(span.span_id)),
+            _bytes_field(4, bytes.fromhex(span.parent_span_id))
+            if span.parent_span_id
+            else b"",
+            _string_field(5, span.name),
+            _varint_field(6, 1),
+            _fixed64_field(7, span.start_ns),
+            _fixed64_field(8, span.end_ns),
+        ]
+    )
+    attributes = dict(span.attributes)
+    build_url = os.getenv("BUILDKITE_BUILD_URL")
+    job_id = os.getenv("BUILDKITE_JOB_ID")
+    if build_url and job_id:
+        attributes.setdefault("buildkite.job.web_url", f"{build_url}#{job_id}")
+    for key, value in attributes.items():
+        encoded += _bytes_field(9, _attribute(key, value))
+    encoded += _bytes_field(15, _varint_field(3, span.status_code))
+    encoded += _fixed32_field(16, 1)
+    return encoded
+
+
+def encode_request(spans: Iterable[Span]) -> bytes:
+    resource = b"".join(
+        _bytes_field(1, _attribute(key, value))
+        for key, value in _resource_attributes().items()
+    )
+    scope = _string_field(1, "vllm.ci") + _string_field(2, "1")
+    scope_spans = _bytes_field(1, scope)
+    for span in spans:
+        scope_spans += _bytes_field(2, _encode_span(span))
+    resource_spans = _bytes_field(1, resource) + _bytes_field(2, scope_spans)
+    return _bytes_field(1, resource_spans)
+
+
+def new_context() -> tuple[str, str, str | None]:
+    traceparent = os.getenv("TRACEPARENT", "").lower()
+    parts = traceparent.split("-")
+    valid_lengths = len(parts) == 4 and [len(part) for part in parts] == [2, 32, 16, 2]
+    valid_hex = valid_lengths and all(
+        all(character in "0123456789abcdef" for character in part) for part in parts
+    )
+    if valid_hex and parts[1] != "0" * 32 and parts[2] != "0" * 16:
+        trace_id = parts[1]
+        parent_span_id = parts[2]
+    else:
+        build_id = os.getenv("BUILDKITE_BUILD_ID", "local")
+        trace_id = hashlib.sha256(build_id.encode()).hexdigest()[:32]
+        parent_span_id = None
+    return trace_id, secrets.token_hex(8), parent_span_id
+
+
+def _oidc_token() -> str:
+    result = subprocess.run(
+        [
+            "buildkite-agent",
+            "oidc",
+            "request-token",
+            "--audience",
+            AUDIENCE,
+            "--lifetime",
+            "300",
+            "--claim",
+            "build_id",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    return result.stdout.strip()
+
+
+def export_spans(spans: list[Span]) -> bool:
+    if not spans or os.getenv("BUILDKITE", "") != "true":
+        return False
+    required = (
+        "BUILDKITE_ORGANIZATION_SLUG",
+        "BUILDKITE_PIPELINE_SLUG",
+        "BUILDKITE_BUILD_ID",
+        "BUILDKITE_BUILD_NUMBER",
+        "BUILDKITE_JOB_ID",
+        "BUILDKITE_BRANCH",
+    )
+    if any(not os.getenv(name) for name in required):
+        return False
+
+    try:
+        token = _oidc_token()
+        for offset in range(0, len(spans), MAX_BATCH_SIZE):
+            payload = encode_request(spans[offset : offset + MAX_BATCH_SIZE])
+            request = urllib.request.Request(
+                ENDPOINT,
+                data=payload,
+                method="POST",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/x-protobuf",
+                    "User-Agent": "vllm-ci-otel/1",
+                },
+            )
+            with urllib.request.urlopen(request, timeout=20) as response:
+                if response.status != 200:
+                    raise RuntimeError(f"OTLP endpoint returned {response.status}")
+        return True
+    except (
+        OSError,
+        RuntimeError,
+        subprocess.SubprocessError,
+        urllib.error.URLError,
+    ) as error:
+        print(f"CI timing upload skipped: {error}", file=sys.stderr)
+        return False
+
+
+def _command_span(args: argparse.Namespace) -> Span:
+    attributes: dict[str, str | int | bool] = {
+        "ci.span.kind": "command",
+        "ci.command.index": args.index,
+        "ci.command.label": args.label,
+        "process.exit.code": args.exit_code,
+    }
+    return Span(
+        trace_id=args.trace_id,
+        span_id=args.span_id,
+        parent_span_id=args.parent_span_id or None,
+        name="ci.command",
+        start_ns=args.start_ns,
+        end_ns=args.end_ns,
+        attributes=attributes,
+        status_code=1 if args.exit_code == 0 else 2,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("new-context")
+    command = subparsers.add_parser("command")
+    command.add_argument("--trace-id", required=True)
+    command.add_argument("--span-id", required=True)
+    command.add_argument("--parent-span-id", default="")
+    command.add_argument("--start-ns", required=True, type=int)
+    command.add_argument("--end-ns", required=True, type=int)
+    command.add_argument("--index", required=True, type=int)
+    command.add_argument("--label", required=True)
+    command.add_argument("--exit-code", required=True, type=int)
+    args = parser.parse_args()
+
+    if args.command == "new-context":
+        trace_id, span_id, parent_span_id = new_context()
+        print(trace_id, span_id, parent_span_id or "-")
+        return 0
+    export_spans([_command_span(args)])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/buildkite/pipeline_generator/otel_helpers/ci_otel.py
+++ b/buildkite/pipeline_generator/otel_helpers/ci_otel.py
@@ -14,7 +14,6 @@ import struct
 import subprocess
 import sys
 import time
-import urllib.error
 import urllib.request
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass
@@ -23,7 +22,17 @@ from pathlib import Path
 ENDPOINT = os.getenv("VLLM_CI_OTEL_ENDPOINT", "https://ci.vllm.ai/api/otel/v1/traces")
 AUDIENCE = os.getenv("VLLM_CI_OTEL_AUDIENCE", "https://ci.vllm.ai/api/otel")
 MAX_BATCH_SIZE = 2_000
-UPLOAD_TIMEOUT_SECONDS = float(os.getenv("VLLM_CI_OTEL_UPLOAD_TIMEOUT", "3"))
+
+
+def _upload_timeout_seconds() -> float:
+    try:
+        value = float(os.getenv("VLLM_CI_OTEL_UPLOAD_TIMEOUT", "3"))
+        return value if value > 0 else 3.0
+    except (TypeError, ValueError):
+        return 3.0
+
+
+UPLOAD_TIMEOUT_SECONDS = _upload_timeout_seconds()
 
 
 @dataclass(frozen=True)
@@ -166,17 +175,17 @@ def _spool_dir() -> Path | None:
 
 def record_spans(spans: Iterable[Span]) -> bool:
     """Append spans to a process-local spool file without doing network I/O."""
-    spool_dir = _spool_dir()
-    records = [json.dumps(asdict(span), separators=(",", ":")) for span in spans]
-    if spool_dir is None or not records:
-        return False
     try:
+        spool_dir = _spool_dir()
+        records = [json.dumps(asdict(span), separators=(",", ":")) for span in spans]
+        if spool_dir is None or not records:
+            return False
         spool_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         spool_file = spool_dir / f"spans-{os.getpid()}.jsonl"
         with spool_file.open("a", encoding="utf-8") as output:
             output.write("\n".join(records) + "\n")
         return True
-    except OSError as error:
+    except Exception as error:
         print(f"CI timing spool skipped: {error}", file=sys.stderr)
         return False
 
@@ -264,13 +273,7 @@ def export_spans(
                 if response.status != 200:
                     raise RuntimeError(f"OTLP endpoint returned {response.status}")
         return True
-    except (
-        OSError,
-        RuntimeError,
-        subprocess.SubprocessError,
-        TimeoutError,
-        urllib.error.URLError,
-    ) as error:
+    except Exception as error:
         print(f"CI timing upload skipped: {error}", file=sys.stderr)
         return False
 

--- a/buildkite/pipeline_generator/otel_helpers/ci_otel.sh
+++ b/buildkite/pipeline_generator/otel_helpers/ci_otel.sh
@@ -1,73 +1,129 @@
 #!/usr/bin/env bash
 
 _VLLM_CI_OTEL_DIR="${VLLM_CI_OTEL_DIR:?VLLM_CI_OTEL_DIR must point to the injected CI tracing helpers}"
-export PYTHONPATH="${_VLLM_CI_OTEL_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
-export PYTEST_ADDOPTS="${PYTEST_ADDOPTS:-} -p ci_pytest_otel"
 export VLLM_CI_OTEL_SPOOL_DIR="${VLLM_CI_OTEL_SPOOL_DIR:-${_VLLM_CI_OTEL_DIR}/spans}"
-mkdir -p "${VLLM_CI_OTEL_SPOOL_DIR}" || true
+VLLM_CI_OTEL_READY=0
+export VLLM_CI_OTEL_READY
 
-_ci_otel_on_exit() {
-  local command_status=$?
-  trap - EXIT
-  if command -v timeout >/dev/null 2>&1; then
-    timeout 4s python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" flush || true
-  else
-    python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" flush || true
-  fi
-  exit "${command_status}"
+_ci_otel_disable() {
+  VLLM_CI_OTEL_READY=0
+  export VLLM_CI_OTEL_READY
+  echo "vLLM CI OTel: tracing disabled after a helper failure" >&2 || :
+  return 0
 }
 
-trap _ci_otel_on_exit EXIT
+_ci_otel_python() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 2s python3 "$@"
+  else
+    python3 "$@"
+  fi
+}
 
-ci_otel_run() {
+_ci_otel_on_exit() {
+  _VLLM_CI_OTEL_EXIT_STATUS=$?
+  trap - 0
+  if [ "${VLLM_CI_OTEL_READY:-0}" = "1" ]; then
+    ci_otel_finish "${_VLLM_CI_OTEL_EXIT_STATUS}" || true
+  fi
+  if [ "${VLLM_CI_OTEL_READY:-0}" = "1" ]; then
+    if command -v timeout >/dev/null 2>&1; then
+      timeout 4s python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" flush || true
+    else
+      python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" flush || true
+    fi
+  fi
+  exit "${_VLLM_CI_OTEL_EXIT_STATUS}"
+}
+
+ci_otel_start() {
   local command_index="$1"
   local encoded_label="$2"
-  local encoded_command="$3"
   local command_label
-  local command_text
   local context
   local trace_id
   local span_id
   local parent_span_id
   local start_ns
-  local end_ns
-  local command_status
 
-  if ! command_label="$(printf '%s' "${encoded_label}" | base64 --decode)" ||
-    ! command_text="$(printf '%s' "${encoded_command}" | base64 --decode)"; then
-    echo "vLLM CI OTel: could not decode generated command metadata" >&2
-    return 1
-  fi
+  command_label="$(printf '%s' "${encoded_label}" | base64 --decode 2>/dev/null)" ||
+    command_label="command ${command_index}"
 
-  if ! context="$(python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" new-context)"; then
-    eval "${command_text}"
-    return $?
+  if ! context="$(_ci_otel_python "${_VLLM_CI_OTEL_DIR}/ci_otel.py" new-context)"; then
+    _ci_otel_disable
+    return 0
   fi
   set -- ${context}
+  if [ "$#" -ne 3 ]; then
+    _ci_otel_disable
+    return 0
+  fi
   trace_id="$1"
   span_id="$2"
   parent_span_id="$3"
   [ "${parent_span_id}" = "-" ] && parent_span_id=""
-  start_ns="$(date +%s%N)"
-
-  local VLLM_CI_TRACE_ID="${trace_id}"
-  local VLLM_CI_COMMAND_SPAN_ID="${span_id}"
-  export VLLM_CI_TRACE_ID VLLM_CI_COMMAND_SPAN_ID
-  if eval "${command_text}"; then
-    command_status=0
-  else
-    command_status=$?
+  if ! start_ns="$(date +%s%N)"; then
+    _ci_otel_disable
+    return 0
   fi
-  end_ns="$(date +%s%N)"
 
-  python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" record-command \
-    --trace-id "${trace_id}" \
-    --span-id "${span_id}" \
-    --parent-span-id "${parent_span_id}" \
-    --start-ns "${start_ns}" \
-    --end-ns "${end_ns}" \
-    --index "${command_index}" \
-    --label "${command_label}" \
-    --exit-code "${command_status}" || true
-  return "${command_status}"
+  VLLM_CI_TRACE_ID="${trace_id}"
+  VLLM_CI_COMMAND_SPAN_ID="${span_id}"
+  export VLLM_CI_TRACE_ID VLLM_CI_COMMAND_SPAN_ID
+  _VLLM_CI_OTEL_ACTIVE=1
+  _VLLM_CI_OTEL_ACTIVE_INDEX="${command_index}"
+  _VLLM_CI_OTEL_ACTIVE_LABEL="${command_label}"
+  _VLLM_CI_OTEL_ACTIVE_TRACE_ID="${trace_id}"
+  _VLLM_CI_OTEL_ACTIVE_SPAN_ID="${span_id}"
+  _VLLM_CI_OTEL_ACTIVE_PARENT_SPAN_ID="${parent_span_id}"
+  _VLLM_CI_OTEL_ACTIVE_START_NS="${start_ns}"
+  return 0
 }
+
+ci_otel_finish() {
+  local command_status="${1:-0}"
+  local end_ns
+
+  if [ "${_VLLM_CI_OTEL_ACTIVE:-0}" != "1" ]; then
+    return 0
+  fi
+  _VLLM_CI_OTEL_ACTIVE=0
+  VLLM_CI_TRACE_ID=""
+  VLLM_CI_COMMAND_SPAN_ID=""
+  export VLLM_CI_TRACE_ID VLLM_CI_COMMAND_SPAN_ID
+  end_ns="$(date +%s%N 2>/dev/null)" ||
+    end_ns="${_VLLM_CI_OTEL_ACTIVE_START_NS}"
+
+  if ! _ci_otel_python "${_VLLM_CI_OTEL_DIR}/ci_otel.py" record-command \
+    --trace-id "${_VLLM_CI_OTEL_ACTIVE_TRACE_ID}" \
+    --span-id "${_VLLM_CI_OTEL_ACTIVE_SPAN_ID}" \
+    --parent-span-id "${_VLLM_CI_OTEL_ACTIVE_PARENT_SPAN_ID}" \
+    --start-ns "${_VLLM_CI_OTEL_ACTIVE_START_NS}" \
+    --end-ns "${end_ns}" \
+    --index "${_VLLM_CI_OTEL_ACTIVE_INDEX}" \
+    --label "${_VLLM_CI_OTEL_ACTIVE_LABEL}" \
+    --exit-code "${command_status}"; then
+    _ci_otel_disable
+  fi
+  return 0
+}
+
+# Do not modify Python or pytest state until both helper modules are importable
+# and the local spool is writable. A failed check leaves tracing disabled and
+# the generated job runs its original command directly.
+if command -v python3 >/dev/null 2>&1 &&
+  mkdir -p "${VLLM_CI_OTEL_SPOOL_DIR}" &&
+  (
+    export PYTHONPATH="${_VLLM_CI_OTEL_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
+    python3 -c "import ci_otel, ci_pytest_otel" >/dev/null 2>&1
+  ); then
+  export PYTHONPATH="${_VLLM_CI_OTEL_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
+  export PYTEST_ADDOPTS="${PYTEST_ADDOPTS:-} -p ci_pytest_otel"
+  VLLM_CI_OTEL_READY=1
+  export VLLM_CI_OTEL_READY
+  trap _ci_otel_on_exit 0
+else
+  echo "vLLM CI OTel: tracing disabled; test command will run normally" >&2 || :
+fi
+
+:

--- a/buildkite/pipeline_generator/otel_helpers/ci_otel.sh
+++ b/buildkite/pipeline_generator/otel_helpers/ci_otel.sh
@@ -43,8 +43,11 @@ ci_otel_run() {
     eval "${command_text}"
     return $?
   fi
-  read -r trace_id span_id parent_span_id <<<"${context}"
-  [[ "${parent_span_id}" == "-" ]] && parent_span_id=""
+  set -- ${context}
+  trace_id="$1"
+  span_id="$2"
+  parent_span_id="$3"
+  [ "${parent_span_id}" = "-" ] && parent_span_id=""
   start_ns="$(date +%s%N)"
 
   local VLLM_CI_TRACE_ID="${trace_id}"

--- a/buildkite/pipeline_generator/otel_helpers/ci_otel.sh
+++ b/buildkite/pipeline_generator/otel_helpers/ci_otel.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+_VLLM_CI_OTEL_DIR="${VLLM_CI_OTEL_DIR:?VLLM_CI_OTEL_DIR must point to the injected CI tracing helpers}"
+export PYTHONPATH="${_VLLM_CI_OTEL_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
+export PYTEST_ADDOPTS="${PYTEST_ADDOPTS:-} -p ci_pytest_otel"
+
+ci_otel_run() {
+  local command_index="$1"
+  local encoded_label="$2"
+  local encoded_command="$3"
+  local command_label
+  local command_text
+  local context
+  local trace_id
+  local span_id
+  local parent_span_id
+  local start_ns
+  local end_ns
+  local command_status
+
+  if ! command_label="$(printf '%s' "${encoded_label}" | base64 --decode)" ||
+    ! command_text="$(printf '%s' "${encoded_command}" | base64 --decode)"; then
+    echo "vLLM CI OTel: could not decode generated command metadata" >&2
+    return 1
+  fi
+
+  if ! context="$(python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" new-context)"; then
+    eval "${command_text}"
+    return $?
+  fi
+  read -r trace_id span_id parent_span_id <<<"${context}"
+  [[ "${parent_span_id}" == "-" ]] && parent_span_id=""
+  start_ns="$(date +%s%N)"
+
+  local VLLM_CI_TRACE_ID="${trace_id}"
+  local VLLM_CI_COMMAND_SPAN_ID="${span_id}"
+  export VLLM_CI_TRACE_ID VLLM_CI_COMMAND_SPAN_ID
+  if eval "${command_text}"; then
+    command_status=0
+  else
+    command_status=$?
+  fi
+  end_ns="$(date +%s%N)"
+
+  python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" command \
+    --trace-id "${trace_id}" \
+    --span-id "${span_id}" \
+    --parent-span-id "${parent_span_id}" \
+    --start-ns "${start_ns}" \
+    --end-ns "${end_ns}" \
+    --index "${command_index}" \
+    --label "${command_label}" \
+    --exit-code "${command_status}" || true
+  return "${command_status}"
+}

--- a/buildkite/pipeline_generator/otel_helpers/ci_otel.sh
+++ b/buildkite/pipeline_generator/otel_helpers/ci_otel.sh
@@ -3,6 +3,21 @@
 _VLLM_CI_OTEL_DIR="${VLLM_CI_OTEL_DIR:?VLLM_CI_OTEL_DIR must point to the injected CI tracing helpers}"
 export PYTHONPATH="${_VLLM_CI_OTEL_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
 export PYTEST_ADDOPTS="${PYTEST_ADDOPTS:-} -p ci_pytest_otel"
+export VLLM_CI_OTEL_SPOOL_DIR="${VLLM_CI_OTEL_SPOOL_DIR:-${_VLLM_CI_OTEL_DIR}/spans}"
+mkdir -p "${VLLM_CI_OTEL_SPOOL_DIR}" || true
+
+_ci_otel_on_exit() {
+  local command_status=$?
+  trap - EXIT
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 4s python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" flush || true
+  else
+    python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" flush || true
+  fi
+  exit "${command_status}"
+}
+
+trap _ci_otel_on_exit EXIT
 
 ci_otel_run() {
   local command_index="$1"
@@ -42,7 +57,7 @@ ci_otel_run() {
   fi
   end_ns="$(date +%s%N)"
 
-  python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" command \
+  python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" record-command \
     --trace-id "${trace_id}" \
     --span-id "${span_id}" \
     --parent-span-id "${parent_span_id}" \

--- a/buildkite/pipeline_generator/otel_helpers/ci_pytest_otel.py
+++ b/buildkite/pipeline_generator/otel_helpers/ci_pytest_otel.py
@@ -9,7 +9,7 @@ import os
 import time
 from dataclasses import dataclass
 
-from ci_otel import Span, export_spans
+from ci_otel import Span, record_spans
 
 
 @dataclass
@@ -77,5 +77,5 @@ def pytest_sessionfinish(session, exitstatus: int):
     for nodeid, run in list(_runs.items()):
         _spans.append(_test_span(nodeid, run))
     _runs.clear()
-    export_spans(_spans)
+    record_spans(_spans)
     _spans.clear()

--- a/buildkite/pipeline_generator/otel_helpers/ci_pytest_otel.py
+++ b/buildkite/pipeline_generator/otel_helpers/ci_pytest_otel.py
@@ -23,33 +23,50 @@ _runs: dict[str, TestRun] = {}
 _spans: list[Span] = []
 
 
+def _soft_fail(action):
+    """Contain every tracing exception so pytest owns the job outcome."""
+    try:
+        action()
+    except Exception:
+        return
+
+
 def _enabled() -> bool:
     return bool(os.getenv("VLLM_CI_TRACE_ID") and os.getenv("VLLM_CI_COMMAND_SPAN_ID"))
 
 
 def pytest_runtest_logstart(nodeid: str, location: tuple[str, int | None, str]):
-    if _enabled():
-        _runs[nodeid] = TestRun(start_ns=time.time_ns())
+    def record_start():
+        if _enabled():
+            _runs[nodeid] = TestRun(start_ns=time.time_ns())
+
+    _soft_fail(record_start)
 
 
 def pytest_runtest_logreport(report):
-    run = _runs.get(report.nodeid)
-    if not run:
-        return
-    if report.failed:
-        run.outcome = "failed"
-    elif report.skipped and run.outcome != "failed":
-        run.outcome = "skipped"
-    elif report.when == "call" and run.outcome == "unknown":
-        run.outcome = "passed"
+    def record_report():
+        run = _runs.get(report.nodeid)
+        if not run:
+            return
+        if report.failed:
+            run.outcome = "failed"
+        elif report.skipped and run.outcome != "failed":
+            run.outcome = "skipped"
+        elif report.when == "call" and run.outcome == "unknown":
+            run.outcome = "passed"
+
+    _soft_fail(record_report)
 
 
 def pytest_runtest_logfinish(nodeid: str, location: tuple[str, int | None, str]):
-    run = _runs.pop(nodeid, None)
-    if not run:
-        return
-    run.end_ns = time.time_ns()
-    _spans.append(_test_span(nodeid, run))
+    def record_finish():
+        run = _runs.pop(nodeid, None)
+        if not run:
+            return
+        run.end_ns = time.time_ns()
+        _spans.append(_test_span(nodeid, run))
+
+    _soft_fail(record_finish)
 
 
 def _test_span(nodeid: str, run: TestRun) -> Span:
@@ -72,10 +89,13 @@ def _test_span(nodeid: str, run: TestRun) -> Span:
 
 
 def pytest_sessionfinish(session, exitstatus: int):
-    if not _enabled():
-        return
-    for nodeid, run in list(_runs.items()):
-        _spans.append(_test_span(nodeid, run))
-    _runs.clear()
-    record_spans(_spans)
-    _spans.clear()
+    def finish_session():
+        if not _enabled():
+            return
+        for nodeid, run in list(_runs.items()):
+            _spans.append(_test_span(nodeid, run))
+        _runs.clear()
+        record_spans(_spans)
+        _spans.clear()
+
+    _soft_fail(finish_session)

--- a/buildkite/pipeline_generator/otel_helpers/ci_pytest_otel.py
+++ b/buildkite/pipeline_generator/otel_helpers/ci_pytest_otel.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Pytest plugin that emits one OTLP span per collected test."""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+
+from ci_otel import Span, export_spans
+
+
+@dataclass
+class TestRun:
+    start_ns: int
+    end_ns: int = 0
+    outcome: str = "unknown"
+
+
+_runs: dict[str, TestRun] = {}
+_spans: list[Span] = []
+
+
+def _enabled() -> bool:
+    return bool(os.getenv("VLLM_CI_TRACE_ID") and os.getenv("VLLM_CI_COMMAND_SPAN_ID"))
+
+
+def pytest_runtest_logstart(nodeid: str, location: tuple[str, int | None, str]):
+    if _enabled():
+        _runs[nodeid] = TestRun(start_ns=time.time_ns())
+
+
+def pytest_runtest_logreport(report):
+    run = _runs.get(report.nodeid)
+    if not run:
+        return
+    if report.failed:
+        run.outcome = "failed"
+    elif report.skipped and run.outcome != "failed":
+        run.outcome = "skipped"
+    elif report.when == "call" and run.outcome == "unknown":
+        run.outcome = "passed"
+
+
+def pytest_runtest_logfinish(nodeid: str, location: tuple[str, int | None, str]):
+    run = _runs.pop(nodeid, None)
+    if not run:
+        return
+    run.end_ns = time.time_ns()
+    _spans.append(_test_span(nodeid, run))
+
+
+def _test_span(nodeid: str, run: TestRun) -> Span:
+    outcome = run.outcome
+    return Span(
+        trace_id=os.environ["VLLM_CI_TRACE_ID"],
+        span_id=os.urandom(8).hex(),
+        parent_span_id=os.environ["VLLM_CI_COMMAND_SPAN_ID"],
+        name="pytest.test",
+        start_ns=run.start_ns,
+        end_ns=run.end_ns or time.time_ns(),
+        attributes={
+            "ci.span.kind": "test",
+            "test.nodeid": nodeid,
+            "test.file": nodeid.split("::", 1)[0],
+            "test.outcome": outcome,
+        },
+        status_code=2 if outcome == "failed" else 1,
+    )
+
+
+def pytest_sessionfinish(session, exitstatus: int):
+    if not _enabled():
+        return
+    for nodeid, run in list(_runs.items()):
+        _spans.append(_test_span(nodeid, run))
+    _runs.clear()
+    export_spans(_spans)
+    _spans.clear()

--- a/buildkite/pipeline_generator/plugin/docker_plugin.py
+++ b/buildkite/pipeline_generator/plugin/docker_plugin.py
@@ -141,7 +141,11 @@ def get_docker_plugin(step: Step, image: str):
     if step.device in (DeviceType.H200_18GB, DeviceType.H200_35GB):
         image = image.replace("public.ecr.aws", "936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache")
         plugin["image"] = image
-    if step.label == "Benchmarks" or step.mount_buildkite_agent:
+    if (
+        step.label == "Benchmarks"
+        or step.mount_buildkite_agent
+        or step.otel_tracing_enabled()
+    ):
         plugin["mount_buildkite_agent"] = True
     if step.device in (DeviceType.CPU, DeviceType.CPU_SMALL, DeviceType.CPU_MEDIUM) and plugin.get("gpus"):
         del plugin["gpus"]

--- a/buildkite/pipeline_generator/pyproject.toml
+++ b/buildkite/pipeline_generator/pyproject.toml
@@ -28,4 +28,7 @@ py-modules = [
 ]
 
 [tool.setuptools.packages.find]
-include = [".", "plugin", "utils_lib"]
+include = [".", "otel_helpers", "plugin", "utils_lib"]
+
+[tool.setuptools.package-data]
+otel_helpers = ["*.sh"]

--- a/buildkite/pipeline_generator/step.py
+++ b/buildkite/pipeline_generator/step.py
@@ -26,6 +26,7 @@ class Step(BaseModel):
     concurrency_group: Optional[str] = None
     timeout_in_minutes: Optional[int] = None
     mount_buildkite_agent: Optional[bool] = False
+    otel_trace: bool = False
     env: Optional[Dict[str, str]] = None
     retry: Optional[Dict[str, Any]] = None
     optional: Optional[bool] = False
@@ -33,6 +34,14 @@ class Step(BaseModel):
     no_gpu: Optional[bool] = False
     dind: bool = True
     mirror: Optional[Dict[str, Dict[str, Any]]] = None
+
+    def otel_tracing_enabled(self) -> bool:
+        config = get_global_config()
+        return bool(
+            self.otel_trace
+            and config["branch"] == "main"
+            and config["pull_request"] == "false"
+        )
 
     @model_validator(mode="after")
     def validate_multi_node(self) -> Self:

--- a/buildkite/pipeline_generator/step.py
+++ b/buildkite/pipeline_generator/step.py
@@ -26,7 +26,6 @@ class Step(BaseModel):
     concurrency_group: Optional[str] = None
     timeout_in_minutes: Optional[int] = None
     mount_buildkite_agent: Optional[bool] = False
-    otel_trace: bool = False
     env: Optional[Dict[str, str]] = None
     retry: Optional[Dict[str, Any]] = None
     optional: Optional[bool] = False
@@ -38,7 +37,7 @@ class Step(BaseModel):
     def otel_tracing_enabled(self) -> bool:
         config = get_global_config()
         return bool(
-            self.otel_trace
+            config["github_repo_name"] == "vllm-project/vllm"
             and config["branch"] == "main"
             and config["pull_request"] == "false"
         )

--- a/buildkite/tests/pipeline_generator/test_plugins.py
+++ b/buildkite/tests/pipeline_generator/test_plugins.py
@@ -22,13 +22,23 @@ def test_standard_docker_templates_forward_buildkite_analytics_token(template):
     assert BUILDKITE_ANALYTICS_TOKEN in template["environment"]
 
 
-def test_traced_main_step_mounts_buildkite_agent(fake_global_config):
+def test_every_trusted_main_step_mounts_buildkite_agent(fake_global_config):
     fake_global_config["branch"] = "main"
-    step = Step(label="Traced", device="h200_35gb", otel_trace=True)
+    step = Step(label="Traced", device="h200_35gb")
 
     plugin = docker_plugin.get_docker_plugin(step, "example/image:latest")
 
     assert plugin["mount_buildkite_agent"] is True
+
+
+def test_pull_request_step_does_not_mount_agent_for_tracing(fake_global_config):
+    fake_global_config["branch"] = "main"
+    fake_global_config["pull_request"] = "123"
+    step = Step(label="Untrusted", device="h200_35gb")
+
+    plugin = docker_plugin.get_docker_plugin(step, "example/image:latest")
+
+    assert not plugin.get("mount_buildkite_agent", False)
 
 
 @pytest.mark.parametrize(

--- a/buildkite/tests/pipeline_generator/test_plugins.py
+++ b/buildkite/tests/pipeline_generator/test_plugins.py
@@ -5,6 +5,7 @@ from plugin.analytics import (
     BUILDKITE_ANALYTICS_SECRET,
     BUILDKITE_ANALYTICS_TOKEN,
 )
+from step import Step
 
 
 @pytest.mark.parametrize(
@@ -19,6 +20,15 @@ from plugin.analytics import (
 )
 def test_standard_docker_templates_forward_buildkite_analytics_token(template):
     assert BUILDKITE_ANALYTICS_TOKEN in template["environment"]
+
+
+def test_traced_main_step_mounts_buildkite_agent(fake_global_config):
+    fake_global_config["branch"] = "main"
+    step = Step(label="Traced", device="h200_35gb", otel_trace=True)
+
+    plugin = docker_plugin.get_docker_plugin(step, "example/image:latest")
+
+    assert plugin["mount_buildkite_agent"] is True
 
 
 @pytest.mark.parametrize(

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -1,4 +1,6 @@
 import base64
+import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -196,17 +198,22 @@ def test_otel_trace_wraps_every_command_on_trusted_main(fake_global_config):
         setup_profile="none",
     )
 
-    assert "VLLM_CI_OTEL_DIR=$$(mktemp -d)" in commands[0]
+    assert "VLLM_CI_OTEL_DIR=$$(mktemp -d 2>/dev/null)" in commands[0]
+    assert commands[0].endswith("fi; :")
     assert '. "$$VLLM_CI_OTEL_DIR/ci_otel.sh"' in commands[0]
-    assert commands[2].startswith("ci_otel_run 1 ")
-    assert commands[4].startswith("ci_otel_run 2 ")
-    _, _, encoded_label, encoded_command = commands[4].split(" ")
+    assert "ci_otel_start 1 " in commands[2]
+    assert "export VALUE=ready" in commands[2]
+    assert "ci_otel_finish" in commands[2]
+    assert "ci_otel_start 2 " in commands[4]
+    assert 'test "$VALUE" = ready' in commands[4]
+    match = re.search(r"ci_otel_start 2 (\S+)", commands[4])
+    assert match is not None
+    (encoded_label,) = match.groups()
     assert base64.b64decode(encoded_label).decode() == "test VALUE = ready"
-    assert base64.b64decode(encoded_command).decode() == 'test "$VALUE" = ready'
     assert "'" not in commands[4]
 
 
-def test_otel_trace_injects_generator_variables_before_encoding(fake_global_config):
+def test_otel_trace_preserves_generator_variable_injection(fake_global_config):
     fake_global_config["branch"] = "main"
     step = Step(
         label="Traced image build",
@@ -224,10 +231,7 @@ def test_otel_trace_injects_generator_variables_before_encoding(fake_global_conf
         setup_profile="none",
     )
 
-    _, _, _, encoded_command = commands[2].split(" ")
-    assert base64.b64decode(encoded_command).decode() == (
-        "build registry.example.com vllm-ci $BUILDKITE_COMMIT"
-    )
+    assert "build registry.example.com vllm-ci $$BUILDKITE_COMMIT" in commands[2]
 
 
 def test_otel_helper_bundle_installs_and_sources():
@@ -239,7 +243,9 @@ def test_otel_helper_bundle_installs_and_sources():
             command
             + " && test -f \"$VLLM_CI_OTEL_DIR/ci_otel.py\""
             + " && test -f \"$VLLM_CI_OTEL_DIR/ci_pytest_otel.py\""
-            + " && type ci_otel_run",
+            + ' && test "$VLLM_CI_OTEL_READY" = 1'
+            + " && type ci_otel_start"
+            + " && type ci_otel_finish",
         ],
         check=False,
         capture_output=True,
@@ -249,6 +255,104 @@ def test_otel_helper_bundle_installs_and_sources():
     assert result.returncode == 0, result.stderr
 
 
+def test_otel_setup_failure_is_soft_and_direct_command_runs(
+    fake_global_config, tmp_path
+):
+    fake_global_config["branch"] = "main"
+    output = tmp_path / "command-ran"
+    step = Step(
+        label="Traced",
+        group="Tracing",
+        commands=['printf ran > "$OUTPUT_FILE"'],
+    )
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="none",
+    )
+    script = "mktemp() { return 1; };\n" + "\n".join(commands).replace("$$", "$")
+
+    result = subprocess.run(
+        ["/bin/sh", "-e", "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "OUTPUT_FILE": str(output)},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output.read_text(encoding="utf-8") == "ran"
+    assert "tracing setup skipped" in result.stderr
+
+
+def test_otel_import_failure_leaves_test_environment_untouched(
+    fake_global_config, tmp_path
+):
+    fake_global_config["branch"] = "main"
+    output = tmp_path / "command-ran"
+    step = Step(
+        label="Traced",
+        group="Tracing",
+        commands=['printf ran > "$OUTPUT_FILE"'],
+    )
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="none",
+    )
+    script = (
+        "python3() { return 1; };\n"
+        + "\n".join(commands).replace("$$", "$")
+        + '\ntest "$VLLM_CI_OTEL_READY" = 0'
+        + '\ntest "$PYTHONPATH" = original-pythonpath'
+        + '\ntest "$PYTEST_ADDOPTS" = original-pytest-options'
+    )
+
+    result = subprocess.run(
+        ["/bin/sh", "-e", "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "OUTPUT_FILE": str(output),
+            "PYTHONPATH": "original-pythonpath",
+            "PYTEST_ADDOPTS": "original-pytest-options",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output.read_text(encoding="utf-8") == "ran"
+    assert "tracing disabled" in result.stderr
+
+
+def test_otel_does_not_change_errexit_behavior(fake_global_config, tmp_path):
+    fake_global_config["branch"] = "main"
+    output = tmp_path / "must-not-run"
+    step = Step(
+        label="Traced failure",
+        group="Tracing",
+        commands=['false\nprintf bad > "$OUTPUT_FILE"'],
+    )
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="none",
+    )
+    script = "\n".join(commands).replace("$$", "$")
+
+    result = subprocess.run(
+        ["/bin/sh", "-e", "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "OUTPUT_FILE": str(output)},
+    )
+
+    assert result.returncode == 1
+    assert not output.exists()
+
+
 def test_otel_helper_bundle_runs_under_posix_shell():
     command = buildkite_step._otel_setup_command().replace("$$", "$")
     result = subprocess.run(
@@ -256,7 +360,8 @@ def test_otel_helper_bundle_runs_under_posix_shell():
             "/bin/sh",
             "-c",
             command
-            + " && ci_otel_run 1 dHJ1ZQ== dHJ1ZQ=="
+            + " && ci_otel_start 1 dHJ1ZQ=="
+            + " && true && ci_otel_finish 0"
             + ' && test -n "$(find "$VLLM_CI_OTEL_SPOOL_DIR" -name spans-\\*.jsonl -size +0c -print -quit)"',
         ],
         check=False,

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -197,7 +197,7 @@ def test_otel_trace_wraps_every_command_on_trusted_main(fake_global_config):
     )
 
     assert "VLLM_CI_OTEL_DIR=$$(mktemp -d)" in commands[0]
-    assert 'source "$$VLLM_CI_OTEL_DIR/ci_otel.sh"' in commands[0]
+    assert '. "$$VLLM_CI_OTEL_DIR/ci_otel.sh"' in commands[0]
     assert commands[2].startswith("ci_otel_run 1 ")
     assert commands[4].startswith("ci_otel_run 2 ")
     _, _, encoded_label, encoded_command = commands[4].split(" ")
@@ -240,6 +240,24 @@ def test_otel_helper_bundle_installs_and_sources():
             + " && test -f \"$VLLM_CI_OTEL_DIR/ci_otel.py\""
             + " && test -f \"$VLLM_CI_OTEL_DIR/ci_pytest_otel.py\""
             + " && type ci_otel_run",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_otel_helper_bundle_runs_under_posix_shell():
+    command = buildkite_step._otel_setup_command().replace("$$", "$")
+    result = subprocess.run(
+        [
+            "/bin/sh",
+            "-c",
+            command
+            + " && ci_otel_run 1 dHJ1ZQ== dHJ1ZQ=="
+            + ' && test -n "$(find "$VLLM_CI_OTEL_SPOOL_DIR" -name spans-\\*.jsonl -size +0c -print -quit)"',
         ],
         check=False,
         capture_output=True,

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -182,13 +182,12 @@ def test_continue_on_failure_exits_nonzero_after_command_failure(monkeypatch):
     assert result.returncode == 1
 
 
-def test_otel_trace_wraps_commands_only_on_trusted_main(fake_global_config):
+def test_otel_trace_wraps_every_command_on_trusted_main(fake_global_config):
     fake_global_config["branch"] = "main"
     step = Step(
         label="Traced",
         group="Tracing",
         commands=["export VALUE=ready", 'test "$VALUE" = ready'],
-        otel_trace=True,
     )
 
     commands = buildkite_step._prepare_commands(
@@ -197,7 +196,8 @@ def test_otel_trace_wraps_commands_only_on_trusted_main(fake_global_config):
         setup_profile="none",
     )
 
-    assert commands[0] == "source /vllm-workspace/.buildkite/scripts/ci_otel.sh"
+    assert "VLLM_CI_OTEL_DIR=$$(mktemp -d)" in commands[0]
+    assert 'source "$$VLLM_CI_OTEL_DIR/ci_otel.sh"' in commands[0]
     assert commands[2].startswith("ci_otel_run 1 ")
     assert commands[4].startswith("ci_otel_run 2 ")
     _, _, encoded_label, encoded_command = commands[4].split(" ")
@@ -206,9 +206,28 @@ def test_otel_trace_wraps_commands_only_on_trusted_main(fake_global_config):
     assert "'" not in commands[4]
 
 
+def test_otel_helper_bundle_installs_and_sources():
+    command = buildkite_step._otel_setup_command().replace("$$", "$")
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            command
+            + " && test -f \"$VLLM_CI_OTEL_DIR/ci_otel.py\""
+            + " && test -f \"$VLLM_CI_OTEL_DIR/ci_pytest_otel.py\""
+            + " && type ci_otel_run",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_otel_trace_is_disabled_for_amd_mirror(fake_global_config):
     fake_global_config["branch"] = "main"
-    step = Step(label="AMD mirror", commands=["pytest tests"], otel_trace=True)
+    step = Step(label="AMD mirror", commands=["pytest tests"])
 
     commands = buildkite_step._prepare_commands(
         step,
@@ -222,7 +241,21 @@ def test_otel_trace_is_disabled_for_amd_mirror(fake_global_config):
 def test_otel_trace_is_disabled_for_pull_requests(fake_global_config):
     fake_global_config["branch"] = "main"
     fake_global_config["pull_request"] = "123"
-    step = Step(label="Untrusted", commands=["pytest tests"], otel_trace=True)
+    step = Step(label="Untrusted", commands=["pytest tests"])
+
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="none",
+    )
+
+    assert not any("ci_otel" in command for command in commands)
+
+
+def test_otel_trace_is_disabled_for_non_vllm_pipelines(fake_global_config):
+    fake_global_config["branch"] = "main"
+    fake_global_config["github_repo_name"] = "vllm-project/other"
+    step = Step(label="Other repository", commands=["pytest tests"])
 
     commands = buildkite_step._prepare_commands(
         step,

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -206,6 +206,30 @@ def test_otel_trace_wraps_every_command_on_trusted_main(fake_global_config):
     assert "'" not in commands[4]
 
 
+def test_otel_trace_injects_generator_variables_before_encoding(fake_global_config):
+    fake_global_config["branch"] = "main"
+    step = Step(
+        label="Traced image build",
+        group="Tracing",
+        commands=["build $REGISTRY $REPO $BUILDKITE_COMMIT"],
+    )
+
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={
+            "$REGISTRY": "registry.example.com",
+            "$REPO": "vllm-ci",
+            "$BUILDKITE_COMMIT": "$$BUILDKITE_COMMIT",
+        },
+        setup_profile="none",
+    )
+
+    _, _, _, encoded_command = commands[2].split(" ")
+    assert base64.b64decode(encoded_command).decode() == (
+        "build registry.example.com vllm-ci $BUILDKITE_COMMIT"
+    )
+
+
 def test_otel_helper_bundle_installs_and_sources():
     command = buildkite_step._otel_setup_command().replace("$$", "$")
     result = subprocess.run(

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -1,3 +1,4 @@
+import base64
 import subprocess
 import sys
 from pathlib import Path
@@ -179,6 +180,57 @@ def test_continue_on_failure_exits_nonzero_after_command_failure(monkeypatch):
     assert "CI_OVERALL_STATUS=1" in script
     assert "after" in result.stdout
     assert result.returncode == 1
+
+
+def test_otel_trace_wraps_commands_only_on_trusted_main(fake_global_config):
+    fake_global_config["branch"] = "main"
+    step = Step(
+        label="Traced",
+        group="Tracing",
+        commands=["export VALUE=ready", 'test "$VALUE" = ready'],
+        otel_trace=True,
+    )
+
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="none",
+    )
+
+    assert commands[0] == "source /vllm-workspace/.buildkite/scripts/ci_otel.sh"
+    assert commands[2].startswith("ci_otel_run 1 ")
+    assert commands[4].startswith("ci_otel_run 2 ")
+    _, _, encoded_label, encoded_command = commands[4].split(" ")
+    assert base64.b64decode(encoded_label).decode() == "test VALUE = ready"
+    assert base64.b64decode(encoded_command).decode() == 'test "$VALUE" = ready'
+    assert "'" not in commands[4]
+
+
+def test_otel_trace_is_disabled_for_amd_mirror(fake_global_config):
+    fake_global_config["branch"] = "main"
+    step = Step(label="AMD mirror", commands=["pytest tests"], otel_trace=True)
+
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="amd",
+    )
+
+    assert not any("ci_otel" in command for command in commands)
+
+
+def test_otel_trace_is_disabled_for_pull_requests(fake_global_config):
+    fake_global_config["branch"] = "main"
+    fake_global_config["pull_request"] = "123"
+    step = Step(label="Untrusted", commands=["pytest tests"], otel_trace=True)
+
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="none",
+    )
+
+    assert not any("ci_otel" in command for command in commands)
 
 
 def test_generated_steps_retry_when_the_agent_is_lost():

--- a/buildkite/tests/test_ci_otel.py
+++ b/buildkite/tests/test_ci_otel.py
@@ -16,6 +16,7 @@ SCRIPTS_DIR = (
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 import ci_otel  # noqa: E402
+import ci_pytest_otel  # noqa: E402
 from ci_otel import (  # noqa: E402
     Span,
     encode_request,
@@ -179,16 +180,76 @@ def test_export_deadline_bounds_oidc_request(monkeypatch, tmp_path):
     assert time.monotonic() - started < 0.5
 
 
+def test_invalid_upload_timeout_cannot_break_plugin_import():
+    result = subprocess.run(
+        [sys.executable, "-c", "import ci_otel, ci_pytest_otel"],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(SCRIPTS_DIR),
+            "VLLM_CI_OTEL_UPLOAD_TIMEOUT": "not-a-number",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_export_contains_unexpected_internal_errors(monkeypatch):
+    for name, value in {
+        "BUILDKITE": "true",
+        "BUILDKITE_ORGANIZATION_SLUG": "vllm",
+        "BUILDKITE_PIPELINE_SLUG": "ci",
+        "BUILDKITE_BUILD_ID": "build-id",
+        "BUILDKITE_BUILD_NUMBER": "42",
+        "BUILDKITE_JOB_ID": "job-id",
+        "BUILDKITE_BRANCH": "main",
+    }.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setattr(
+        ci_otel,
+        "_oidc_token",
+        lambda deadline: (_ for _ in ()).throw(ValueError("broken exporter")),
+    )
+    span = Span(
+        trace_id="01" * 16,
+        span_id="02" * 8,
+        parent_span_id=None,
+        name="ci.command",
+        start_ns=100,
+        end_ns=200,
+        attributes={},
+    )
+
+    assert export_spans([span]) is False
+
+
+def test_record_spans_contains_serialization_errors(monkeypatch, tmp_path):
+    monkeypatch.setenv("VLLM_CI_OTEL_SPOOL_DIR", str(tmp_path))
+    span = Span(
+        trace_id="01" * 16,
+        span_id="02" * 8,
+        parent_span_id=None,
+        name="ci.command",
+        start_ns=100,
+        end_ns=200,
+        attributes={"invalid": object()},  # type: ignore[dict-item]
+    )
+
+    assert record_spans([span]) is False
+
+
 def test_shell_wrapper_preserves_command_state_and_quoting(tmp_path):
     script = SCRIPTS_DIR / "ci_otel.sh"
-    first = "ci_otel_run 1 {} {}".format(
-        _encoded("export VALUE=ready"),
-        _encoded("export VALUE=ready"),
+    first = f"ci_otel_start 1 {_encoded('export VALUE=ready')}"
+    second = f"ci_otel_start 2 {_encoded('check VALUE')}"
+    shell = (
+        f'source "{script}"; {first}; export VALUE=ready; ci_otel_finish 0; '
+        f'{second}; test "$VALUE" = ready; ci_otel_finish 0'
     )
-    second_command = 'test "$VALUE" = ready'
-    second = f"ci_otel_run 2 {_encoded('check VALUE')} {_encoded(second_command)}"
     result = subprocess.run(
-        ["bash", "-c", f'source "{script}"; {first}; {second}'],
+        ["bash", "-c", shell],
         check=False,
         capture_output=True,
         text=True,
@@ -204,13 +265,10 @@ def test_shell_wrapper_preserves_command_state_and_quoting(tmp_path):
 
 def test_shell_wrapper_expands_runtime_environment_arguments(tmp_path):
     script = SCRIPTS_DIR / "ci_otel.sh"
-    command_text = 'test "$REGISTRY" = registry.example.com && test "$COMMIT" = abc123'
-    command = "ci_otel_run 1 {} {}".format(
-        _encoded("check generated variables"),
-        _encoded(command_text),
-    )
+    start = f"ci_otel_start 1 {_encoded('check generated variables')}"
+    command = 'test "$REGISTRY" = registry.example.com && test "$COMMIT" = abc123'
     result = subprocess.run(
-        ["bash", "-c", f'source "{script}"; {command}'],
+        ["bash", "-c", f'source "{script}"; {start}; {command}; ci_otel_finish $?'],
         check=False,
         capture_output=True,
         text=True,
@@ -228,12 +286,14 @@ def test_shell_wrapper_expands_runtime_environment_arguments(tmp_path):
 
 def test_shell_wrapper_preserves_failure_status(tmp_path):
     script = SCRIPTS_DIR / "ci_otel.sh"
-    command = "ci_otel_run 1 {} {}".format(
-        _encoded("false"),
-        _encoded("false"),
-    )
+    start = f"ci_otel_start 1 {_encoded('false')}"
     result = subprocess.run(
-        ["bash", "-c", f'source "{script}"; {command}'],
+        [
+            "bash",
+            "-c",
+            f'source "{script}"; {start}; false; status=$?; '
+            'ci_otel_finish "$status"; (exit "$status")',
+        ],
         check=False,
         capture_output=True,
         text=True,
@@ -245,3 +305,124 @@ def test_shell_wrapper_preserves_failure_status(tmp_path):
     )
 
     assert result.returncode == 1, result.stderr
+
+
+def test_shell_wrapper_runs_command_when_context_creation_fails(tmp_path):
+    script = SCRIPTS_DIR / "ci_otel.sh"
+    start = f"ci_otel_start 1 {_encoded('write marker')}"
+    result = subprocess.run(
+        [
+            "/bin/sh",
+            "-c",
+            f'. "{script}"; python3() {{ return 1; }}; {start} || :; '
+            'printf ran > "$OUTPUT_FILE"',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "OUTPUT_FILE": str(tmp_path / "ran"),
+            "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
+            "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path / "spans"),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "ran").read_text(encoding="utf-8") == "ran"
+
+
+def test_shell_wrapper_ignores_recording_failure(tmp_path):
+    script = SCRIPTS_DIR / "ci_otel.sh"
+    start = f"ci_otel_start 1 {_encoded('true')}"
+    shell = f"""
+      . "{script}"
+      python3() {{
+        if [ "$2" = "new-context" ]; then
+          echo 01010101010101010101010101010101 0202020202020202 -
+          return 0
+        fi
+        return 99
+      }}
+      {start}
+      true
+      ci_otel_finish 0
+    """
+    result = subprocess.run(
+        ["/bin/sh", "-e", "-c", shell],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
+            "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_exit_flush_failure_preserves_success_and_failure(tmp_path):
+    script = SCRIPTS_DIR / "ci_otel.sh"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python3"
+    fake_python.write_text("#!/bin/sh\nexit 99\n", encoding="utf-8")
+    fake_python.chmod(0o755)
+
+    def run_with_status(status: int):
+        shell = f'. "{script}"; PATH="{fake_bin}"; export PATH; exit {status}'
+        return subprocess.run(
+            ["/bin/sh", "-c", shell],
+            check=False,
+            capture_output=True,
+            text=True,
+            env={
+                **os.environ,
+                "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
+                "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path / f"spans-{status}"),
+            },
+        )
+
+    assert run_with_status(0).returncode == 0
+    assert run_with_status(7).returncode == 7
+
+
+def test_pytest_hooks_contain_all_tracing_errors(monkeypatch):
+    monkeypatch.setenv("VLLM_CI_TRACE_ID", "01" * 16)
+    monkeypatch.setenv("VLLM_CI_COMMAND_SPAN_ID", "02" * 8)
+    ci_pytest_otel._runs.clear()
+    ci_pytest_otel._spans.clear()
+    monkeypatch.setattr(
+        ci_pytest_otel.time,
+        "time_ns",
+        lambda: (_ for _ in ()).throw(RuntimeError("broken clock")),
+    )
+
+    ci_pytest_otel.pytest_runtest_logstart("test_example", ("test.py", 1, "test"))
+    ci_pytest_otel.pytest_runtest_logreport(object())
+    ci_pytest_otel.pytest_runtest_logfinish("test_example", ("test.py", 1, "test"))
+    ci_pytest_otel.pytest_sessionfinish(None, 0)
+
+
+def test_real_pytest_passes_when_otel_spool_is_unwritable(tmp_path):
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text("def test_sample():\n    assert True\n", encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", str(test_file)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(SCRIPTS_DIR),
+            "PYTEST_ADDOPTS": "-p ci_pytest_otel",
+            "VLLM_CI_TRACE_ID": "01" * 16,
+            "VLLM_CI_COMMAND_SPAN_ID": "02" * 8,
+            "VLLM_CI_OTEL_SPOOL_DIR": "/dev/null/spans",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "1 passed" in result.stdout

--- a/buildkite/tests/test_ci_otel.py
+++ b/buildkite/tests/test_ci_otel.py
@@ -7,16 +7,23 @@ import binascii
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 SCRIPTS_DIR = (
-    Path(__file__).resolve().parents[1]
-    / "pipeline_generator"
-    / "otel_helpers"
+    Path(__file__).resolve().parents[1] / "pipeline_generator" / "otel_helpers"
 )
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from ci_otel import Span, encode_request, export_spans, new_context  # noqa: E402
+import ci_otel
+from ci_otel import (
+    Span,
+    encode_request,
+    export_spans,
+    load_spans,
+    new_context,
+    record_spans,
+)
 
 
 def _encoded(value: str) -> str:
@@ -67,7 +74,112 @@ def test_export_is_disabled_outside_buildkite(monkeypatch):
     assert export_spans([]) is False
 
 
-def test_shell_wrapper_preserves_command_state_and_quoting():
+def test_spans_are_spooled_without_requesting_credentials(monkeypatch, tmp_path):
+    monkeypatch.setenv("VLLM_CI_OTEL_SPOOL_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        ci_otel,
+        "_oidc_token",
+        lambda deadline: (_ for _ in ()).throw(AssertionError("unexpected upload")),
+    )
+    span = Span(
+        trace_id="01" * 16,
+        span_id="02" * 8,
+        parent_span_id=None,
+        name="ci.command",
+        start_ns=100,
+        end_ns=200,
+        attributes={"ci.command.index": 1},
+    )
+
+    assert record_spans([span]) is True
+    assert load_spans() == [span]
+
+
+def test_export_mints_one_token_for_multiple_batches(monkeypatch):
+    for name, value in {
+        "BUILDKITE": "true",
+        "BUILDKITE_ORGANIZATION_SLUG": "vllm",
+        "BUILDKITE_PIPELINE_SLUG": "ci",
+        "BUILDKITE_BUILD_ID": "build-id",
+        "BUILDKITE_BUILD_NUMBER": "42",
+        "BUILDKITE_JOB_ID": "job-id",
+        "BUILDKITE_BRANCH": "main",
+    }.items():
+        monkeypatch.setenv(name, value)
+    token_calls = []
+    request_timeouts = []
+    monkeypatch.setattr(ci_otel, "MAX_BATCH_SIZE", 1)
+    monkeypatch.setattr(
+        ci_otel,
+        "_oidc_token",
+        lambda deadline: token_calls.append(deadline) or "token",
+    )
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def open_request(request, timeout):
+        request_timeouts.append(timeout)
+        return Response()
+
+    monkeypatch.setattr(ci_otel.urllib.request, "urlopen", open_request)
+    spans = [
+        Span(
+            trace_id="01" * 16,
+            span_id=f"{index:016x}",
+            parent_span_id=None,
+            name="pytest.test",
+            start_ns=100,
+            end_ns=200,
+            attributes={"test.nodeid": f"test_{index}"},
+        )
+        for index in (1, 2)
+    ]
+
+    assert export_spans(spans, timeout_seconds=0.5) is True
+    assert len(token_calls) == 1
+    assert len(request_timeouts) == 2
+    assert all(0 < timeout <= 0.5 for timeout in request_timeouts)
+
+
+def test_export_deadline_bounds_oidc_request(monkeypatch, tmp_path):
+    for name, value in {
+        "BUILDKITE": "true",
+        "BUILDKITE_ORGANIZATION_SLUG": "vllm",
+        "BUILDKITE_PIPELINE_SLUG": "ci",
+        "BUILDKITE_BUILD_ID": "build-id",
+        "BUILDKITE_BUILD_NUMBER": "42",
+        "BUILDKITE_JOB_ID": "job-id",
+        "BUILDKITE_BRANCH": "main",
+    }.items():
+        monkeypatch.setenv(name, value)
+    agent = tmp_path / "buildkite-agent"
+    agent.write_text("#!/bin/sh\nsleep 5\n", encoding="utf-8")
+    agent.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
+    span = Span(
+        trace_id="01" * 16,
+        span_id="02" * 8,
+        parent_span_id=None,
+        name="ci.command",
+        start_ns=100,
+        end_ns=200,
+        attributes={},
+    )
+
+    started = time.monotonic()
+    assert export_spans([span], timeout_seconds=0.1) is False
+
+    assert time.monotonic() - started < 0.5
+
+
+def test_shell_wrapper_preserves_command_state_and_quoting(tmp_path):
     script = SCRIPTS_DIR / "ci_otel.sh"
     first = "ci_otel_run 1 {} {}".format(
         _encoded("export VALUE=ready"),
@@ -80,7 +192,32 @@ def test_shell_wrapper_preserves_command_state_and_quoting():
         check=False,
         capture_output=True,
         text=True,
-        env={**os.environ, "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR)},
+        env={
+            **os.environ,
+            "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
+            "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path),
+        },
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_shell_wrapper_preserves_failure_status(tmp_path):
+    script = SCRIPTS_DIR / "ci_otel.sh"
+    command = "ci_otel_run 1 {} {}".format(
+        _encoded("false"),
+        _encoded("false"),
+    )
+    result = subprocess.run(
+        ["bash", "-c", f'source "{script}"; {command}'],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
+            "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path),
+        },
+    )
+
+    assert result.returncode == 1, result.stderr

--- a/buildkite/tests/test_ci_otel.py
+++ b/buildkite/tests/test_ci_otel.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import binascii
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "pipeline_generator"
+    / "otel_helpers"
+)
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from ci_otel import Span, encode_request, export_spans, new_context  # noqa: E402
+
+
+def _encoded(value: str) -> str:
+    return binascii.b2a_base64(value.encode(), newline=False).decode()
+
+
+def test_new_context_continues_w3c_traceparent(monkeypatch):
+    monkeypatch.setenv(
+        "TRACEPARENT",
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+    )
+
+    trace_id, span_id, parent_span_id = new_context()
+
+    assert trace_id == "4bf92f3577b34da6a3ce929d0e0e4736"
+    assert len(span_id) == 16
+    assert parent_span_id == "00f067aa0ba902b7"
+
+
+def test_otlp_payload_contains_span_and_build_identity(monkeypatch):
+    monkeypatch.setenv("BUILDKITE_ORGANIZATION_SLUG", "vllm")
+    monkeypatch.setenv("BUILDKITE_PIPELINE_SLUG", "ci")
+    monkeypatch.setenv("BUILDKITE_BUILD_ID", "build-id")
+    monkeypatch.setenv("BUILDKITE_BUILD_NUMBER", "42")
+    monkeypatch.setenv("BUILDKITE_BRANCH", "main")
+    monkeypatch.setenv("BUILDKITE_JOB_ID", "job-id")
+    span = Span(
+        trace_id="01" * 16,
+        span_id="02" * 8,
+        parent_span_id="03" * 8,
+        name="ci.command",
+        start_ns=100,
+        end_ns=200,
+        attributes={"ci.span.kind": "command"},
+    )
+
+    payload = encode_request([span])
+
+    assert b"ci.command" in payload
+    assert b"ci.span.kind" in payload
+    assert b"buildkite.job.id" in payload
+    assert b"job-id" in payload
+
+
+def test_export_is_disabled_outside_buildkite(monkeypatch):
+    monkeypatch.delenv("BUILDKITE", raising=False)
+
+    assert export_spans([]) is False
+
+
+def test_shell_wrapper_preserves_command_state_and_quoting():
+    script = SCRIPTS_DIR / "ci_otel.sh"
+    first = "ci_otel_run 1 {} {}".format(
+        _encoded("export VALUE=ready"),
+        _encoded("export VALUE=ready"),
+    )
+    second_command = 'test "$VALUE" = ready'
+    second = f"ci_otel_run 2 {_encoded('check VALUE')} {_encoded(second_command)}"
+    result = subprocess.run(
+        ["bash", "-c", f'source "{script}"; {first}; {second}'],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR)},
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/buildkite/tests/test_ci_otel.py
+++ b/buildkite/tests/test_ci_otel.py
@@ -15,8 +15,8 @@ SCRIPTS_DIR = (
 )
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-import ci_otel
-from ci_otel import (
+import ci_otel  # noqa: E402
+from ci_otel import (  # noqa: E402
     Span,
     encode_request,
     export_spans,
@@ -194,6 +194,30 @@ def test_shell_wrapper_preserves_command_state_and_quoting(tmp_path):
         text=True,
         env={
             **os.environ,
+            "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
+            "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_shell_wrapper_expands_runtime_environment_arguments(tmp_path):
+    script = SCRIPTS_DIR / "ci_otel.sh"
+    command_text = 'test "$REGISTRY" = registry.example.com && test "$COMMIT" = abc123'
+    command = "ci_otel_run 1 {} {}".format(
+        _encoded("check generated variables"),
+        _encoded(command_text),
+    )
+    result = subprocess.run(
+        ["bash", "-c", f'source "{script}"; {command}'],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "REGISTRY": "registry.example.com",
+            "COMMIT": "abc123",
             "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
             "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path),
         },


### PR DESCRIPTION
## What changed

- Make fine-grained tracing automatic for every trusted `vllm-project/vllm` main-branch job; job YAML no longer has or needs an `otel_trace` key.
- Keep the dependency-free OTLP command exporter and pytest plugin in the installable ci-infra pipeline-generator package.
- Inject a deterministic compressed helper bundle into each generated job, then emit one `ci.command` span per configured command and one `pytest.test` span per test.
- Run every original command directly in the job shell and bracket it with best-effort span start/finish calls; tracing never owns command execution.
- Make helper extraction/import, context creation, local recording, pytest hooks, and final upload fail open. A tracing error disables further tracing but cannot turn a passing test command into a failed job.
- Spool spans locally while commands run and upload them once from an `EXIT` trap instead of performing synchronous network I/O after every command.
- Bound local helper calls to two seconds where GNU `timeout` is available, and bound the final upload to a three-second internal deadline plus a four-second shell kill guard while preserving the original job exit status.
- Preserve shell state, command quoting, POSIX `/bin/sh` execution, `set -e`, and continue-on-failure behavior.
- Mount the Buildkite agent only for trusted jobs so the exporter can mint a short-lived OIDC upload token.
- Keep fine-grained instrumentation out of untrusted PR containers and AMD mirrors; native agent tracing can still cover their job phases.

## Why

Buildkite native OTel integration reports build, job, and agent-phase timing, but the agent executes a generated command list as one shell script. It cannot identify the individual YAML commands or pytest tests inside that script. Central generator instrumentation adds that detail without requiring changes to vLLM job definitions.

The helpers live in ci-infra because the generator owns this cross-cutting behavior. They are included in the pipeline-generator wheel and injected at generation time, so existing CI images do not need rebuilding.

## Trust boundary

Fine-grained uploads use a short-lived Buildkite OIDC token. The agent binary is therefore mounted only for trusted non-PR main builds. Mounting it into a container executing untrusted PR code would expose agent capabilities to that code.

## Validation

- `python3 -m pytest buildkite/tests -q` - 101 passed.
- `ruff check` and targeted `ruff format --check` passed on the generator, helpers, and tests.
- `bash -n`, `/bin/sh -n`, and `git diff --check` passed.
- Fault-injection tests cover extraction/setup failure, helper import failure, invalid timeout configuration, context creation failure, serialization and spool failures, unexpected exporter exceptions, pytest hook exceptions, an unwritable pytest spool, and final upload failure.
- Verified OTel failures preserve successful status 0 and a real command failure status 7; tracing also preserves `set -e` behavior and does not run commands after the real failure.
- Built the `buildkite/pipeline_generator` sdist and wheel and verified the wheel contains all three runtime helpers.
- Verified multiple upload batches mint only one OIDC token and command execution never requests credentials.
- Live control: [vLLM CI #84183](https://buildkite.com/vllm/ci/builds/84183), `Basic Models Test (Other CPU)` at commit `cc7cf71fc819df579664adc2e944438d464dbc30`, 188.409 seconds.
- Live treatment: [vLLM CI #84187](https://buildkite.com/vllm/ci/builds/84187), same commit and step, 188.757 seconds. Delta: +0.348 seconds (+0.18%).
- Treatment pytest result: 91 passed, 10 skipped in 40.62 seconds; control pytest result: the same 91 passed, 10 skipped in 39.90 seconds.
- Confirmed `ci.vllm.ai` stored the treatment data end to end: 113 total spans, including 2 command spans and all 101 test spans.

The timing comparison is a single before/after sample, so it establishes that overhead is small, not a statistically precise benchmark.
