### PR TITLE
Shift one tpu7x-8 back to four tpu7x-2 agents

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -58,7 +58,7 @@ module "ci_v7x_2" {
 
   accelerator_type                = "tpu7x-2"
   reserved                        = true
-  instance_count                  = 8
+  instance_count                  = 12
   buildkite_queue_name            = "tpu_v7x_2_queue"
   disk_size                       = 2048
   project_id                      = var.project_id
@@ -76,7 +76,7 @@ module "ci_v7x_8" {
 
   accelerator_type                = "tpu7x-8"
   reserved                        = true
-  instance_count                  = 19
+  instance_count                  = 18
   buildkite_queue_name            = "tpu_v7x_8_queue"
   disk_size                       = 4096
   project_id                      = var.project_id


### PR DESCRIPTION
Follow-up to #470, which deliberately oversubscribed `tpu_v7x_2_queue` to relieve `tpu_v7x_8_queue`. With a day of data on the new shape, that trade overshot.

## Measurements

24h window, summing per-agent busy time clipped to the window across all pipelines using each queue:

| Queue | Demand | Agents now | Utilization now | Agents after | Utilization after |
|---|---|---|---|---|---|
| `tpu_v7x_2_queue` | 174 agent-h | 8 | **91%** | 12 | 60% |
| `tpu_v7x_8_queue` | 299 agent-h | 19 | 66% | 18 | 69% |
| `tpu_v7x_16_queue` | 10 agent-h | 2 | 22% | 2 | 22% |

`tpu_v7x_2_queue` top consumers: `Unit Tests - General (PR)` 47.7 h, `[daily] daily_qwen_llama_tpu` 21.7 h.

## Change

`tpu7x-8` = `2x2x1` = 4 chips; `tpu7x-2` = `1x1x1` = 1 chip.

| Module | Before | After | Chips |
|---|---|---|---|
| `ci_v7x_8` | 19 | 18 | −4 |
| `ci_v7x_2` | 8 | 12 | +4 |

Net zero against the reservation, which stays at 128/128.

## Applied

Already applied to `cloud-ullm-inference-ci-cd`, module-by-module with `-target`, shrinking before growing so the reservation had free chips at create time. The destroyed `tpu7x-8-ci-18` was idle, so no job was killed. All four new `tpu7x-2` agents registered and immediately picked up work.

Post-apply agent counts: `tpu_v7x_8_queue` 18, `tpu_v7x_2_queue` 12, `tpu_v7x_16_queue` 2.

## Note

`Perf/Eval: General suite` is still ~172 of the ~299 agent-hours on `tpu_v7x_8_queue`, running unconditionally on every push at `parallelism: 3`. Gating it remains worth more than any reallocation between these fleets.
