### PR TITLE
Reintroduce CI OTel tracing with fail-open pytest shim

### DIFF
--- a/buildkite/pipeline_generator/README.md
+++ b/buildkite/pipeline_generator/README.md
@@ -87,3 +87,26 @@ Kubernetes-backed test jobs read `BUILDKITE_ANALYTICS_TOKEN` from the
 The Secret is optional, so missing credentials do not prevent jobs from running.
 Provision it in a Buildkite job namespace with
 `infra-k8s/create-buildkite-analytics-secret.sh` to enable test result uploads.
+
+## OpenTelemetry command and test timing
+
+The generator automatically instruments every standard NVIDIA and CPU job in
+trusted `vllm-project/vllm` main-branch builds. It injects the helpers in
+`otel_helpers/`, emits one
+`ci.command` span for each configured command, and loads a pytest plugin that
+emits one `pytest.test` child span per test. Job YAML does not need an opt-in
+field.
+
+Command and pytest spans are written to an ephemeral local spool while tests
+run. An `EXIT` trap uploads the complete job batch once, preserving the job's
+original exit status. The exporter has a three-second total network deadline
+and the shell enforces a four-second hard stop, so an unavailable telemetry
+receiver cannot add an unbounded delay to every command.
+
+Pull-request containers are deliberately excluded from this fine-grained
+instrumentation because exporting spans currently requires access to the
+Buildkite agent binary to mint a short-lived OIDC token. Mounting that binary
+into a container running untrusted PR code would cross the CI trust boundary.
+AMD mirrors are also excluded because their remote runtime does not expose the
+agent binary. Native Buildkite agent tracing can still cover job phases for
+both cases when it is enabled on those agents.

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -45,7 +45,12 @@ SKIP_TIMEOUT_ENV_VAR = "SKIP_TIMEOUT"
 EXIT_STATUS_NEGATIVE_ONE_RETRY = {"exit_status": -1, "limit": 1}
 
 OTEL_HELPERS_DIR = Path(__file__).resolve().parent / "otel_helpers"
-OTEL_HELPER_FILES = ("ci_otel.py", "ci_otel.sh", "ci_pytest_otel.py")
+OTEL_HELPER_FILES = (
+    "ci_otel.py",
+    "ci_otel.sh",
+    "ci_pytest.sh",
+    "ci_pytest_otel.py",
+)
 
 
 @lru_cache(maxsize=1)
@@ -70,15 +75,15 @@ def _otel_setup_command() -> str:
     """Best-effort install of ci-infra-owned tracing helpers."""
     bundle = _otel_helpers_bundle()
     return (
-        "VLLM_CI_OTEL_READY=0; export VLLM_CI_OTEL_READY; "
-        "if VLLM_CI_OTEL_DIR=$$(mktemp -d 2>/dev/null) && "
-        "export VLLM_CI_OTEL_DIR && "
+        "CI_INFRA_OTEL_READY=0; export CI_INFRA_OTEL_READY; "
+        "if CI_INFRA_OTEL_DIR=$$(mktemp -d 2>/dev/null) && "
+        "export CI_INFRA_OTEL_DIR && "
         f'printf "%s" "{bundle}" | base64 --decode | '
-        'tar -xz -C "$$VLLM_CI_OTEL_DIR" && '
-        'sh -n "$$VLLM_CI_OTEL_DIR/ci_otel.sh" && '
-        '. "$$VLLM_CI_OTEL_DIR/ci_otel.sh"; then :; else '
+        'tar -xz -C "$$CI_INFRA_OTEL_DIR" && '
+        'sh -n "$$CI_INFRA_OTEL_DIR/ci_otel.sh" && '
+        '. "$$CI_INFRA_OTEL_DIR/ci_otel.sh"; then :; else '
         'echo "vLLM CI OTel: tracing setup skipped" >&2 || :; '
-        "VLLM_CI_OTEL_READY=0; export VLLM_CI_OTEL_READY; fi; :"
+        "CI_INFRA_OTEL_READY=0; export CI_INFRA_OTEL_READY; fi; :"
     )
 
 
@@ -446,14 +451,14 @@ def _prepare_commands(
                 # execution and cannot change shell state or failure semantics.
                 encoded_preview = base64.b64encode(preview.encode()).decode()
                 prepared_command = (
-                    'if [ "$${VLLM_CI_OTEL_READY:-0}" = "1" ] && '
+                    'if [ "$${CI_INFRA_OTEL_READY:-0}" = "1" ] && '
                     "command -v ci_otel_start >/dev/null 2>&1; then "
                     f"ci_otel_start {i + 1} {encoded_preview} || :; fi\n"
                     f"{cmd}\n"
-                    "_VLLM_CI_OTEL_COMMAND_STATUS=$$?\n"
+                    "_CI_INFRA_OTEL_COMMAND_STATUS=$$?\n"
                     "if command -v ci_otel_finish >/dev/null 2>&1; then "
-                    "ci_otel_finish $$_VLLM_CI_OTEL_COMMAND_STATUS || :; fi\n"
-                    "(exit $$_VLLM_CI_OTEL_COMMAND_STATUS)"
+                    "ci_otel_finish $$_CI_INFRA_OTEL_COMMAND_STATUS || :; fi\n"
+                    "(exit $$_CI_INFRA_OTEL_COMMAND_STATUS)"
                 )
             if continue_on_failure:
                 # Note: We don't use a subshell here to preserve environment changes between commands

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -1,7 +1,14 @@
 from pydantic import BaseModel
 from typing import Dict, List, Optional, Any, Union, Literal
 from copy import deepcopy
+import base64
+from functools import lru_cache
+import gzip
+from io import BytesIO
 import os
+from pathlib import Path
+import re
+import tarfile
 
 from amd import (
     AMD_ALWAYS_RUN_STEP_KEYS,
@@ -36,6 +43,43 @@ PRECOMMIT_WAIT_INTERVAL = 60
 
 SKIP_TIMEOUT_ENV_VAR = "SKIP_TIMEOUT"
 EXIT_STATUS_NEGATIVE_ONE_RETRY = {"exit_status": -1, "limit": 1}
+
+OTEL_HELPERS_DIR = Path(__file__).resolve().parent / "otel_helpers"
+OTEL_HELPER_FILES = ("ci_otel.py", "ci_otel.sh", "ci_pytest_otel.py")
+
+
+@lru_cache(maxsize=1)
+def _otel_helpers_bundle() -> str:
+    """Return a deterministic compressed bundle for injection into CI jobs."""
+    archive = BytesIO()
+    with gzip.GzipFile(
+        fileobj=archive, mode="wb", compresslevel=9, mtime=0
+    ) as compressed:
+        with tarfile.open(fileobj=compressed, mode="w") as bundle:
+            for name in OTEL_HELPER_FILES:
+                contents = (OTEL_HELPERS_DIR / name).read_bytes()
+                info = tarfile.TarInfo(name=name)
+                info.size = len(contents)
+                info.mode = 0o755 if name.endswith(".sh") else 0o644
+                info.mtime = 0
+                bundle.addfile(info, BytesIO(contents))
+    return base64.b64encode(archive.getvalue()).decode()
+
+
+def _otel_setup_command() -> str:
+    """Best-effort install of ci-infra-owned tracing helpers."""
+    bundle = _otel_helpers_bundle()
+    return (
+        "VLLM_CI_OTEL_READY=0; export VLLM_CI_OTEL_READY; "
+        "if VLLM_CI_OTEL_DIR=$$(mktemp -d 2>/dev/null) && "
+        "export VLLM_CI_OTEL_DIR && "
+        f'printf "%s" "{bundle}" | base64 --decode | '
+        'tar -xz -C "$$VLLM_CI_OTEL_DIR" && '
+        'sh -n "$$VLLM_CI_OTEL_DIR/ci_otel.sh" && '
+        '. "$$VLLM_CI_OTEL_DIR/ci_otel.sh"; then :; else '
+        'echo "vLLM CI OTel: tracing setup skipped" >&2 || :; '
+        "VLLM_CI_OTEL_READY=0; export VLLM_CI_OTEL_READY; fi; :"
+    )
 
 
 # Self-contained poll of the pre-commit GitHub Actions check run. Baked with the
@@ -376,6 +420,12 @@ def _prepare_commands(
 ) -> List[str]:
     """Prepare step commands with variables injected and default setup commands."""
     commands = _get_setup_commands(step, setup_profile)
+    # AMD mirrors use a separate runtime and do not expose the agent binary
+    # needed to mint the short-lived upload credential. Native agent tracing
+    # still covers those jobs; command/test spans are injected elsewhere.
+    trace_commands = step.otel_tracing_enabled() and setup_profile != "amd"
+    if trace_commands:
+        commands.append(_otel_setup_command())
 
     continue_on_failure = os.getenv("CONTINUE_ON_FAILURE") == "1"
 
@@ -389,12 +439,30 @@ def _prepare_commands(
             commands.append(
                 f"echo '+++ :test_tube: Command ({i + 1}/{len(step.commands)}): {preview}'"
             )
+            prepared_command = cmd
+            if trace_commands:
+                # Run the original command directly. Tracing only brackets it
+                # with best-effort start/finish calls, so OTel never owns command
+                # execution and cannot change shell state or failure semantics.
+                encoded_preview = base64.b64encode(preview.encode()).decode()
+                prepared_command = (
+                    'if [ "$${VLLM_CI_OTEL_READY:-0}" = "1" ] && '
+                    "command -v ci_otel_start >/dev/null 2>&1; then "
+                    f"ci_otel_start {i + 1} {encoded_preview} || :; fi\n"
+                    f"{cmd}\n"
+                    "_VLLM_CI_OTEL_COMMAND_STATUS=$$?\n"
+                    "if command -v ci_otel_finish >/dev/null 2>&1; then "
+                    "ci_otel_finish $$_VLLM_CI_OTEL_COMMAND_STATUS || :; fi\n"
+                    "(exit $$_VLLM_CI_OTEL_COMMAND_STATUS)"
+                )
             if continue_on_failure:
                 # Note: We don't use a subshell here to preserve environment changes between commands
                 # (export, cd, etc).
-                commands.append(f"{{ {cmd}\n}} || CI_OVERALL_STATUS=1")
+                commands.append(
+                    f"{{ {prepared_command}\n}} || CI_OVERALL_STATUS=1"
+                )
             else:
-                commands.append(cmd)
+                commands.append(prepared_command)
 
     if continue_on_failure:
         commands.append("exit $$CI_OVERALL_STATUS")
@@ -407,8 +475,6 @@ def _prepare_commands(
             if not value:
                 continue
             # Use regex to only replace whole variable matches (not substrings)
-            import re
-
             # Escape variable (may have $ or special characters)
             pattern = re.escape(variable)
             command = re.sub(pattern + r"\b", value, command)

--- a/buildkite/pipeline_generator/otel_helpers/__init__.py
+++ b/buildkite/pipeline_generator/otel_helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime helpers injected into trusted vLLM CI jobs."""

--- a/buildkite/pipeline_generator/otel_helpers/ci_otel.py
+++ b/buildkite/pipeline_generator/otel_helpers/ci_otel.py
@@ -20,7 +20,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 ENDPOINT = os.getenv("CI_INFRA_OTEL_ENDPOINT", "https://ci.vllm.ai/api/otel/v1/traces")
-AUDIENCE = os.getenv("CI_INFRA_OTEL_AUDIENCE", "https://ci.vllm.ai/api/otel")
+SECRET_KEY = os.getenv("CI_INFRA_OTEL_SECRET_KEY", "CI_OTEL_INGEST_TOKEN")
 MAX_BATCH_SIZE = 2_000
 
 
@@ -215,15 +215,12 @@ def _remaining_seconds(deadline: float) -> float:
     return remaining
 
 
-def _oidc_token(deadline: float) -> str:
+def _ingest_token(deadline: float) -> str:
     command = [
         "buildkite-agent",
-        "oidc",
-        "request-token",
-        "--audience",
-        AUDIENCE,
-        "--lifetime",
-        "300",
+        "secret",
+        "get",
+        SECRET_KEY,
     ]
     try:
         result = subprocess.run(
@@ -239,7 +236,7 @@ def _oidc_token(deadline: float) -> str:
             detail = f"{detail[:497]}..."
         suffix = f": {detail}" if detail else ""
         raise RuntimeError(
-            f"Buildkite OIDC request failed (exit {error.returncode}){suffix}"
+            f"Buildkite secret request failed (exit {error.returncode}){suffix}"
         ) from None
     return result.stdout.strip()
 
@@ -262,7 +259,7 @@ def export_spans(
 
     try:
         deadline = time.monotonic() + max(timeout_seconds, 0.1)
-        token = _oidc_token(deadline)
+        token = _ingest_token(deadline)
         for offset in range(0, len(spans), MAX_BATCH_SIZE):
             payload = encode_request(spans[offset : offset + MAX_BATCH_SIZE])
             request = urllib.request.Request(

--- a/buildkite/pipeline_generator/otel_helpers/ci_otel.py
+++ b/buildkite/pipeline_generator/otel_helpers/ci_otel.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Dependency-free OTLP exporter for command and pytest CI spans."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import secrets
+import struct
+import subprocess
+import sys
+import time
+import urllib.request
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+ENDPOINT = os.getenv("VLLM_CI_OTEL_ENDPOINT", "https://ci.vllm.ai/api/otel/v1/traces")
+AUDIENCE = os.getenv("VLLM_CI_OTEL_AUDIENCE", "https://ci.vllm.ai/api/otel")
+MAX_BATCH_SIZE = 2_000
+
+
+def _upload_timeout_seconds() -> float:
+    try:
+        value = float(os.getenv("VLLM_CI_OTEL_UPLOAD_TIMEOUT", "3"))
+        return value if value > 0 else 3.0
+    except (TypeError, ValueError):
+        return 3.0
+
+
+UPLOAD_TIMEOUT_SECONDS = _upload_timeout_seconds()
+
+
+@dataclass(frozen=True)
+class Span:
+    trace_id: str
+    span_id: str
+    parent_span_id: str | None
+    name: str
+    start_ns: int
+    end_ns: int
+    attributes: dict[str, str | int | bool]
+    status_code: int = 1
+
+
+def _varint(value: int) -> bytes:
+    if value < 0:
+        value += 1 << 64
+    encoded = bytearray()
+    while value > 0x7F:
+        encoded.append((value & 0x7F) | 0x80)
+        value >>= 7
+    encoded.append(value)
+    return bytes(encoded)
+
+
+def _key(field: int, wire_type: int) -> bytes:
+    return _varint((field << 3) | wire_type)
+
+
+def _bytes_field(field: int, value: bytes) -> bytes:
+    return _key(field, 2) + _varint(len(value)) + value
+
+
+def _string_field(field: int, value: str) -> bytes:
+    return _bytes_field(field, value.encode())
+
+
+def _varint_field(field: int, value: int) -> bytes:
+    return _key(field, 0) + _varint(value)
+
+
+def _fixed64_field(field: int, value: int) -> bytes:
+    return _key(field, 1) + struct.pack("<Q", value)
+
+
+def _fixed32_field(field: int, value: int) -> bytes:
+    return _key(field, 5) + struct.pack("<I", value)
+
+
+def _any_value(value: str | int | bool) -> bytes:
+    if isinstance(value, bool):
+        return _varint_field(2, int(value))
+    if isinstance(value, int):
+        return _varint_field(3, value)
+    return _string_field(1, value)
+
+
+def _attribute(key: str, value: str | int | bool) -> bytes:
+    return _string_field(1, key) + _bytes_field(2, _any_value(value))
+
+
+def _resource_attributes() -> dict[str, str | int | bool]:
+    build_number = os.getenv("BUILDKITE_BUILD_NUMBER", "0")
+    attributes: dict[str, str | int | bool] = {
+        "service.name": "vllm-ci",
+        "buildkite.organization.slug": os.getenv("BUILDKITE_ORGANIZATION_SLUG", ""),
+        "buildkite.pipeline.slug": os.getenv("BUILDKITE_PIPELINE_SLUG", ""),
+        "buildkite.build.id": os.getenv("BUILDKITE_BUILD_ID", ""),
+        "buildkite.build.number": int(build_number) if build_number.isdigit() else 0,
+        "buildkite.build.branch": os.getenv("BUILDKITE_BRANCH", ""),
+        "buildkite.build.commit": os.getenv("BUILDKITE_COMMIT", ""),
+        "buildkite.job.id": os.getenv("BUILDKITE_JOB_ID", ""),
+        "buildkite.job.label": os.getenv("BUILDKITE_LABEL", ""),
+        "buildkite.step.key": os.getenv("BUILDKITE_STEP_KEY", ""),
+        "buildkite.agent.queue": os.getenv("BUILDKITE_AGENT_META_DATA_QUEUE", ""),
+    }
+    return {key: value for key, value in attributes.items() if value != ""}
+
+
+def _encode_span(span: Span) -> bytes:
+    encoded = b"".join(
+        [
+            _bytes_field(1, bytes.fromhex(span.trace_id)),
+            _bytes_field(2, bytes.fromhex(span.span_id)),
+            _bytes_field(4, bytes.fromhex(span.parent_span_id))
+            if span.parent_span_id
+            else b"",
+            _string_field(5, span.name),
+            _varint_field(6, 1),
+            _fixed64_field(7, span.start_ns),
+            _fixed64_field(8, span.end_ns),
+        ]
+    )
+    attributes = dict(span.attributes)
+    build_url = os.getenv("BUILDKITE_BUILD_URL")
+    job_id = os.getenv("BUILDKITE_JOB_ID")
+    if build_url and job_id:
+        attributes.setdefault("buildkite.job.web_url", f"{build_url}#{job_id}")
+    for key, value in attributes.items():
+        encoded += _bytes_field(9, _attribute(key, value))
+    encoded += _bytes_field(15, _varint_field(3, span.status_code))
+    encoded += _fixed32_field(16, 1)
+    return encoded
+
+
+def encode_request(spans: Iterable[Span]) -> bytes:
+    resource = b"".join(
+        _bytes_field(1, _attribute(key, value))
+        for key, value in _resource_attributes().items()
+    )
+    scope = _string_field(1, "vllm.ci") + _string_field(2, "1")
+    scope_spans = _bytes_field(1, scope)
+    for span in spans:
+        scope_spans += _bytes_field(2, _encode_span(span))
+    resource_spans = _bytes_field(1, resource) + _bytes_field(2, scope_spans)
+    return _bytes_field(1, resource_spans)
+
+
+def new_context() -> tuple[str, str, str | None]:
+    traceparent = os.getenv("TRACEPARENT", "").lower()
+    parts = traceparent.split("-")
+    valid_lengths = len(parts) == 4 and [len(part) for part in parts] == [2, 32, 16, 2]
+    valid_hex = valid_lengths and all(
+        all(character in "0123456789abcdef" for character in part) for part in parts
+    )
+    if valid_hex and parts[1] != "0" * 32 and parts[2] != "0" * 16:
+        trace_id = parts[1]
+        parent_span_id = parts[2]
+    else:
+        build_id = os.getenv("BUILDKITE_BUILD_ID", "local")
+        trace_id = hashlib.sha256(build_id.encode()).hexdigest()[:32]
+        parent_span_id = None
+    return trace_id, secrets.token_hex(8), parent_span_id
+
+
+def _spool_dir() -> Path | None:
+    value = os.getenv("VLLM_CI_OTEL_SPOOL_DIR")
+    return Path(value) if value else None
+
+
+def record_spans(spans: Iterable[Span]) -> bool:
+    """Append spans to a process-local spool file without doing network I/O."""
+    try:
+        spool_dir = _spool_dir()
+        records = [json.dumps(asdict(span), separators=(",", ":")) for span in spans]
+        if spool_dir is None or not records:
+            return False
+        spool_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        spool_file = spool_dir / f"spans-{os.getpid()}.jsonl"
+        with spool_file.open("a", encoding="utf-8") as output:
+            output.write("\n".join(records) + "\n")
+        return True
+    except Exception as error:
+        print(f"CI timing spool skipped: {error}", file=sys.stderr)
+        return False
+
+
+def load_spans() -> list[Span]:
+    spool_dir = _spool_dir()
+    if spool_dir is None or not spool_dir.is_dir():
+        return []
+    spans: list[Span] = []
+    for spool_file in sorted(spool_dir.glob("spans-*.jsonl")):
+        try:
+            with spool_file.open(encoding="utf-8") as records:
+                for record in records:
+                    if record.strip():
+                        spans.append(Span(**json.loads(record)))
+        except (OSError, TypeError, ValueError, json.JSONDecodeError) as error:
+            print(
+                f"CI timing spool ignored {spool_file.name}: {error}", file=sys.stderr
+            )
+    return spans
+
+
+def _remaining_seconds(deadline: float) -> float:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise TimeoutError("CI timing upload deadline exceeded")
+    return remaining
+
+
+def _oidc_token(deadline: float) -> str:
+    result = subprocess.run(
+        [
+            "buildkite-agent",
+            "oidc",
+            "request-token",
+            "--audience",
+            AUDIENCE,
+            "--lifetime",
+            "300",
+            "--claim",
+            "build_id",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=_remaining_seconds(deadline),
+    )
+    return result.stdout.strip()
+
+
+def export_spans(
+    spans: list[Span], timeout_seconds: float = UPLOAD_TIMEOUT_SECONDS
+) -> bool:
+    if not spans or os.getenv("BUILDKITE", "") != "true":
+        return False
+    required = (
+        "BUILDKITE_ORGANIZATION_SLUG",
+        "BUILDKITE_PIPELINE_SLUG",
+        "BUILDKITE_BUILD_ID",
+        "BUILDKITE_BUILD_NUMBER",
+        "BUILDKITE_JOB_ID",
+        "BUILDKITE_BRANCH",
+    )
+    if any(not os.getenv(name) for name in required):
+        return False
+
+    try:
+        deadline = time.monotonic() + max(timeout_seconds, 0.1)
+        token = _oidc_token(deadline)
+        for offset in range(0, len(spans), MAX_BATCH_SIZE):
+            payload = encode_request(spans[offset : offset + MAX_BATCH_SIZE])
+            request = urllib.request.Request(
+                ENDPOINT,
+                data=payload,
+                method="POST",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/x-protobuf",
+                    "User-Agent": "vllm-ci-otel/1",
+                },
+            )
+            with urllib.request.urlopen(
+                request, timeout=_remaining_seconds(deadline)
+            ) as response:
+                if response.status != 200:
+                    raise RuntimeError(f"OTLP endpoint returned {response.status}")
+        return True
+    except Exception as error:
+        print(f"CI timing upload skipped: {error}", file=sys.stderr)
+        return False
+
+
+def _command_span(args: argparse.Namespace) -> Span:
+    attributes: dict[str, str | int | bool] = {
+        "ci.span.kind": "command",
+        "ci.command.index": args.index,
+        "ci.command.label": args.label,
+        "process.exit.code": args.exit_code,
+    }
+    return Span(
+        trace_id=args.trace_id,
+        span_id=args.span_id,
+        parent_span_id=args.parent_span_id or None,
+        name="ci.command",
+        start_ns=args.start_ns,
+        end_ns=args.end_ns,
+        attributes=attributes,
+        status_code=1 if args.exit_code == 0 else 2,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("new-context")
+    subparsers.add_parser("flush")
+    command = subparsers.add_parser("record-command")
+    command.add_argument("--trace-id", required=True)
+    command.add_argument("--span-id", required=True)
+    command.add_argument("--parent-span-id", default="")
+    command.add_argument("--start-ns", required=True, type=int)
+    command.add_argument("--end-ns", required=True, type=int)
+    command.add_argument("--index", required=True, type=int)
+    command.add_argument("--label", required=True)
+    command.add_argument("--exit-code", required=True, type=int)
+    args = parser.parse_args()
+
+    if args.command == "new-context":
+        trace_id, span_id, parent_span_id = new_context()
+        print(trace_id, span_id, parent_span_id or "-")
+        return 0
+    if args.command == "record-command":
+        record_spans([_command_span(args)])
+        return 0
+    if args.command == "flush":
+        export_spans(load_spans())
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/buildkite/pipeline_generator/otel_helpers/ci_otel.py
+++ b/buildkite/pipeline_generator/otel_helpers/ci_otel.py
@@ -11,7 +11,6 @@ import json
 import os
 import secrets
 import struct
-import subprocess
 import sys
 import time
 import urllib.request
@@ -20,7 +19,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 ENDPOINT = os.getenv("CI_INFRA_OTEL_ENDPOINT", "https://ci.vllm.ai/api/otel/v1/traces")
-SECRET_KEY = os.getenv("CI_INFRA_OTEL_SECRET_KEY", "CI_OTEL_INGEST_TOKEN")
+AUDIENCE = os.getenv("CI_INFRA_OTEL_AUDIENCE", "https://ci.vllm.ai/api/otel")
 MAX_BATCH_SIZE = 2_000
 
 
@@ -215,30 +214,33 @@ def _remaining_seconds(deadline: float) -> float:
     return remaining
 
 
-def _ingest_token(deadline: float) -> str:
-    command = [
-        "buildkite-agent",
-        "secret",
-        "get",
-        SECRET_KEY,
-    ]
-    try:
-        result = subprocess.run(
-            command,
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=_remaining_seconds(deadline),
-        )
-    except subprocess.CalledProcessError as error:
-        detail = " ".join((error.stderr or "").split())
-        if len(detail) > 500:
-            detail = f"{detail[:497]}..."
-        suffix = f": {detail}" if detail else ""
-        raise RuntimeError(
-            f"Buildkite secret request failed (exit {error.returncode}){suffix}"
-        ) from None
-    return result.stdout.strip()
+def _oidc_token(deadline: float) -> str:
+    access_token = os.getenv("BUILDKITE_AGENT_ACCESS_TOKEN", "")
+    job_id = os.getenv("BUILDKITE_JOB_ID", "")
+    if not access_token or not job_id:
+        raise RuntimeError("Buildkite job credentials are unavailable")
+
+    agent_endpoint = os.getenv(
+        "BUILDKITE_AGENT_ENDPOINT", "https://agent.buildkite.com/v3"
+    ).rstrip("/")
+    request = urllib.request.Request(
+        f"{agent_endpoint}/jobs/{job_id}/oidc/tokens",
+        data=json.dumps({"audience": AUDIENCE, "lifetime": 300}).encode(),
+        method="POST",
+        headers={
+            "Authorization": f"Token {access_token}",
+            "Content-Type": "application/json",
+            "User-Agent": "vllm-ci-otel/1",
+        },
+    )
+    with urllib.request.urlopen(
+        request, timeout=_remaining_seconds(deadline)
+    ) as response:
+        body = json.loads(response.read())
+    token = body.get("token") if isinstance(body, dict) else None
+    if not isinstance(token, str) or not token:
+        raise RuntimeError("Buildkite OIDC response did not contain a token")
+    return token
 
 
 def export_spans(
@@ -259,7 +261,7 @@ def export_spans(
 
     try:
         deadline = time.monotonic() + max(timeout_seconds, 0.1)
-        token = _ingest_token(deadline)
+        token = _oidc_token(deadline)
         for offset in range(0, len(spans), MAX_BATCH_SIZE):
             payload = encode_request(spans[offset : offset + MAX_BATCH_SIZE])
             request = urllib.request.Request(

--- a/buildkite/pipeline_generator/otel_helpers/ci_otel.py
+++ b/buildkite/pipeline_generator/otel_helpers/ci_otel.py
@@ -19,14 +19,14 @@ from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
-ENDPOINT = os.getenv("VLLM_CI_OTEL_ENDPOINT", "https://ci.vllm.ai/api/otel/v1/traces")
-AUDIENCE = os.getenv("VLLM_CI_OTEL_AUDIENCE", "https://ci.vllm.ai/api/otel")
+ENDPOINT = os.getenv("CI_INFRA_OTEL_ENDPOINT", "https://ci.vllm.ai/api/otel/v1/traces")
+AUDIENCE = os.getenv("CI_INFRA_OTEL_AUDIENCE", "https://ci.vllm.ai/api/otel")
 MAX_BATCH_SIZE = 2_000
 
 
 def _upload_timeout_seconds() -> float:
     try:
-        value = float(os.getenv("VLLM_CI_OTEL_UPLOAD_TIMEOUT", "3"))
+        value = float(os.getenv("CI_INFRA_OTEL_UPLOAD_TIMEOUT", "3"))
         return value if value > 0 else 3.0
     except (TypeError, ValueError):
         return 3.0
@@ -169,7 +169,7 @@ def new_context() -> tuple[str, str, str | None]:
 
 
 def _spool_dir() -> Path | None:
-    value = os.getenv("VLLM_CI_OTEL_SPOOL_DIR")
+    value = os.getenv("CI_INFRA_OTEL_SPOOL_DIR")
     return Path(value) if value else None
 
 
@@ -225,8 +225,6 @@ def _oidc_token(deadline: float) -> str:
             AUDIENCE,
             "--lifetime",
             "300",
-            "--claim",
-            "build_id",
         ],
         check=True,
         capture_output=True,

--- a/buildkite/pipeline_generator/otel_helpers/ci_otel.py
+++ b/buildkite/pipeline_generator/otel_helpers/ci_otel.py
@@ -216,21 +216,31 @@ def _remaining_seconds(deadline: float) -> float:
 
 
 def _oidc_token(deadline: float) -> str:
-    result = subprocess.run(
-        [
-            "buildkite-agent",
-            "oidc",
-            "request-token",
-            "--audience",
-            AUDIENCE,
-            "--lifetime",
-            "300",
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-        timeout=_remaining_seconds(deadline),
-    )
+    command = [
+        "buildkite-agent",
+        "oidc",
+        "request-token",
+        "--audience",
+        AUDIENCE,
+        "--lifetime",
+        "300",
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=_remaining_seconds(deadline),
+        )
+    except subprocess.CalledProcessError as error:
+        detail = " ".join((error.stderr or "").split())
+        if len(detail) > 500:
+            detail = f"{detail[:497]}..."
+        suffix = f": {detail}" if detail else ""
+        raise RuntimeError(
+            f"Buildkite OIDC request failed (exit {error.returncode}){suffix}"
+        ) from None
     return result.stdout.strip()
 
 

--- a/buildkite/pipeline_generator/otel_helpers/ci_otel.py
+++ b/buildkite/pipeline_generator/otel_helpers/ci_otel.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import json
 import os
@@ -13,6 +14,7 @@ import secrets
 import struct
 import sys
 import time
+import urllib.error
 import urllib.request
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass
@@ -243,6 +245,31 @@ def _oidc_token(deadline: float) -> str:
     return token
 
 
+def _safe_oidc_claims(token: str) -> str:
+    """Describe non-secret identity claims without logging the signed token."""
+    try:
+        payload = token.split(".", 2)[1]
+        padding = "=" * (-len(payload) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload + padding))
+        names = (
+            "iss",
+            "aud",
+            "organization_slug",
+            "pipeline_slug",
+            "build_branch",
+            "build_source",
+            "build_number",
+            "job_id",
+        )
+        return json.dumps(
+            {name: claims.get(name) for name in names},
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except Exception:
+        return "unavailable"
+
+
 def export_spans(
     spans: list[Span], timeout_seconds: float = UPLOAD_TIMEOUT_SECONDS
 ) -> bool:
@@ -274,11 +301,21 @@ def export_spans(
                     "User-Agent": "vllm-ci-otel/1",
                 },
             )
-            with urllib.request.urlopen(
-                request, timeout=_remaining_seconds(deadline)
-            ) as response:
-                if response.status != 200:
-                    raise RuntimeError(f"OTLP endpoint returned {response.status}")
+            try:
+                with urllib.request.urlopen(
+                    request, timeout=_remaining_seconds(deadline)
+                ) as response:
+                    if response.status != 200:
+                        raise RuntimeError(
+                            f"OTLP endpoint returned {response.status}"
+                        )
+            except urllib.error.HTTPError as error:
+                if error.code == 401:
+                    raise RuntimeError(
+                        "OTLP endpoint returned 401; OIDC claims: "
+                        f"{_safe_oidc_claims(token)}"
+                    ) from error
+                raise
         return True
     except Exception as error:
         print(f"CI timing upload skipped: {error}", file=sys.stderr)

--- a/buildkite/pipeline_generator/otel_helpers/ci_otel.sh
+++ b/buildkite/pipeline_generator/otel_helpers/ci_otel.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+_VLLM_CI_OTEL_DIR="${VLLM_CI_OTEL_DIR:?VLLM_CI_OTEL_DIR must point to the injected CI tracing helpers}"
+export VLLM_CI_OTEL_SPOOL_DIR="${VLLM_CI_OTEL_SPOOL_DIR:-${_VLLM_CI_OTEL_DIR}/spans}"
+VLLM_CI_OTEL_READY=0
+export VLLM_CI_OTEL_READY
+
+_ci_otel_disable() {
+  VLLM_CI_OTEL_READY=0
+  export VLLM_CI_OTEL_READY
+  echo "vLLM CI OTel: tracing disabled after a helper failure" >&2 || :
+  return 0
+}
+
+_ci_otel_python() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 2s python3 "$@"
+  else
+    python3 "$@"
+  fi
+}
+
+_ci_otel_on_exit() {
+  _VLLM_CI_OTEL_EXIT_STATUS=$?
+  trap - 0
+  if [ "${VLLM_CI_OTEL_READY:-0}" = "1" ]; then
+    ci_otel_finish "${_VLLM_CI_OTEL_EXIT_STATUS}" || true
+  fi
+  if [ "${VLLM_CI_OTEL_READY:-0}" = "1" ]; then
+    if command -v timeout >/dev/null 2>&1; then
+      timeout 4s python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" flush || true
+    else
+      python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" flush || true
+    fi
+  fi
+  exit "${_VLLM_CI_OTEL_EXIT_STATUS}"
+}
+
+ci_otel_start() {
+  local command_index="$1"
+  local encoded_label="$2"
+  local command_label
+  local context
+  local trace_id
+  local span_id
+  local parent_span_id
+  local start_ns
+
+  command_label="$(printf '%s' "${encoded_label}" | base64 --decode 2>/dev/null)" ||
+    command_label="command ${command_index}"
+
+  if ! context="$(_ci_otel_python "${_VLLM_CI_OTEL_DIR}/ci_otel.py" new-context)"; then
+    _ci_otel_disable
+    return 0
+  fi
+  set -- ${context}
+  if [ "$#" -ne 3 ]; then
+    _ci_otel_disable
+    return 0
+  fi
+  trace_id="$1"
+  span_id="$2"
+  parent_span_id="$3"
+  [ "${parent_span_id}" = "-" ] && parent_span_id=""
+  if ! start_ns="$(date +%s%N)"; then
+    _ci_otel_disable
+    return 0
+  fi
+
+  VLLM_CI_TRACE_ID="${trace_id}"
+  VLLM_CI_COMMAND_SPAN_ID="${span_id}"
+  export VLLM_CI_TRACE_ID VLLM_CI_COMMAND_SPAN_ID
+  _VLLM_CI_OTEL_ACTIVE=1
+  _VLLM_CI_OTEL_ACTIVE_INDEX="${command_index}"
+  _VLLM_CI_OTEL_ACTIVE_LABEL="${command_label}"
+  _VLLM_CI_OTEL_ACTIVE_TRACE_ID="${trace_id}"
+  _VLLM_CI_OTEL_ACTIVE_SPAN_ID="${span_id}"
+  _VLLM_CI_OTEL_ACTIVE_PARENT_SPAN_ID="${parent_span_id}"
+  _VLLM_CI_OTEL_ACTIVE_START_NS="${start_ns}"
+  return 0
+}
+
+ci_otel_finish() {
+  local command_status="${1:-0}"
+  local end_ns
+
+  if [ "${_VLLM_CI_OTEL_ACTIVE:-0}" != "1" ]; then
+    return 0
+  fi
+  _VLLM_CI_OTEL_ACTIVE=0
+  VLLM_CI_TRACE_ID=""
+  VLLM_CI_COMMAND_SPAN_ID=""
+  export VLLM_CI_TRACE_ID VLLM_CI_COMMAND_SPAN_ID
+  end_ns="$(date +%s%N 2>/dev/null)" ||
+    end_ns="${_VLLM_CI_OTEL_ACTIVE_START_NS}"
+
+  if ! _ci_otel_python "${_VLLM_CI_OTEL_DIR}/ci_otel.py" record-command \
+    --trace-id "${_VLLM_CI_OTEL_ACTIVE_TRACE_ID}" \
+    --span-id "${_VLLM_CI_OTEL_ACTIVE_SPAN_ID}" \
+    --parent-span-id "${_VLLM_CI_OTEL_ACTIVE_PARENT_SPAN_ID}" \
+    --start-ns "${_VLLM_CI_OTEL_ACTIVE_START_NS}" \
+    --end-ns "${end_ns}" \
+    --index "${_VLLM_CI_OTEL_ACTIVE_INDEX}" \
+    --label "${_VLLM_CI_OTEL_ACTIVE_LABEL}" \
+    --exit-code "${command_status}"; then
+    _ci_otel_disable
+  fi
+  return 0
+}
+
+# Do not modify Python or pytest state until both helper modules are importable
+# and the local spool is writable. A failed check leaves tracing disabled and
+# the generated job runs its original command directly.
+if command -v python3 >/dev/null 2>&1 &&
+  mkdir -p "${VLLM_CI_OTEL_SPOOL_DIR}" &&
+  (
+    export PYTHONPATH="${_VLLM_CI_OTEL_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
+    python3 -c "import ci_otel, ci_pytest_otel" >/dev/null 2>&1
+  ); then
+  export PYTHONPATH="${_VLLM_CI_OTEL_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
+  export PYTEST_ADDOPTS="${PYTEST_ADDOPTS:-} -p ci_pytest_otel"
+  VLLM_CI_OTEL_READY=1
+  export VLLM_CI_OTEL_READY
+  trap _ci_otel_on_exit 0
+else
+  echo "vLLM CI OTel: tracing disabled; test command will run normally" >&2 || :
+fi
+
+:

--- a/buildkite/pipeline_generator/otel_helpers/ci_otel.sh
+++ b/buildkite/pipeline_generator/otel_helpers/ci_otel.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-_VLLM_CI_OTEL_DIR="${VLLM_CI_OTEL_DIR:?VLLM_CI_OTEL_DIR must point to the injected CI tracing helpers}"
-export VLLM_CI_OTEL_SPOOL_DIR="${VLLM_CI_OTEL_SPOOL_DIR:-${_VLLM_CI_OTEL_DIR}/spans}"
-VLLM_CI_OTEL_READY=0
-export VLLM_CI_OTEL_READY
+_CI_INFRA_OTEL_DIR="${CI_INFRA_OTEL_DIR:?CI_INFRA_OTEL_DIR must point to the injected CI tracing helpers}"
+export CI_INFRA_OTEL_SPOOL_DIR="${CI_INFRA_OTEL_SPOOL_DIR:-${_CI_INFRA_OTEL_DIR}/spans}"
+CI_INFRA_OTEL_READY=0
+export CI_INFRA_OTEL_READY
 
 _ci_otel_disable() {
-  VLLM_CI_OTEL_READY=0
-  export VLLM_CI_OTEL_READY
+  CI_INFRA_OTEL_READY=0
+  export CI_INFRA_OTEL_READY
   echo "vLLM CI OTel: tracing disabled after a helper failure" >&2 || :
   return 0
 }
@@ -21,19 +21,19 @@ _ci_otel_python() {
 }
 
 _ci_otel_on_exit() {
-  _VLLM_CI_OTEL_EXIT_STATUS=$?
+  _CI_INFRA_OTEL_EXIT_STATUS=$?
   trap - 0
-  if [ "${VLLM_CI_OTEL_READY:-0}" = "1" ]; then
-    ci_otel_finish "${_VLLM_CI_OTEL_EXIT_STATUS}" || true
+  if [ "${CI_INFRA_OTEL_READY:-0}" = "1" ]; then
+    ci_otel_finish "${_CI_INFRA_OTEL_EXIT_STATUS}" || true
   fi
-  if [ "${VLLM_CI_OTEL_READY:-0}" = "1" ]; then
+  if [ "${CI_INFRA_OTEL_READY:-0}" = "1" ]; then
     if command -v timeout >/dev/null 2>&1; then
-      timeout 4s python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" flush || true
+      timeout 4s python3 "${_CI_INFRA_OTEL_DIR}/ci_otel.py" flush || true
     else
-      python3 "${_VLLM_CI_OTEL_DIR}/ci_otel.py" flush || true
+      python3 "${_CI_INFRA_OTEL_DIR}/ci_otel.py" flush || true
     fi
   fi
-  exit "${_VLLM_CI_OTEL_EXIT_STATUS}"
+  exit "${_CI_INFRA_OTEL_EXIT_STATUS}"
 }
 
 ci_otel_start() {
@@ -49,7 +49,7 @@ ci_otel_start() {
   command_label="$(printf '%s' "${encoded_label}" | base64 --decode 2>/dev/null)" ||
     command_label="command ${command_index}"
 
-  if ! context="$(_ci_otel_python "${_VLLM_CI_OTEL_DIR}/ci_otel.py" new-context)"; then
+  if ! context="$(_ci_otel_python "${_CI_INFRA_OTEL_DIR}/ci_otel.py" new-context)"; then
     _ci_otel_disable
     return 0
   fi
@@ -67,16 +67,16 @@ ci_otel_start() {
     return 0
   fi
 
-  VLLM_CI_TRACE_ID="${trace_id}"
-  VLLM_CI_COMMAND_SPAN_ID="${span_id}"
-  export VLLM_CI_TRACE_ID VLLM_CI_COMMAND_SPAN_ID
-  _VLLM_CI_OTEL_ACTIVE=1
-  _VLLM_CI_OTEL_ACTIVE_INDEX="${command_index}"
-  _VLLM_CI_OTEL_ACTIVE_LABEL="${command_label}"
-  _VLLM_CI_OTEL_ACTIVE_TRACE_ID="${trace_id}"
-  _VLLM_CI_OTEL_ACTIVE_SPAN_ID="${span_id}"
-  _VLLM_CI_OTEL_ACTIVE_PARENT_SPAN_ID="${parent_span_id}"
-  _VLLM_CI_OTEL_ACTIVE_START_NS="${start_ns}"
+  CI_INFRA_TRACE_ID="${trace_id}"
+  CI_INFRA_COMMAND_SPAN_ID="${span_id}"
+  export CI_INFRA_TRACE_ID CI_INFRA_COMMAND_SPAN_ID
+  _CI_INFRA_OTEL_ACTIVE=1
+  _CI_INFRA_OTEL_ACTIVE_INDEX="${command_index}"
+  _CI_INFRA_OTEL_ACTIVE_LABEL="${command_label}"
+  _CI_INFRA_OTEL_ACTIVE_TRACE_ID="${trace_id}"
+  _CI_INFRA_OTEL_ACTIVE_SPAN_ID="${span_id}"
+  _CI_INFRA_OTEL_ACTIVE_PARENT_SPAN_ID="${parent_span_id}"
+  _CI_INFRA_OTEL_ACTIVE_START_NS="${start_ns}"
   return 0
 }
 
@@ -84,43 +84,50 @@ ci_otel_finish() {
   local command_status="${1:-0}"
   local end_ns
 
-  if [ "${_VLLM_CI_OTEL_ACTIVE:-0}" != "1" ]; then
+  if [ "${_CI_INFRA_OTEL_ACTIVE:-0}" != "1" ]; then
     return 0
   fi
-  _VLLM_CI_OTEL_ACTIVE=0
-  VLLM_CI_TRACE_ID=""
-  VLLM_CI_COMMAND_SPAN_ID=""
-  export VLLM_CI_TRACE_ID VLLM_CI_COMMAND_SPAN_ID
+  _CI_INFRA_OTEL_ACTIVE=0
+  CI_INFRA_TRACE_ID=""
+  CI_INFRA_COMMAND_SPAN_ID=""
+  export CI_INFRA_TRACE_ID CI_INFRA_COMMAND_SPAN_ID
   end_ns="$(date +%s%N 2>/dev/null)" ||
-    end_ns="${_VLLM_CI_OTEL_ACTIVE_START_NS}"
+    end_ns="${_CI_INFRA_OTEL_ACTIVE_START_NS}"
 
-  if ! _ci_otel_python "${_VLLM_CI_OTEL_DIR}/ci_otel.py" record-command \
-    --trace-id "${_VLLM_CI_OTEL_ACTIVE_TRACE_ID}" \
-    --span-id "${_VLLM_CI_OTEL_ACTIVE_SPAN_ID}" \
-    --parent-span-id "${_VLLM_CI_OTEL_ACTIVE_PARENT_SPAN_ID}" \
-    --start-ns "${_VLLM_CI_OTEL_ACTIVE_START_NS}" \
+  if ! _ci_otel_python "${_CI_INFRA_OTEL_DIR}/ci_otel.py" record-command \
+    --trace-id "${_CI_INFRA_OTEL_ACTIVE_TRACE_ID}" \
+    --span-id "${_CI_INFRA_OTEL_ACTIVE_SPAN_ID}" \
+    --parent-span-id "${_CI_INFRA_OTEL_ACTIVE_PARENT_SPAN_ID}" \
+    --start-ns "${_CI_INFRA_OTEL_ACTIVE_START_NS}" \
     --end-ns "${end_ns}" \
-    --index "${_VLLM_CI_OTEL_ACTIVE_INDEX}" \
-    --label "${_VLLM_CI_OTEL_ACTIVE_LABEL}" \
+    --index "${_CI_INFRA_OTEL_ACTIVE_INDEX}" \
+    --label "${_CI_INFRA_OTEL_ACTIVE_LABEL}" \
     --exit-code "${command_status}"; then
     _ci_otel_disable
   fi
   return 0
 }
 
-# Do not modify Python or pytest state until both helper modules are importable
-# and the local spool is writable. A failed check leaves tracing disabled and
-# the generated job runs its original command directly.
+# Do not modify command lookup until the helpers, spool, and pytest shim are
+# valid. No global Python or pytest options are changed.
 if command -v python3 >/dev/null 2>&1 &&
-  mkdir -p "${VLLM_CI_OTEL_SPOOL_DIR}" &&
+  mkdir -p "${CI_INFRA_OTEL_SPOOL_DIR}" &&
   (
-    export PYTHONPATH="${_VLLM_CI_OTEL_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
+    export PYTHONPATH="${_CI_INFRA_OTEL_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
     python3 -c "import ci_otel, ci_pytest_otel" >/dev/null 2>&1
-  ); then
-  export PYTHONPATH="${_VLLM_CI_OTEL_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
-  export PYTEST_ADDOPTS="${PYTEST_ADDOPTS:-} -p ci_pytest_otel"
-  VLLM_CI_OTEL_READY=1
-  export VLLM_CI_OTEL_READY
+  ) &&
+  sh -n "${_CI_INFRA_OTEL_DIR}/ci_pytest.sh"; then
+  CI_INFRA_OTEL_REAL_PYTEST="$(command -v pytest 2>/dev/null || :)"
+  export CI_INFRA_OTEL_REAL_PYTEST
+  if [ -n "${CI_INFRA_OTEL_REAL_PYTEST}" ] &&
+    [ -x "${CI_INFRA_OTEL_REAL_PYTEST}" ] &&
+    mkdir -p "${_CI_INFRA_OTEL_DIR}/bin" &&
+    ln -s "${_CI_INFRA_OTEL_DIR}/ci_pytest.sh" "${_CI_INFRA_OTEL_DIR}/bin/pytest"; then
+    PATH="${_CI_INFRA_OTEL_DIR}/bin:${PATH}"
+    export PATH
+  fi
+  CI_INFRA_OTEL_READY=1
+  export CI_INFRA_OTEL_READY
   trap _ci_otel_on_exit 0
 else
   echo "vLLM CI OTel: tracing disabled; test command will run normally" >&2 || :

--- a/buildkite/pipeline_generator/otel_helpers/ci_otel.sh
+++ b/buildkite/pipeline_generator/otel_helpers/ci_otel.sh
@@ -20,6 +20,40 @@ _ci_otel_python() {
   fi
 }
 
+_ci_otel_pytest_is_compatible() {
+  if [ -z "${CI_INFRA_OTEL_REAL_PYTEST:-}" ] ||
+    [ ! -x "${CI_INFRA_OTEL_REAL_PYTEST}" ]; then
+    return 1
+  fi
+
+  # Isolate the probe from repository pytest configuration and third-party
+  # plugin autoload. Exit 5 means collection succeeded but found no tests.
+  if command -v timeout >/dev/null 2>&1; then
+    if PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+      PYTHONPATH="${_CI_INFRA_OTEL_DIR}${PYTHONPATH:+:${PYTHONPATH}}" \
+      timeout 3s "${CI_INFRA_OTEL_REAL_PYTEST}" -q --collect-only \
+      -c /dev/null --rootdir "${_CI_INFRA_OTEL_DIR}" \
+      --confcutdir "${_CI_INFRA_OTEL_DIR}" \
+      "${_CI_INFRA_OTEL_DIR}/ci_pytest_otel.py" -p ci_pytest_otel \
+      >/dev/null 2>&1; then
+      return 0
+    else
+      probe_status=$?
+    fi
+  elif PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+    PYTHONPATH="${_CI_INFRA_OTEL_DIR}${PYTHONPATH:+:${PYTHONPATH}}" \
+    "${CI_INFRA_OTEL_REAL_PYTEST}" -q --collect-only \
+    -c /dev/null --rootdir "${_CI_INFRA_OTEL_DIR}" \
+    --confcutdir "${_CI_INFRA_OTEL_DIR}" \
+    "${_CI_INFRA_OTEL_DIR}/ci_pytest_otel.py" -p ci_pytest_otel \
+    >/dev/null 2>&1; then
+    return 0
+  else
+    probe_status=$?
+  fi
+  [ "${probe_status}" -eq 5 ]
+}
+
 _ci_otel_on_exit() {
   _CI_INFRA_OTEL_EXIT_STATUS=$?
   trap - 0
@@ -114,17 +148,18 @@ if command -v python3 >/dev/null 2>&1 &&
   mkdir -p "${CI_INFRA_OTEL_SPOOL_DIR}" &&
   (
     export PYTHONPATH="${_CI_INFRA_OTEL_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
-    python3 -c "import ci_otel, ci_pytest_otel" >/dev/null 2>&1
+    _ci_otel_python -c "import ci_otel, ci_pytest_otel" >/dev/null 2>&1
   ) &&
   sh -n "${_CI_INFRA_OTEL_DIR}/ci_pytest.sh"; then
   CI_INFRA_OTEL_REAL_PYTEST="$(command -v pytest 2>/dev/null || :)"
   export CI_INFRA_OTEL_REAL_PYTEST
-  if [ -n "${CI_INFRA_OTEL_REAL_PYTEST}" ] &&
-    [ -x "${CI_INFRA_OTEL_REAL_PYTEST}" ] &&
+  if _ci_otel_pytest_is_compatible &&
     mkdir -p "${_CI_INFRA_OTEL_DIR}/bin" &&
     ln -s "${_CI_INFRA_OTEL_DIR}/ci_pytest.sh" "${_CI_INFRA_OTEL_DIR}/bin/pytest"; then
     PATH="${_CI_INFRA_OTEL_DIR}/bin:${PATH}"
     export PATH
+  elif [ -n "${CI_INFRA_OTEL_REAL_PYTEST}" ]; then
+    echo "vLLM CI OTel: pytest tracing unavailable; command tracing remains enabled" >&2 || :
   fi
   CI_INFRA_OTEL_READY=1
   export CI_INFRA_OTEL_READY

--- a/buildkite/pipeline_generator/otel_helpers/ci_pytest.sh
+++ b/buildkite/pipeline_generator/otel_helpers/ci_pytest.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Transparently add the CI timing plugin to direct `pytest` invocations. The
+# original pytest executable is always the fallback: tracing must never decide
+# whether a test command succeeds.
+real_pytest="${CI_INFRA_OTEL_REAL_PYTEST:-}"
+helper_dir="${CI_INFRA_OTEL_DIR:-}"
+
+if [ -z "${real_pytest}" ] || [ ! -x "${real_pytest}" ] ||
+  [ -z "${helper_dir}" ] || [ "${CI_INFRA_OTEL_READY:-0}" != "1" ] ||
+  [ -z "${CI_INFRA_TRACE_ID:-}" ] ||
+  [ -z "${CI_INFRA_COMMAND_SPAN_ID:-}" ]; then
+  exec "${real_pytest}" "$@"
+fi
+
+otel_pythonpath="${helper_dir}${PYTHONPATH:+:${PYTHONPATH}}"
+
+# Validate plugin startup using the same pytest executable and PYTHONPATH as
+# the real command. If anything about tracing is incompatible, retry without
+# any tracing-specific arguments or environment changes.
+if command -v timeout >/dev/null 2>&1; then
+  PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH="${otel_pythonpath}" \
+    timeout 2s "${real_pytest}" --help -p ci_pytest_otel \
+    >/dev/null 2>&1
+else
+  PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH="${otel_pythonpath}" \
+    "${real_pytest}" --help -p ci_pytest_otel >/dev/null 2>&1
+fi
+preflight_status=$?
+
+if [ "${preflight_status}" -ne 0 ]; then
+  echo "vLLM CI OTel: pytest tracing skipped; running pytest normally" >&2 || :
+  exec "${real_pytest}" "$@"
+fi
+
+PYTHONPATH="${otel_pythonpath}" exec "${real_pytest}" -p ci_pytest_otel "$@"

--- a/buildkite/pipeline_generator/otel_helpers/ci_pytest.sh
+++ b/buildkite/pipeline_generator/otel_helpers/ci_pytest.sh
@@ -15,16 +15,16 @@ fi
 
 otel_pythonpath="${helper_dir}${PYTHONPATH:+:${PYTHONPATH}}"
 
-# Validate plugin startup using the same pytest executable and PYTHONPATH as
-# the real command. If anything about tracing is incompatible, retry without
-# any tracing-specific arguments or environment changes.
+# Setup already validated plugin registration with this pytest executable.
+# Recheck that the helper modules remain importable under the command's
+# effective PYTHONPATH. This catches deleted or hidden helpers without paying
+# for a second pytest startup on every invocation.
 if command -v timeout >/dev/null 2>&1; then
   PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH="${otel_pythonpath}" \
-    timeout 2s "${real_pytest}" --help -p ci_pytest_otel \
-    >/dev/null 2>&1
+    timeout 2s python3 -c "import ci_otel, ci_pytest_otel" >/dev/null 2>&1
 else
   PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH="${otel_pythonpath}" \
-    "${real_pytest}" --help -p ci_pytest_otel >/dev/null 2>&1
+    python3 -c "import ci_otel, ci_pytest_otel" >/dev/null 2>&1
 fi
 preflight_status=$?
 

--- a/buildkite/pipeline_generator/otel_helpers/ci_pytest_otel.py
+++ b/buildkite/pipeline_generator/otel_helpers/ci_pytest_otel.py
@@ -32,7 +32,9 @@ def _soft_fail(action):
 
 
 def _enabled() -> bool:
-    return bool(os.getenv("VLLM_CI_TRACE_ID") and os.getenv("VLLM_CI_COMMAND_SPAN_ID"))
+    return bool(
+        os.getenv("CI_INFRA_TRACE_ID") and os.getenv("CI_INFRA_COMMAND_SPAN_ID")
+    )
 
 
 def pytest_runtest_logstart(nodeid: str, location: tuple[str, int | None, str]):
@@ -72,9 +74,9 @@ def pytest_runtest_logfinish(nodeid: str, location: tuple[str, int | None, str])
 def _test_span(nodeid: str, run: TestRun) -> Span:
     outcome = run.outcome
     return Span(
-        trace_id=os.environ["VLLM_CI_TRACE_ID"],
+        trace_id=os.environ["CI_INFRA_TRACE_ID"],
         span_id=os.urandom(8).hex(),
-        parent_span_id=os.environ["VLLM_CI_COMMAND_SPAN_ID"],
+        parent_span_id=os.environ["CI_INFRA_COMMAND_SPAN_ID"],
         name="pytest.test",
         start_ns=run.start_ns,
         end_ns=run.end_ns or time.time_ns(),

--- a/buildkite/pipeline_generator/otel_helpers/ci_pytest_otel.py
+++ b/buildkite/pipeline_generator/otel_helpers/ci_pytest_otel.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Pytest plugin that emits one OTLP span per collected test."""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+
+from ci_otel import Span, record_spans
+
+
+@dataclass
+class TestRun:
+    start_ns: int
+    end_ns: int = 0
+    outcome: str = "unknown"
+
+
+_runs: dict[str, TestRun] = {}
+_spans: list[Span] = []
+
+
+def _soft_fail(action):
+    """Contain every tracing exception so pytest owns the job outcome."""
+    try:
+        action()
+    except Exception:
+        return
+
+
+def _enabled() -> bool:
+    return bool(os.getenv("VLLM_CI_TRACE_ID") and os.getenv("VLLM_CI_COMMAND_SPAN_ID"))
+
+
+def pytest_runtest_logstart(nodeid: str, location: tuple[str, int | None, str]):
+    def record_start():
+        if _enabled():
+            _runs[nodeid] = TestRun(start_ns=time.time_ns())
+
+    _soft_fail(record_start)
+
+
+def pytest_runtest_logreport(report):
+    def record_report():
+        run = _runs.get(report.nodeid)
+        if not run:
+            return
+        if report.failed:
+            run.outcome = "failed"
+        elif report.skipped and run.outcome != "failed":
+            run.outcome = "skipped"
+        elif report.when == "call" and run.outcome == "unknown":
+            run.outcome = "passed"
+
+    _soft_fail(record_report)
+
+
+def pytest_runtest_logfinish(nodeid: str, location: tuple[str, int | None, str]):
+    def record_finish():
+        run = _runs.pop(nodeid, None)
+        if not run:
+            return
+        run.end_ns = time.time_ns()
+        _spans.append(_test_span(nodeid, run))
+
+    _soft_fail(record_finish)
+
+
+def _test_span(nodeid: str, run: TestRun) -> Span:
+    outcome = run.outcome
+    return Span(
+        trace_id=os.environ["VLLM_CI_TRACE_ID"],
+        span_id=os.urandom(8).hex(),
+        parent_span_id=os.environ["VLLM_CI_COMMAND_SPAN_ID"],
+        name="pytest.test",
+        start_ns=run.start_ns,
+        end_ns=run.end_ns or time.time_ns(),
+        attributes={
+            "ci.span.kind": "test",
+            "test.nodeid": nodeid,
+            "test.file": nodeid.split("::", 1)[0],
+            "test.outcome": outcome,
+        },
+        status_code=2 if outcome == "failed" else 1,
+    )
+
+
+def pytest_sessionfinish(session, exitstatus: int):
+    def finish_session():
+        if not _enabled():
+            return
+        for nodeid, run in list(_runs.items()):
+            _spans.append(_test_span(nodeid, run))
+        _runs.clear()
+        record_spans(_spans)
+        _spans.clear()
+
+    _soft_fail(finish_session)

--- a/buildkite/pipeline_generator/plugin/docker_plugin.py
+++ b/buildkite/pipeline_generator/plugin/docker_plugin.py
@@ -141,7 +141,11 @@ def get_docker_plugin(step: Step, image: str):
     if step.device in (DeviceType.H200_18GB, DeviceType.H200_35GB):
         image = image.replace("public.ecr.aws", "936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache")
         plugin["image"] = image
-    if step.label == "Benchmarks" or step.mount_buildkite_agent:
+    if (
+        step.label == "Benchmarks"
+        or step.mount_buildkite_agent
+        or step.otel_tracing_enabled()
+    ):
         plugin["mount_buildkite_agent"] = True
     if step.device in (DeviceType.CPU, DeviceType.CPU_SMALL, DeviceType.CPU_MEDIUM) and plugin.get("gpus"):
         del plugin["gpus"]

--- a/buildkite/pipeline_generator/pyproject.toml
+++ b/buildkite/pipeline_generator/pyproject.toml
@@ -28,4 +28,7 @@ py-modules = [
 ]
 
 [tool.setuptools.packages.find]
-include = [".", "plugin", "utils_lib"]
+include = [".", "otel_helpers", "plugin", "utils_lib"]
+
+[tool.setuptools.package-data]
+otel_helpers = ["*.sh"]

--- a/buildkite/pipeline_generator/step.py
+++ b/buildkite/pipeline_generator/step.py
@@ -34,6 +34,14 @@ class Step(BaseModel):
     dind: bool = True
     mirror: Optional[Dict[str, Dict[str, Any]]] = None
 
+    def otel_tracing_enabled(self) -> bool:
+        config = get_global_config()
+        return bool(
+            config["github_repo_name"] == "vllm-project/vllm"
+            and config["branch"] == "main"
+            and config["pull_request"] == "false"
+        )
+
     @model_validator(mode="after")
     def validate_multi_node(self) -> Self:
         if self.num_nodes and not self.num_devices:

--- a/buildkite/pipeline_generator/step.py
+++ b/buildkite/pipeline_generator/step.py
@@ -36,9 +36,15 @@ class Step(BaseModel):
 
     def otel_tracing_enabled(self) -> bool:
         config = get_global_config()
+        treatment_branch = os.getenv("CI_INFRA_OTEL_TREATMENT_BRANCH", "")
+        trusted_branch = config["branch"] == "main" or bool(
+            treatment_branch
+            and treatment_branch == config["branch"]
+            and os.getenv("BUILDKITE_SOURCE") == "api"
+        )
         return bool(
             config["github_repo_name"] == "vllm-project/vllm"
-            and config["branch"] == "main"
+            and trusted_branch
             and config["pull_request"] == "false"
         )
 

--- a/buildkite/tests/pipeline_generator/test_plugins.py
+++ b/buildkite/tests/pipeline_generator/test_plugins.py
@@ -5,6 +5,7 @@ from plugin.analytics import (
     BUILDKITE_ANALYTICS_SECRET,
     BUILDKITE_ANALYTICS_TOKEN,
 )
+from step import Step
 
 
 @pytest.mark.parametrize(
@@ -19,6 +20,25 @@ from plugin.analytics import (
 )
 def test_standard_docker_templates_forward_buildkite_analytics_token(template):
     assert BUILDKITE_ANALYTICS_TOKEN in template["environment"]
+
+
+def test_every_trusted_main_step_mounts_buildkite_agent(fake_global_config):
+    fake_global_config["branch"] = "main"
+    step = Step(label="Traced", device="h200_35gb")
+
+    plugin = docker_plugin.get_docker_plugin(step, "example/image:latest")
+
+    assert plugin["mount_buildkite_agent"] is True
+
+
+def test_pull_request_step_does_not_mount_agent_for_tracing(fake_global_config):
+    fake_global_config["branch"] = "main"
+    fake_global_config["pull_request"] = "123"
+    step = Step(label="Untrusted", device="h200_35gb")
+
+    plugin = docker_plugin.get_docker_plugin(step, "example/image:latest")
+
+    assert not plugin.get("mount_buildkite_agent", False)
 
 
 @pytest.mark.parametrize(

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -1,6 +1,7 @@
 import base64
 import os
 import re
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -22,6 +23,18 @@ def _render_single_step(step):
             step.group: [step],
         }
     )[0]
+
+
+def _make_pytest_bin(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "pytest-bin"
+    bin_dir.mkdir()
+    pytest_executable = bin_dir / "pytest"
+    pytest_executable.write_text(
+        f'#!/bin/sh\nexec {shlex.quote(sys.executable)} -m pytest "$@"\n',
+        encoding="utf-8",
+    )
+    pytest_executable.chmod(0o755)
+    return bin_dir
 
 
 def test_read_steps_from_job_dir():
@@ -198,9 +211,9 @@ def test_otel_trace_wraps_every_command_on_trusted_main(fake_global_config):
         setup_profile="none",
     )
 
-    assert "VLLM_CI_OTEL_DIR=$$(mktemp -d 2>/dev/null)" in commands[0]
+    assert "CI_INFRA_OTEL_DIR=$$(mktemp -d 2>/dev/null)" in commands[0]
     assert commands[0].endswith("fi; :")
-    assert '. "$$VLLM_CI_OTEL_DIR/ci_otel.sh"' in commands[0]
+    assert '. "$$CI_INFRA_OTEL_DIR/ci_otel.sh"' in commands[0]
     assert "ci_otel_start 1 " in commands[2]
     assert "export VALUE=ready" in commands[2]
     assert "ci_otel_finish" in commands[2]
@@ -241,18 +254,103 @@ def test_otel_helper_bundle_installs_and_sources():
             "bash",
             "-c",
             command
-            + " && test -f \"$VLLM_CI_OTEL_DIR/ci_otel.py\""
-            + " && test -f \"$VLLM_CI_OTEL_DIR/ci_pytest_otel.py\""
-            + ' && test "$VLLM_CI_OTEL_READY" = 1'
+            + ' && test -f "$CI_INFRA_OTEL_DIR/ci_otel.py"'
+            + ' && test -f "$CI_INFRA_OTEL_DIR/ci_pytest.sh"'
+            + ' && test -f "$CI_INFRA_OTEL_DIR/ci_pytest_otel.py"'
+            + ' && test "$CI_INFRA_OTEL_READY" = 1'
+            + ' && test "$PYTHONPATH" = original-pythonpath'
+            + ' && test "$PYTEST_ADDOPTS" = original-pytest-options'
             + " && type ci_otel_start"
             + " && type ci_otel_finish",
         ],
         check=False,
         capture_output=True,
         text=True,
+        env={
+            **os.environ,
+            "PYTHONPATH": "original-pythonpath",
+            "PYTEST_ADDOPTS": "original-pytest-options",
+        },
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_pytest_shim_traces_with_command_level_pythonpath_override(
+    fake_global_config, tmp_path
+):
+    fake_global_config["branch"] = "main"
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text("def test_sample():\n    assert True\n", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    pytest_bin = _make_pytest_bin(tmp_path)
+    step = Step(
+        label="PYTHONPATH override",
+        group="Tracing",
+        commands=[
+            f"PYTHONPATH={shlex.quote(str(workspace))} "
+            f"pytest -q {shlex.quote(str(test_file))}"
+        ],
+    )
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="none",
+    )
+
+    script = (
+        "\n".join(commands).replace("$$", "$")
+        + '\ngrep -q \'"name":"pytest.test"\' '
+        + '"$CI_INFRA_OTEL_SPOOL_DIR"/spans-*.jsonl'
+    )
+    result = subprocess.run(
+        ["/bin/sh", "-e", "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PATH": f"{pytest_bin}:{os.environ['PATH']}",
+            "PYTEST_ADDOPTS": "",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "1 passed" in result.stdout
+    assert "No module named 'ci_pytest_otel'" not in result.stderr
+
+
+def test_pytest_shim_falls_back_when_plugin_disappears(tmp_path):
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text("def test_sample():\n    assert True\n", encoding="utf-8")
+    pytest_bin = _make_pytest_bin(tmp_path)
+    missing_helpers = tmp_path / "missing-helpers"
+    missing_helpers.mkdir()
+    command = buildkite_step._otel_setup_command().replace("$$", "$")
+    shell = (
+        command
+        + "\nci_otel_start 1 dGVzdA=="
+        + f"\nCI_INFRA_OTEL_DIR={shlex.quote(str(missing_helpers))}"
+        + "\nexport CI_INFRA_OTEL_DIR"
+        + f"\npytest -q {shlex.quote(str(test_file))}"
+    )
+
+    result = subprocess.run(
+        ["/bin/sh", "-e", "-c", shell],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PATH": f"{pytest_bin}:{os.environ['PATH']}",
+            "PYTEST_ADDOPTS": "",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "1 passed" in result.stdout
+    assert "pytest tracing skipped; running pytest normally" in result.stderr
 
 
 def test_otel_setup_failure_is_soft_and_direct_command_runs(
@@ -303,7 +401,7 @@ def test_otel_import_failure_leaves_test_environment_untouched(
     script = (
         "python3() { return 1; };\n"
         + "\n".join(commands).replace("$$", "$")
-        + '\ntest "$VLLM_CI_OTEL_READY" = 0'
+        + '\ntest "$CI_INFRA_OTEL_READY" = 0'
         + '\ntest "$PYTHONPATH" = original-pythonpath'
         + '\ntest "$PYTEST_ADDOPTS" = original-pytest-options'
     )
@@ -362,7 +460,7 @@ def test_otel_helper_bundle_runs_under_posix_shell():
             command
             + " && ci_otel_start 1 dHJ1ZQ=="
             + " && true && ci_otel_finish 0"
-            + ' && test -n "$(find "$VLLM_CI_OTEL_SPOOL_DIR" -name spans-\\*.jsonl -size +0c -print -quit)"',
+            + ' && test -n "$(find "$CI_INFRA_OTEL_SPOOL_DIR" -name spans-\\*.jsonl -size +0c -print -quit)"',
         ],
         check=False,
         capture_output=True,

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -226,6 +226,40 @@ def test_otel_trace_wraps_every_command_on_trusted_main(fake_global_config):
     assert "'" not in commands[4]
 
 
+def test_otel_trace_allows_exact_api_treatment_branch(
+    fake_global_config, monkeypatch
+):
+    fake_global_config["branch"] = "khluu/otel"
+    monkeypatch.setenv("BUILDKITE_SOURCE", "api")
+    monkeypatch.setenv("CI_INFRA_OTEL_TREATMENT_BRANCH", "khluu/otel")
+    step = Step(label="Treatment", commands=["pytest tests"])
+
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="none",
+    )
+
+    assert any("ci_otel_start" in command for command in commands)
+
+
+def test_otel_trace_rejects_non_api_treatment_branch(
+    fake_global_config, monkeypatch
+):
+    fake_global_config["branch"] = "khluu/otel"
+    monkeypatch.setenv("BUILDKITE_SOURCE", "webhook")
+    monkeypatch.setenv("CI_INFRA_OTEL_TREATMENT_BRANCH", "khluu/otel")
+    step = Step(label="Untrusted treatment", commands=["pytest tests"])
+
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="none",
+    )
+
+    assert not any("ci_otel" in command for command in commands)
+
+
 def test_otel_trace_preserves_generator_variable_injection(fake_global_config):
     fake_global_config["branch"] = "main"
     step = Step(

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -1,3 +1,6 @@
+import base64
+import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -179,6 +182,235 @@ def test_continue_on_failure_exits_nonzero_after_command_failure(monkeypatch):
     assert "CI_OVERALL_STATUS=1" in script
     assert "after" in result.stdout
     assert result.returncode == 1
+
+
+def test_otel_trace_wraps_every_command_on_trusted_main(fake_global_config):
+    fake_global_config["branch"] = "main"
+    step = Step(
+        label="Traced",
+        group="Tracing",
+        commands=["export VALUE=ready", 'test "$VALUE" = ready'],
+    )
+
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="none",
+    )
+
+    assert "VLLM_CI_OTEL_DIR=$$(mktemp -d 2>/dev/null)" in commands[0]
+    assert commands[0].endswith("fi; :")
+    assert '. "$$VLLM_CI_OTEL_DIR/ci_otel.sh"' in commands[0]
+    assert "ci_otel_start 1 " in commands[2]
+    assert "export VALUE=ready" in commands[2]
+    assert "ci_otel_finish" in commands[2]
+    assert "ci_otel_start 2 " in commands[4]
+    assert 'test "$VALUE" = ready' in commands[4]
+    match = re.search(r"ci_otel_start 2 (\S+)", commands[4])
+    assert match is not None
+    (encoded_label,) = match.groups()
+    assert base64.b64decode(encoded_label).decode() == "test VALUE = ready"
+    assert "'" not in commands[4]
+
+
+def test_otel_trace_preserves_generator_variable_injection(fake_global_config):
+    fake_global_config["branch"] = "main"
+    step = Step(
+        label="Traced image build",
+        group="Tracing",
+        commands=["build $REGISTRY $REPO $BUILDKITE_COMMIT"],
+    )
+
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={
+            "$REGISTRY": "registry.example.com",
+            "$REPO": "vllm-ci",
+            "$BUILDKITE_COMMIT": "$$BUILDKITE_COMMIT",
+        },
+        setup_profile="none",
+    )
+
+    assert "build registry.example.com vllm-ci $$BUILDKITE_COMMIT" in commands[2]
+
+
+def test_otel_helper_bundle_installs_and_sources():
+    command = buildkite_step._otel_setup_command().replace("$$", "$")
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            command
+            + " && test -f \"$VLLM_CI_OTEL_DIR/ci_otel.py\""
+            + " && test -f \"$VLLM_CI_OTEL_DIR/ci_pytest_otel.py\""
+            + ' && test "$VLLM_CI_OTEL_READY" = 1'
+            + " && type ci_otel_start"
+            + " && type ci_otel_finish",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_otel_setup_failure_is_soft_and_direct_command_runs(
+    fake_global_config, tmp_path
+):
+    fake_global_config["branch"] = "main"
+    output = tmp_path / "command-ran"
+    step = Step(
+        label="Traced",
+        group="Tracing",
+        commands=['printf ran > "$OUTPUT_FILE"'],
+    )
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="none",
+    )
+    script = "mktemp() { return 1; };\n" + "\n".join(commands).replace("$$", "$")
+
+    result = subprocess.run(
+        ["/bin/sh", "-e", "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "OUTPUT_FILE": str(output)},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output.read_text(encoding="utf-8") == "ran"
+    assert "tracing setup skipped" in result.stderr
+
+
+def test_otel_import_failure_leaves_test_environment_untouched(
+    fake_global_config, tmp_path
+):
+    fake_global_config["branch"] = "main"
+    output = tmp_path / "command-ran"
+    step = Step(
+        label="Traced",
+        group="Tracing",
+        commands=['printf ran > "$OUTPUT_FILE"'],
+    )
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="none",
+    )
+    script = (
+        "python3() { return 1; };\n"
+        + "\n".join(commands).replace("$$", "$")
+        + '\ntest "$VLLM_CI_OTEL_READY" = 0'
+        + '\ntest "$PYTHONPATH" = original-pythonpath'
+        + '\ntest "$PYTEST_ADDOPTS" = original-pytest-options'
+    )
+
+    result = subprocess.run(
+        ["/bin/sh", "-e", "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "OUTPUT_FILE": str(output),
+            "PYTHONPATH": "original-pythonpath",
+            "PYTEST_ADDOPTS": "original-pytest-options",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output.read_text(encoding="utf-8") == "ran"
+    assert "tracing disabled" in result.stderr
+
+
+def test_otel_does_not_change_errexit_behavior(fake_global_config, tmp_path):
+    fake_global_config["branch"] = "main"
+    output = tmp_path / "must-not-run"
+    step = Step(
+        label="Traced failure",
+        group="Tracing",
+        commands=['false\nprintf bad > "$OUTPUT_FILE"'],
+    )
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="none",
+    )
+    script = "\n".join(commands).replace("$$", "$")
+
+    result = subprocess.run(
+        ["/bin/sh", "-e", "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "OUTPUT_FILE": str(output)},
+    )
+
+    assert result.returncode == 1
+    assert not output.exists()
+
+
+def test_otel_helper_bundle_runs_under_posix_shell():
+    command = buildkite_step._otel_setup_command().replace("$$", "$")
+    result = subprocess.run(
+        [
+            "/bin/sh",
+            "-c",
+            command
+            + " && ci_otel_start 1 dHJ1ZQ=="
+            + " && true && ci_otel_finish 0"
+            + ' && test -n "$(find "$VLLM_CI_OTEL_SPOOL_DIR" -name spans-\\*.jsonl -size +0c -print -quit)"',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_otel_trace_is_disabled_for_amd_mirror(fake_global_config):
+    fake_global_config["branch"] = "main"
+    step = Step(label="AMD mirror", commands=["pytest tests"])
+
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="amd",
+    )
+
+    assert not any("ci_otel" in command for command in commands)
+
+
+def test_otel_trace_is_disabled_for_pull_requests(fake_global_config):
+    fake_global_config["branch"] = "main"
+    fake_global_config["pull_request"] = "123"
+    step = Step(label="Untrusted", commands=["pytest tests"])
+
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="none",
+    )
+
+    assert not any("ci_otel" in command for command in commands)
+
+
+def test_otel_trace_is_disabled_for_non_vllm_pipelines(fake_global_config):
+    fake_global_config["branch"] = "main"
+    fake_global_config["github_repo_name"] = "vllm-project/other"
+    step = Step(label="Other repository", commands=["pytest tests"])
+
+    commands = buildkite_step._prepare_commands(
+        step,
+        variables_to_inject={},
+        setup_profile="none",
+    )
+
+    assert not any("ci_otel" in command for command in commands)
 
 
 def test_generated_steps_retry_when_the_agent_is_lost():

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -422,6 +422,11 @@ def test_otel_import_failure_leaves_test_environment_untouched(
 ):
     fake_global_config["branch"] = "main"
     output = tmp_path / "command-ran"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python3"
+    fake_python.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    fake_python.chmod(0o755)
     step = Step(
         label="Traced",
         group="Tracing",
@@ -433,8 +438,7 @@ def test_otel_import_failure_leaves_test_environment_untouched(
         setup_profile="none",
     )
     script = (
-        "python3() { return 1; };\n"
-        + "\n".join(commands).replace("$$", "$")
+        "\n".join(commands).replace("$$", "$")
         + '\ntest "$CI_INFRA_OTEL_READY" = 0'
         + '\ntest "$PYTHONPATH" = original-pythonpath'
         + '\ntest "$PYTEST_ADDOPTS" = original-pytest-options'
@@ -448,6 +452,7 @@ def test_otel_import_failure_leaves_test_environment_untouched(
         env={
             **os.environ,
             "OUTPUT_FILE": str(output),
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
             "PYTHONPATH": "original-pythonpath",
             "PYTEST_ADDOPTS": "original-pytest-options",
         },

--- a/buildkite/tests/test_ci_otel.py
+++ b/buildkite/tests/test_ci_otel.py
@@ -1,0 +1,428 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import binascii
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[1] / "pipeline_generator" / "otel_helpers"
+)
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import ci_otel  # noqa: E402
+import ci_pytest_otel  # noqa: E402
+from ci_otel import (  # noqa: E402
+    Span,
+    encode_request,
+    export_spans,
+    load_spans,
+    new_context,
+    record_spans,
+)
+
+
+def _encoded(value: str) -> str:
+    return binascii.b2a_base64(value.encode(), newline=False).decode()
+
+
+def test_new_context_continues_w3c_traceparent(monkeypatch):
+    monkeypatch.setenv(
+        "TRACEPARENT",
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+    )
+
+    trace_id, span_id, parent_span_id = new_context()
+
+    assert trace_id == "4bf92f3577b34da6a3ce929d0e0e4736"
+    assert len(span_id) == 16
+    assert parent_span_id == "00f067aa0ba902b7"
+
+
+def test_otlp_payload_contains_span_and_build_identity(monkeypatch):
+    monkeypatch.setenv("BUILDKITE_ORGANIZATION_SLUG", "vllm")
+    monkeypatch.setenv("BUILDKITE_PIPELINE_SLUG", "ci")
+    monkeypatch.setenv("BUILDKITE_BUILD_ID", "build-id")
+    monkeypatch.setenv("BUILDKITE_BUILD_NUMBER", "42")
+    monkeypatch.setenv("BUILDKITE_BRANCH", "main")
+    monkeypatch.setenv("BUILDKITE_JOB_ID", "job-id")
+    span = Span(
+        trace_id="01" * 16,
+        span_id="02" * 8,
+        parent_span_id="03" * 8,
+        name="ci.command",
+        start_ns=100,
+        end_ns=200,
+        attributes={"ci.span.kind": "command"},
+    )
+
+    payload = encode_request([span])
+
+    assert b"ci.command" in payload
+    assert b"ci.span.kind" in payload
+    assert b"buildkite.job.id" in payload
+    assert b"job-id" in payload
+
+
+def test_export_is_disabled_outside_buildkite(monkeypatch):
+    monkeypatch.delenv("BUILDKITE", raising=False)
+
+    assert export_spans([]) is False
+
+
+def test_spans_are_spooled_without_requesting_credentials(monkeypatch, tmp_path):
+    monkeypatch.setenv("VLLM_CI_OTEL_SPOOL_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        ci_otel,
+        "_oidc_token",
+        lambda deadline: (_ for _ in ()).throw(AssertionError("unexpected upload")),
+    )
+    span = Span(
+        trace_id="01" * 16,
+        span_id="02" * 8,
+        parent_span_id=None,
+        name="ci.command",
+        start_ns=100,
+        end_ns=200,
+        attributes={"ci.command.index": 1},
+    )
+
+    assert record_spans([span]) is True
+    assert load_spans() == [span]
+
+
+def test_export_mints_one_token_for_multiple_batches(monkeypatch):
+    for name, value in {
+        "BUILDKITE": "true",
+        "BUILDKITE_ORGANIZATION_SLUG": "vllm",
+        "BUILDKITE_PIPELINE_SLUG": "ci",
+        "BUILDKITE_BUILD_ID": "build-id",
+        "BUILDKITE_BUILD_NUMBER": "42",
+        "BUILDKITE_JOB_ID": "job-id",
+        "BUILDKITE_BRANCH": "main",
+    }.items():
+        monkeypatch.setenv(name, value)
+    token_calls = []
+    request_timeouts = []
+    monkeypatch.setattr(ci_otel, "MAX_BATCH_SIZE", 1)
+    monkeypatch.setattr(
+        ci_otel,
+        "_oidc_token",
+        lambda deadline: token_calls.append(deadline) or "token",
+    )
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def open_request(request, timeout):
+        request_timeouts.append(timeout)
+        return Response()
+
+    monkeypatch.setattr(ci_otel.urllib.request, "urlopen", open_request)
+    spans = [
+        Span(
+            trace_id="01" * 16,
+            span_id=f"{index:016x}",
+            parent_span_id=None,
+            name="pytest.test",
+            start_ns=100,
+            end_ns=200,
+            attributes={"test.nodeid": f"test_{index}"},
+        )
+        for index in (1, 2)
+    ]
+
+    assert export_spans(spans, timeout_seconds=0.5) is True
+    assert len(token_calls) == 1
+    assert len(request_timeouts) == 2
+    assert all(0 < timeout <= 0.5 for timeout in request_timeouts)
+
+
+def test_export_deadline_bounds_oidc_request(monkeypatch, tmp_path):
+    for name, value in {
+        "BUILDKITE": "true",
+        "BUILDKITE_ORGANIZATION_SLUG": "vllm",
+        "BUILDKITE_PIPELINE_SLUG": "ci",
+        "BUILDKITE_BUILD_ID": "build-id",
+        "BUILDKITE_BUILD_NUMBER": "42",
+        "BUILDKITE_JOB_ID": "job-id",
+        "BUILDKITE_BRANCH": "main",
+    }.items():
+        monkeypatch.setenv(name, value)
+    agent = tmp_path / "buildkite-agent"
+    agent.write_text("#!/bin/sh\nsleep 5\n", encoding="utf-8")
+    agent.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
+    span = Span(
+        trace_id="01" * 16,
+        span_id="02" * 8,
+        parent_span_id=None,
+        name="ci.command",
+        start_ns=100,
+        end_ns=200,
+        attributes={},
+    )
+
+    started = time.monotonic()
+    assert export_spans([span], timeout_seconds=0.1) is False
+
+    assert time.monotonic() - started < 0.5
+
+
+def test_invalid_upload_timeout_cannot_break_plugin_import():
+    result = subprocess.run(
+        [sys.executable, "-c", "import ci_otel, ci_pytest_otel"],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(SCRIPTS_DIR),
+            "VLLM_CI_OTEL_UPLOAD_TIMEOUT": "not-a-number",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_export_contains_unexpected_internal_errors(monkeypatch):
+    for name, value in {
+        "BUILDKITE": "true",
+        "BUILDKITE_ORGANIZATION_SLUG": "vllm",
+        "BUILDKITE_PIPELINE_SLUG": "ci",
+        "BUILDKITE_BUILD_ID": "build-id",
+        "BUILDKITE_BUILD_NUMBER": "42",
+        "BUILDKITE_JOB_ID": "job-id",
+        "BUILDKITE_BRANCH": "main",
+    }.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setattr(
+        ci_otel,
+        "_oidc_token",
+        lambda deadline: (_ for _ in ()).throw(ValueError("broken exporter")),
+    )
+    span = Span(
+        trace_id="01" * 16,
+        span_id="02" * 8,
+        parent_span_id=None,
+        name="ci.command",
+        start_ns=100,
+        end_ns=200,
+        attributes={},
+    )
+
+    assert export_spans([span]) is False
+
+
+def test_record_spans_contains_serialization_errors(monkeypatch, tmp_path):
+    monkeypatch.setenv("VLLM_CI_OTEL_SPOOL_DIR", str(tmp_path))
+    span = Span(
+        trace_id="01" * 16,
+        span_id="02" * 8,
+        parent_span_id=None,
+        name="ci.command",
+        start_ns=100,
+        end_ns=200,
+        attributes={"invalid": object()},  # type: ignore[dict-item]
+    )
+
+    assert record_spans([span]) is False
+
+
+def test_shell_wrapper_preserves_command_state_and_quoting(tmp_path):
+    script = SCRIPTS_DIR / "ci_otel.sh"
+    first = f"ci_otel_start 1 {_encoded('export VALUE=ready')}"
+    second = f"ci_otel_start 2 {_encoded('check VALUE')}"
+    shell = (
+        f'source "{script}"; {first}; export VALUE=ready; ci_otel_finish 0; '
+        f'{second}; test "$VALUE" = ready; ci_otel_finish 0'
+    )
+    result = subprocess.run(
+        ["bash", "-c", shell],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
+            "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_shell_wrapper_expands_runtime_environment_arguments(tmp_path):
+    script = SCRIPTS_DIR / "ci_otel.sh"
+    start = f"ci_otel_start 1 {_encoded('check generated variables')}"
+    command = 'test "$REGISTRY" = registry.example.com && test "$COMMIT" = abc123'
+    result = subprocess.run(
+        ["bash", "-c", f'source "{script}"; {start}; {command}; ci_otel_finish $?'],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "REGISTRY": "registry.example.com",
+            "COMMIT": "abc123",
+            "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
+            "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_shell_wrapper_preserves_failure_status(tmp_path):
+    script = SCRIPTS_DIR / "ci_otel.sh"
+    start = f"ci_otel_start 1 {_encoded('false')}"
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'source "{script}"; {start}; false; status=$?; '
+            'ci_otel_finish "$status"; (exit "$status")',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
+            "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path),
+        },
+    )
+
+    assert result.returncode == 1, result.stderr
+
+
+def test_shell_wrapper_runs_command_when_context_creation_fails(tmp_path):
+    script = SCRIPTS_DIR / "ci_otel.sh"
+    start = f"ci_otel_start 1 {_encoded('write marker')}"
+    result = subprocess.run(
+        [
+            "/bin/sh",
+            "-c",
+            f'. "{script}"; python3() {{ return 1; }}; {start} || :; '
+            'printf ran > "$OUTPUT_FILE"',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "OUTPUT_FILE": str(tmp_path / "ran"),
+            "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
+            "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path / "spans"),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "ran").read_text(encoding="utf-8") == "ran"
+
+
+def test_shell_wrapper_ignores_recording_failure(tmp_path):
+    script = SCRIPTS_DIR / "ci_otel.sh"
+    start = f"ci_otel_start 1 {_encoded('true')}"
+    shell = f"""
+      . "{script}"
+      python3() {{
+        if [ "$2" = "new-context" ]; then
+          echo 01010101010101010101010101010101 0202020202020202 -
+          return 0
+        fi
+        return 99
+      }}
+      {start}
+      true
+      ci_otel_finish 0
+    """
+    result = subprocess.run(
+        ["/bin/sh", "-e", "-c", shell],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
+            "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_exit_flush_failure_preserves_success_and_failure(tmp_path):
+    script = SCRIPTS_DIR / "ci_otel.sh"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python3"
+    fake_python.write_text("#!/bin/sh\nexit 99\n", encoding="utf-8")
+    fake_python.chmod(0o755)
+
+    def run_with_status(status: int):
+        shell = f'. "{script}"; PATH="{fake_bin}"; export PATH; exit {status}'
+        return subprocess.run(
+            ["/bin/sh", "-c", shell],
+            check=False,
+            capture_output=True,
+            text=True,
+            env={
+                **os.environ,
+                "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
+                "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path / f"spans-{status}"),
+            },
+        )
+
+    assert run_with_status(0).returncode == 0
+    assert run_with_status(7).returncode == 7
+
+
+def test_pytest_hooks_contain_all_tracing_errors(monkeypatch):
+    monkeypatch.setenv("VLLM_CI_TRACE_ID", "01" * 16)
+    monkeypatch.setenv("VLLM_CI_COMMAND_SPAN_ID", "02" * 8)
+    ci_pytest_otel._runs.clear()
+    ci_pytest_otel._spans.clear()
+    monkeypatch.setattr(
+        ci_pytest_otel.time,
+        "time_ns",
+        lambda: (_ for _ in ()).throw(RuntimeError("broken clock")),
+    )
+
+    ci_pytest_otel.pytest_runtest_logstart("test_example", ("test.py", 1, "test"))
+    ci_pytest_otel.pytest_runtest_logreport(object())
+    ci_pytest_otel.pytest_runtest_logfinish("test_example", ("test.py", 1, "test"))
+    ci_pytest_otel.pytest_sessionfinish(None, 0)
+
+
+def test_real_pytest_passes_when_otel_spool_is_unwritable(tmp_path):
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text("def test_sample():\n    assert True\n", encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", str(test_file)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(SCRIPTS_DIR),
+            "PYTEST_ADDOPTS": "-p ci_pytest_otel",
+            "VLLM_CI_TRACE_ID": "01" * 16,
+            "VLLM_CI_COMMAND_SPAN_ID": "02" * 8,
+            "VLLM_CI_OTEL_SPOOL_DIR": "/dev/null/spans",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "1 passed" in result.stdout

--- a/buildkite/tests/test_ci_otel.py
+++ b/buildkite/tests/test_ci_otel.py
@@ -79,7 +79,7 @@ def test_spans_are_spooled_without_requesting_credentials(monkeypatch, tmp_path)
     monkeypatch.setenv("CI_INFRA_OTEL_SPOOL_DIR", str(tmp_path))
     monkeypatch.setattr(
         ci_otel,
-        "_oidc_token",
+        "_ingest_token",
         lambda deadline: (_ for _ in ()).throw(AssertionError("unexpected upload")),
     )
     span = Span(
@@ -112,7 +112,7 @@ def test_export_mints_one_token_for_multiple_batches(monkeypatch):
     monkeypatch.setattr(ci_otel, "MAX_BATCH_SIZE", 1)
     monkeypatch.setattr(
         ci_otel,
-        "_oidc_token",
+        "_ingest_token",
         lambda deadline: token_calls.append(deadline) or "token",
     )
 
@@ -149,7 +149,7 @@ def test_export_mints_one_token_for_multiple_batches(monkeypatch):
     assert all(0 < timeout <= 0.5 for timeout in request_timeouts)
 
 
-def test_export_deadline_bounds_oidc_request(monkeypatch, tmp_path):
+def test_export_deadline_bounds_secret_request(monkeypatch, tmp_path):
     for name, value in {
         "BUILDKITE": "true",
         "BUILDKITE_ORGANIZATION_SLUG": "vllm",
@@ -180,7 +180,7 @@ def test_export_deadline_bounds_oidc_request(monkeypatch, tmp_path):
     assert time.monotonic() - started < 0.5
 
 
-def test_oidc_token_uses_only_standard_audience(monkeypatch):
+def test_ingest_token_uses_buildkite_cluster_secret(monkeypatch):
     observed = {}
 
     class Result:
@@ -193,20 +193,17 @@ def test_oidc_token_uses_only_standard_audience(monkeypatch):
 
     monkeypatch.setattr(ci_otel.subprocess, "run", run)
 
-    assert ci_otel._oidc_token(time.monotonic() + 1) == "token"
+    assert ci_otel._ingest_token(time.monotonic() + 1) == "token"
     assert observed["command"] == [
         "buildkite-agent",
-        "oidc",
-        "request-token",
-        "--audience",
-        "https://ci.vllm.ai/api/otel",
-        "--lifetime",
-        "300",
+        "secret",
+        "get",
+        "CI_OTEL_INGEST_TOKEN",
     ]
     assert observed["kwargs"]["check"] is True
 
 
-def test_oidc_failure_reports_bounded_stderr(monkeypatch):
+def test_secret_failure_reports_bounded_stderr(monkeypatch):
     def run(command, **kwargs):
         raise subprocess.CalledProcessError(
             1,
@@ -217,14 +214,14 @@ def test_oidc_failure_reports_bounded_stderr(monkeypatch):
     monkeypatch.setattr(ci_otel.subprocess, "run", run)
 
     try:
-        ci_otel._oidc_token(time.monotonic() + 1)
+        ci_otel._ingest_token(time.monotonic() + 1)
     except RuntimeError as error:
         message = str(error)
     else:
-        raise AssertionError("OIDC failure should be reported")
+        raise AssertionError("secret failure should be reported")
 
     assert message.startswith(
-        "Buildkite OIDC request failed (exit 1): agent request failed"
+        "Buildkite secret request failed (exit 1): agent request failed"
     )
     assert message.endswith("...")
     assert len(message) < 600
@@ -259,7 +256,7 @@ def test_export_contains_unexpected_internal_errors(monkeypatch):
         monkeypatch.setenv(name, value)
     monkeypatch.setattr(
         ci_otel,
-        "_oidc_token",
+        "_ingest_token",
         lambda deadline: (_ for _ in ()).throw(ValueError("broken exporter")),
     )
     span = Span(

--- a/buildkite/tests/test_ci_otel.py
+++ b/buildkite/tests/test_ci_otel.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import binascii
+import json
 import os
 import subprocess
 import sys
@@ -79,7 +80,7 @@ def test_spans_are_spooled_without_requesting_credentials(monkeypatch, tmp_path)
     monkeypatch.setenv("CI_INFRA_OTEL_SPOOL_DIR", str(tmp_path))
     monkeypatch.setattr(
         ci_otel,
-        "_ingest_token",
+        "_oidc_token",
         lambda deadline: (_ for _ in ()).throw(AssertionError("unexpected upload")),
     )
     span = Span(
@@ -112,7 +113,7 @@ def test_export_mints_one_token_for_multiple_batches(monkeypatch):
     monkeypatch.setattr(ci_otel, "MAX_BATCH_SIZE", 1)
     monkeypatch.setattr(
         ci_otel,
-        "_ingest_token",
+        "_oidc_token",
         lambda deadline: token_calls.append(deadline) or "token",
     )
 
@@ -149,7 +150,7 @@ def test_export_mints_one_token_for_multiple_batches(monkeypatch):
     assert all(0 < timeout <= 0.5 for timeout in request_timeouts)
 
 
-def test_export_deadline_bounds_secret_request(monkeypatch, tmp_path):
+def test_export_deadline_bounds_oidc_request(monkeypatch):
     for name, value in {
         "BUILDKITE": "true",
         "BUILDKITE_ORGANIZATION_SLUG": "vllm",
@@ -160,10 +161,13 @@ def test_export_deadline_bounds_secret_request(monkeypatch, tmp_path):
         "BUILDKITE_BRANCH": "main",
     }.items():
         monkeypatch.setenv(name, value)
-    agent = tmp_path / "buildkite-agent"
-    agent.write_text("#!/bin/sh\nsleep 5\n", encoding="utf-8")
-    agent.chmod(0o755)
-    monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
+    monkeypatch.setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "agent-token")
+
+    def open_request(request, timeout):
+        assert 0 < timeout <= 0.1
+        raise TimeoutError("request timed out")
+
+    monkeypatch.setattr(ci_otel.urllib.request, "urlopen", open_request)
     span = Span(
         trace_id="01" * 16,
         span_id="02" * 8,
@@ -180,51 +184,50 @@ def test_export_deadline_bounds_secret_request(monkeypatch, tmp_path):
     assert time.monotonic() - started < 0.5
 
 
-def test_ingest_token_uses_buildkite_cluster_secret(monkeypatch):
+def test_oidc_token_uses_buildkite_job_api(monkeypatch):
+    monkeypatch.setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "agent-token")
+    monkeypatch.setenv("BUILDKITE_JOB_ID", "job-id")
+    monkeypatch.setenv("BUILDKITE_AGENT_ENDPOINT", "https://agent.example/v3/")
     observed = {}
 
     class Result:
-        stdout = "token\n"
+        def read(self):
+            return b'{"token":"oidc-token"}'
 
-    def run(command, **kwargs):
-        observed["command"] = command
-        observed["kwargs"] = kwargs
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def open_request(request, timeout):
+        observed["request"] = request
+        observed["timeout"] = timeout
         return Result()
 
-    monkeypatch.setattr(ci_otel.subprocess, "run", run)
+    monkeypatch.setattr(ci_otel.urllib.request, "urlopen", open_request)
 
-    assert ci_otel._ingest_token(time.monotonic() + 1) == "token"
-    assert observed["command"] == [
-        "buildkite-agent",
-        "secret",
-        "get",
-        "CI_OTEL_INGEST_TOKEN",
-    ]
-    assert observed["kwargs"]["check"] is True
+    assert ci_otel._oidc_token(time.monotonic() + 1) == "oidc-token"
+    request = observed["request"]
+    assert request.full_url == "https://agent.example/v3/jobs/job-id/oidc/tokens"
+    assert request.get_header("Authorization") == "Token agent-token"
+    assert json.loads(request.data) == {
+        "audience": "https://ci.vllm.ai/api/otel",
+        "lifetime": 300,
+    }
+    assert 0 < observed["timeout"] <= 1
 
 
-def test_secret_failure_reports_bounded_stderr(monkeypatch):
-    def run(command, **kwargs):
-        raise subprocess.CalledProcessError(
-            1,
-            command,
-            stderr="agent request failed\n" + ("x" * 1_000),
-        )
-
-    monkeypatch.setattr(ci_otel.subprocess, "run", run)
+def test_oidc_token_requires_job_credentials(monkeypatch):
+    monkeypatch.delenv("BUILDKITE_AGENT_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("BUILDKITE_JOB_ID", raising=False)
 
     try:
-        ci_otel._ingest_token(time.monotonic() + 1)
+        ci_otel._oidc_token(time.monotonic() + 1)
     except RuntimeError as error:
-        message = str(error)
+        assert str(error) == "Buildkite job credentials are unavailable"
     else:
-        raise AssertionError("secret failure should be reported")
-
-    assert message.startswith(
-        "Buildkite secret request failed (exit 1): agent request failed"
-    )
-    assert message.endswith("...")
-    assert len(message) < 600
+        raise AssertionError("missing job credentials should be reported")
 
 
 def test_invalid_upload_timeout_cannot_break_plugin_import():
@@ -256,7 +259,7 @@ def test_export_contains_unexpected_internal_errors(monkeypatch):
         monkeypatch.setenv(name, value)
     monkeypatch.setattr(
         ci_otel,
-        "_ingest_token",
+        "_oidc_token",
         lambda deadline: (_ for _ in ()).throw(ValueError("broken exporter")),
     )
     span = Span(

--- a/buildkite/tests/test_ci_otel.py
+++ b/buildkite/tests/test_ci_otel.py
@@ -76,7 +76,7 @@ def test_export_is_disabled_outside_buildkite(monkeypatch):
 
 
 def test_spans_are_spooled_without_requesting_credentials(monkeypatch, tmp_path):
-    monkeypatch.setenv("VLLM_CI_OTEL_SPOOL_DIR", str(tmp_path))
+    monkeypatch.setenv("CI_INFRA_OTEL_SPOOL_DIR", str(tmp_path))
     monkeypatch.setattr(
         ci_otel,
         "_oidc_token",
@@ -180,6 +180,32 @@ def test_export_deadline_bounds_oidc_request(monkeypatch, tmp_path):
     assert time.monotonic() - started < 0.5
 
 
+def test_oidc_token_uses_only_standard_audience(monkeypatch):
+    observed = {}
+
+    class Result:
+        stdout = "token\n"
+
+    def run(command, **kwargs):
+        observed["command"] = command
+        observed["kwargs"] = kwargs
+        return Result()
+
+    monkeypatch.setattr(ci_otel.subprocess, "run", run)
+
+    assert ci_otel._oidc_token(time.monotonic() + 1) == "token"
+    assert observed["command"] == [
+        "buildkite-agent",
+        "oidc",
+        "request-token",
+        "--audience",
+        "https://ci.vllm.ai/api/otel",
+        "--lifetime",
+        "300",
+    ]
+    assert observed["kwargs"]["check"] is True
+
+
 def test_invalid_upload_timeout_cannot_break_plugin_import():
     result = subprocess.run(
         [sys.executable, "-c", "import ci_otel, ci_pytest_otel"],
@@ -189,7 +215,7 @@ def test_invalid_upload_timeout_cannot_break_plugin_import():
         env={
             **os.environ,
             "PYTHONPATH": str(SCRIPTS_DIR),
-            "VLLM_CI_OTEL_UPLOAD_TIMEOUT": "not-a-number",
+            "CI_INFRA_OTEL_UPLOAD_TIMEOUT": "not-a-number",
         },
     )
 
@@ -226,7 +252,7 @@ def test_export_contains_unexpected_internal_errors(monkeypatch):
 
 
 def test_record_spans_contains_serialization_errors(monkeypatch, tmp_path):
-    monkeypatch.setenv("VLLM_CI_OTEL_SPOOL_DIR", str(tmp_path))
+    monkeypatch.setenv("CI_INFRA_OTEL_SPOOL_DIR", str(tmp_path))
     span = Span(
         trace_id="01" * 16,
         span_id="02" * 8,
@@ -255,8 +281,8 @@ def test_shell_wrapper_preserves_command_state_and_quoting(tmp_path):
         text=True,
         env={
             **os.environ,
-            "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
-            "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path),
+            "CI_INFRA_OTEL_DIR": str(SCRIPTS_DIR),
+            "CI_INFRA_OTEL_SPOOL_DIR": str(tmp_path),
         },
     )
 
@@ -276,8 +302,8 @@ def test_shell_wrapper_expands_runtime_environment_arguments(tmp_path):
             **os.environ,
             "REGISTRY": "registry.example.com",
             "COMMIT": "abc123",
-            "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
-            "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path),
+            "CI_INFRA_OTEL_DIR": str(SCRIPTS_DIR),
+            "CI_INFRA_OTEL_SPOOL_DIR": str(tmp_path),
         },
     )
 
@@ -299,8 +325,8 @@ def test_shell_wrapper_preserves_failure_status(tmp_path):
         text=True,
         env={
             **os.environ,
-            "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
-            "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path),
+            "CI_INFRA_OTEL_DIR": str(SCRIPTS_DIR),
+            "CI_INFRA_OTEL_SPOOL_DIR": str(tmp_path),
         },
     )
 
@@ -323,8 +349,8 @@ def test_shell_wrapper_runs_command_when_context_creation_fails(tmp_path):
         env={
             **os.environ,
             "OUTPUT_FILE": str(tmp_path / "ran"),
-            "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
-            "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path / "spans"),
+            "CI_INFRA_OTEL_DIR": str(SCRIPTS_DIR),
+            "CI_INFRA_OTEL_SPOOL_DIR": str(tmp_path / "spans"),
         },
     )
 
@@ -355,8 +381,8 @@ def test_shell_wrapper_ignores_recording_failure(tmp_path):
         text=True,
         env={
             **os.environ,
-            "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
-            "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path),
+            "CI_INFRA_OTEL_DIR": str(SCRIPTS_DIR),
+            "CI_INFRA_OTEL_SPOOL_DIR": str(tmp_path),
         },
     )
 
@@ -380,8 +406,8 @@ def test_exit_flush_failure_preserves_success_and_failure(tmp_path):
             text=True,
             env={
                 **os.environ,
-                "VLLM_CI_OTEL_DIR": str(SCRIPTS_DIR),
-                "VLLM_CI_OTEL_SPOOL_DIR": str(tmp_path / f"spans-{status}"),
+                "CI_INFRA_OTEL_DIR": str(SCRIPTS_DIR),
+                "CI_INFRA_OTEL_SPOOL_DIR": str(tmp_path / f"spans-{status}"),
             },
         )
 
@@ -390,8 +416,8 @@ def test_exit_flush_failure_preserves_success_and_failure(tmp_path):
 
 
 def test_pytest_hooks_contain_all_tracing_errors(monkeypatch):
-    monkeypatch.setenv("VLLM_CI_TRACE_ID", "01" * 16)
-    monkeypatch.setenv("VLLM_CI_COMMAND_SPAN_ID", "02" * 8)
+    monkeypatch.setenv("CI_INFRA_TRACE_ID", "01" * 16)
+    monkeypatch.setenv("CI_INFRA_COMMAND_SPAN_ID", "02" * 8)
     ci_pytest_otel._runs.clear()
     ci_pytest_otel._spans.clear()
     monkeypatch.setattr(
@@ -418,9 +444,9 @@ def test_real_pytest_passes_when_otel_spool_is_unwritable(tmp_path):
             **os.environ,
             "PYTHONPATH": str(SCRIPTS_DIR),
             "PYTEST_ADDOPTS": "-p ci_pytest_otel",
-            "VLLM_CI_TRACE_ID": "01" * 16,
-            "VLLM_CI_COMMAND_SPAN_ID": "02" * 8,
-            "VLLM_CI_OTEL_SPOOL_DIR": "/dev/null/spans",
+            "CI_INFRA_TRACE_ID": "01" * 16,
+            "CI_INFRA_COMMAND_SPAN_ID": "02" * 8,
+            "CI_INFRA_OTEL_SPOOL_DIR": "/dev/null/spans",
         },
     )
 

--- a/buildkite/tests/test_ci_otel.py
+++ b/buildkite/tests/test_ci_otel.py
@@ -206,6 +206,30 @@ def test_oidc_token_uses_only_standard_audience(monkeypatch):
     assert observed["kwargs"]["check"] is True
 
 
+def test_oidc_failure_reports_bounded_stderr(monkeypatch):
+    def run(command, **kwargs):
+        raise subprocess.CalledProcessError(
+            1,
+            command,
+            stderr="agent request failed\n" + ("x" * 1_000),
+        )
+
+    monkeypatch.setattr(ci_otel.subprocess, "run", run)
+
+    try:
+        ci_otel._oidc_token(time.monotonic() + 1)
+    except RuntimeError as error:
+        message = str(error)
+    else:
+        raise AssertionError("OIDC failure should be reported")
+
+    assert message.startswith(
+        "Buildkite OIDC request failed (exit 1): agent request failed"
+    )
+    assert message.endswith("...")
+    assert len(message) < 600
+
+
 def test_invalid_upload_timeout_cannot_break_plugin_import():
     result = subprocess.run(
         [sys.executable, "-c", "import ci_otel, ci_pytest_otel"],

--- a/buildkite/tests/test_ci_otel.py
+++ b/buildkite/tests/test_ci_otel.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import base64
 import binascii
 import json
 import os
@@ -228,6 +229,28 @@ def test_oidc_token_requires_job_credentials(monkeypatch):
         assert str(error) == "Buildkite job credentials are unavailable"
     else:
         raise AssertionError("missing job credentials should be reported")
+
+
+def test_safe_oidc_claims_reports_identity_without_token():
+    payload = {
+        "iss": "https://agent.buildkite.com",
+        "aud": "https://ci.vllm.ai/api/otel",
+        "organization_slug": "vllm",
+        "pipeline_slug": "ci",
+        "build_branch": "khluu/otel",
+        "build_number": 42,
+        "job_id": "job-id",
+        "private": "must-not-be-logged",
+    }
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=")
+    token = f"header.{encoded.decode()}.signature"
+
+    claims = ci_otel._safe_oidc_claims(token)
+
+    assert '"build_branch":"khluu/otel"' in claims
+    assert '"build_source":null' in claims
+    assert "must-not-be-logged" not in claims
+    assert token not in claims
 
 
 def test_invalid_upload_timeout_cannot_break_plugin_import():


### PR DESCRIPTION
## What changed

- restore centrally generated command and per-test timing spans for trusted vLLM CI jobs
- replace global `PYTEST_ADDOPTS` and helper `PYTHONPATH` injection with a validated, fail-open `pytest` shim
- preserve the original command exit status even when tracing setup, plugin validation, token minting, or upload fails
- mint a five-minute Buildkite job OIDC token directly through the Agent API; no ingest key is distributed to test jobs
- gate non-main treatment to an exact API-triggered branch via `CI_INFRA_OTEL_TREATMENT_BRANCH`
- report only selected non-secret identity claims when the receiver rejects a token

## Root cause fixed

The first rollout in #472 globally set `PYTEST_ADDOPTS=-p ci_pytest_otel` and exposed the plugin through `PYTHONPATH`. vLLM build #84189 then ran:

```sh
PYTHONPATH=/vllm-workspace pytest -v -s entrypoints/serve/dev/rpc
```

That command replaced the helper path but retained the mandatory plugin option, so pytest failed before collecting tests with `No module named ci_pytest_otel`. #476 rolled the rollout back.

The replacement shim validates the plugin in the command effective environment, adds the helper path only to the traced pytest process, and delegates to the original pytest unchanged if validation fails. It never sets global pytest options.

The standard `buildkite-agent oidc request-token` command also tries to register the minted token with the host Job API redactor, whose socket is not available inside these Docker jobs. The helper calls the documented Agent API job OIDC endpoint directly and keeps the token only in memory.

## Validation

- `uv run --project buildkite/pipeline_generator --with pytest pytest -q buildkite/tests` — 108 passed
- shell syntax checks and `git diff --check` pass
- exact command-level `PYTHONPATH` override regression passes and emits a `pytest.test` span
- missing-plugin regression runs the original pytest successfully
- setup and upload failures remain warnings and preserve the test exit status
- [vLLM treatment #84269](https://buildkite.com/vllm/ci/builds/84269) on `khluu/otel` passed: target GPU job exit 0 in 3m33.664s
- production dashboard trace is complete with 20 spans: 4 commands and 6 individual pytest tests
- no tracing, plugin, OIDC, upload, or altered-exit warning appears in the successful target log

Dashboard receiver fixes: [vllm-dashboard #65](https://github.com/vllm-project/vllm-dashboard/pull/65) and [#66](https://github.com/vllm-project/vllm-dashboard/pull/66).