### PR TITLE
Allow AMD mirrors to declare their own display label

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -684,6 +684,7 @@ def convert_group_step_to_buildkite_step(
                     ),
                     timeout_in_minutes=amd.get("timeout_in_minutes"),
                     agent_tags=amd.get("agent_tags"),
+                    display_label=amd.get("label"),
                 )
                 if not _amd_mirror_should_run(
                     _step_should_run(
@@ -699,7 +700,9 @@ def convert_group_step_to_buildkite_step(
                         else "image-build-amd"
                     )
                     amd_block_step = _create_block_step(
-                        block=f"Run AMD: {step.label}",
+                        block=f"Run {amd_step.label}"
+                        if amd.get("label")
+                        else f"Run AMD: {step.label}",
                         key=f"block-amd-{step_key}",
                         command_step=amd_step,
                         depends_on=[mirror_build_dep],
@@ -822,6 +825,7 @@ def _create_amd_step(
     key: str,
     timeout_in_minutes: Optional[int] = None,
     agent_tags: Optional[Dict[str, str]] = None,
+    display_label: Optional[str] = None,
 ) -> BuildkiteCommandStep:
     """Create a Buildkite command step that runs through the AMD CI wrapper."""
     options = build_amd_step_options(
@@ -837,6 +841,8 @@ def _create_amd_step(
         num_nodes=num_nodes,
         agent_tags=agent_tags,
     )
+    if display_label:
+        options["label"] = display_label
     return BuildkiteCommandStep(
         **options,
         key=key,

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -548,3 +548,58 @@ def test_amd_mirror_without_timeout_uses_standard_timeout(fake_global_config):
     # An AMD mirror without its own timeout does not inherit the shorter main
     # timeout (AMD runs slower); it receives the standard AMD timeout.
     assert amd_command_step.timeout_in_minutes == 180
+
+
+@pytest.mark.parametrize(
+    "amd_label,expected_amd_label",
+    [
+        (None, "AMD: Mirrored label test (mi300_1)"),
+        (
+            ":amd: MI300 Attention Kernels",
+            ":amd: MI300 Attention Kernels",
+        ),
+    ],
+)
+def test_amd_mirror_label_override(fake_global_config, amd_label, expected_amd_label):
+    fake_global_config["list_file_diff"] = ["vllm/foo.py"]
+    amd_mirror = {
+        "device": "mi300_1",
+        "depends_on": ["image-build-amd"],
+    }
+    if amd_label is not None:
+        amd_mirror["label"] = amd_label
+    step = Step(
+        label="Mirrored label test",
+        group="Mirrors",
+        key="mirrored-label",
+        depends_on=["image-build"],
+        working_dir="/vllm-workspace/tests",
+        commands=["pytest tests/mirror.py"],
+        source_file_dependencies=["vllm/"],
+        device="h200_18gb",
+        mirror={"amd": amd_mirror},
+    )
+
+    group_steps = buildkite_step.convert_group_step_to_buildkite_step(
+        {
+            step.group: [step],
+        }
+    )
+    amd_group = next(
+        group for group in group_steps if group.group == "Hardware-AMD Tests"
+    )
+    amd_command_step = next(
+        s for s in amd_group.steps if isinstance(s, buildkite_step.BuildkiteCommandStep)
+    )
+    default_group = next(group for group in group_steps if group.group == "Mirrors")
+    default_command_step = next(
+        s
+        for s in default_group.steps
+        if isinstance(s, buildkite_step.BuildkiteCommandStep)
+    )
+
+    # A mirror-level label is used verbatim; without one the derived
+    # "AMD: <label> (<device>)" form is unchanged. The NVIDIA label is
+    # never affected either way.
+    assert amd_command_step.label == expected_amd_label
+    assert default_command_step.label == "Mirrored label test"


### PR DESCRIPTION
## Purpose

Enables the CI job-renaming convention (vendor icon + device first, e.g. `:nvidia: H200 Attention Kernels`) for the 58 vLLM jobs whose AMD mirror shares the source label. Today the mirror label is always derived as `AMD: <label> (<device>)`, so renaming the source to the NVIDIA-branded form would make the AMD job render as `AMD: :nvidia: H200 … (mi300_1)`.

## Change

`mirror.amd.label` (optional): when present, used **verbatim** as the mirror step's display label — e.g. `:amd: MI300 Attention Kernels` — and the manual-run block text follows it. When absent, behavior is byte-identical to today (`AMD: <label> (<device>)`). The NVIDIA step label is never affected. Keys, commands, gating, and dependencies are untouched — display only.

This keeps the naming itself fully manual: each mirrored job's AMD label is hand-written in the same vLLM YAML, no automation.

## Tests

Parametrized regression in `test_amd.py`: no `label` → derived form unchanged; with `label` → verbatim override; NVIDIA label unaffected in both. 27/27 AMD tests, 74/74 full generator suite.

## Notes

- Companion to the vLLM label-rename PR (which will depend on this) per the plan in the CI naming discussion.
- AI assistance was used for this change.