### PR TITLE
Scale gpu_4_queue from 1 to 64

### DIFF
--- a/terraform/aws/cloudformation_stack.tf
+++ b/terraform/aws/cloudformation_stack.tf
@@ -213,14 +213,16 @@ locals {
       BuildkiteAgentTokenParameterStorePath = data.aws_ssm_parameter.bk_agent_token_cluster_ci.name
       BuildkiteQueue                       = "gpu_4_queue"
       InstanceTypes                        = "g6.12xlarge" # 4 Nvidia L4 GPUs, 192GB memory
+      MinSize                              = 1
       MaxSize                              = 64
+      ScaleInIdlePeriod                    = 1200
       ECRAccessPolicy                      = "readonly"
       InstanceOperatingSystem              = "linux"
       OnDemandPercentage                   = 100
       ImageId                              = "ami-040f1b73b7a7c7453" # Custom AMI with Nvidia driver 570.133.20
       BootstrapScriptUrl                   = "https://vllm-ci.s3.us-west-2.amazonaws.com/bootstrap.sh"
-      # Recycle each GPU instance after a single job completes.
-      BuildkiteTerminateInstanceAfterJob   = true
+      # Keep agents between jobs; recycle only after 20 minutes idle.
+      BuildkiteTerminateInstanceAfterJob   = false
     }
   }
 


### PR DESCRIPTION
## Summary

- allow `gpu_4_queue` to scale from 1 to 64 instances
- terminate agents only after 20 minutes of idle time
- keep instances between jobs

## Why

The queue no longer needs a fixed warm floor of five. A one-instance minimum preserves baseline availability while the existing autoscaler can grow the same ASG to 64 for agent-ready demand. Idle agents self-terminate after 1200 seconds instead of being recycled after every job.

## Validation

- `terraform validate`
- targeted Terraform plan: 0 add, 1 change, 0 destroy
- live CloudFormation update reached `UPDATE_COMPLETE`
- post-apply targeted Terraform plan reported no changes
- live agent verified with `disconnect-after-idle-timeout=1200`, `disconnect-after-job=false`, `Restart=on-failure`, and the normal `ExecStopPost=/usr/local/bin/terminate-instance` hook