### PR TITLE
[CI] zstd-compress the CI test image to speed agent pulls

### DIFF
--- a/docker/ci.hcl
+++ b/docker/ci.hcl
@@ -145,7 +145,10 @@ target "test-ci" {
     IMAGE_TAG,
     IMAGE_TAG_LATEST,
   ])
-  output = ["type=registry"]
+  # zstd is faster to decompress than the default gzip (multi-threaded), which
+  # is the bottleneck when agents pull this ~30GB image. The cache exports above
+  # already use zstd; apply it to the pushed image too.
+  output = ["type=registry,compression=zstd,force-compression=true,oci-mediatypes=true"]
 }
 
 target "cache-warm" {


### PR DESCRIPTION
## Why
The `vllm-ci-test-repo` image (~30 GB, measured on h200-ci-1) is pulled on every test job. The pull is **decompress/extract-bound, not network** — a warm node re-downloads only the ~1.25 GB per-commit top, but that still takes 2-3 min because the default **gzip** layers decompress single-threaded.

## What (one CI-only change to the `test-ci` bake target — release image untouched)
zstd-compress the pushed image:
`output = ["type=registry,compression=zstd,force-compression=true,oci-mediatypes=true"]`

zstd decompresses much faster (multi-threaded) than gzip; `oci-mediatypes=true` makes the manifest advertise the spec-explicit `application/vnd.oci.image.layer.v1.tar+zstd`. The `cache-to` exports in this file already use `compression=zstd`; this just extends it to the image agents actually pull.

## Notes / validation
- CI-only: only the `test-ci` target changes; `cache-warm`/release/`openai` targets are untouched.
- Confirm build #84800 (fresh SHA so image-build doesn't skip) validates zstd push to ECR + the OCI media type; then smoke pull/run on L4 + H200 + B200 and a warm-pull decompress-delta measurement.
- Draft pending that live gate.
