### PR TITLE
[CI] Nice buildkitd below the buildkite-agent to avoid heartbeat starvation

### DIFF
--- a/packer/cpu/scripts/install-build-tools.sh
+++ b/packer/cpu/scripts/install-build-tools.sh
@@ -74,6 +74,16 @@ RestartSec=5
 # Prevent OOM killer from targeting buildkitd
 OOMScoreAdjust=-500
 
+# Yield CPU to the buildkite-agent under contention so its heartbeat is never
+# starved. Compressing the image on export (zstd) can saturate every vCPU for
+# minutes; if that starves the agent, Buildkite declares the job dead (~20 min)
+# while the export is still running. Weight-based, not a hard quota: costs
+# nothing on an idle box, and only gives the agent priority when buildkitd would
+# otherwise monopolize all cores. Agent runs in its own cgroup slice at the
+# default weight (100), so CPUWeight=25 gives it ~4:1 priority under contention.
+Nice=10
+CPUWeight=25
+
 # No timeout for long-running builds
 TimeoutStartSec=0
 TimeoutStopSec=300


### PR DESCRIPTION
## Problem

After #481 (zstd image compression), genuinely-cold postmerge `Build image` steps on the CPU build agents (`r6in.16xlarge`) intermittently die with `exit_status=-1` at ~20 min, with logs ending while registry cache export is still running (#84908 / #84913 / #84915).

**Leading hypothesis (not yet journal-confirmed — see merge gate below): CPU starvation, not a process/instance failure.** `force-compression=true` on the image output recompresses the whole layer set to zstd on export; on a cold cache that saturates all 64 vCPUs for minutes. `buildkitd.service` currently runs with no CPU priority bound, so it can monopolize the box and starve the `buildkite-agent`'s heartbeat. Buildkite then marks the agent `lost` (~16 min in, a uniform ~3.8–4.6 min after cache export begins) and finalizes the job via its grace period while the export is still progressing — one agent even reconnected ~13 min later. Retries pass because the cache is then already zstd and the export is short.

This is a strong timing fit for missed-heartbeat behavior, but it remains a hypothesis until the runtime evidence in the merge gate confirms it over a real agent restart.

## Fix

Add `Nice=10` and `CPUWeight=25` to `buildkitd.service`. Weight-based, not a hard quota:
- Zero cost on an idle/uncontended box (work-conserving).
- The `buildkite-agent` runs in its own cgroup slice at the default weight (100), so `CPUWeight=25` gives it ~4:1 priority only when buildkitd would otherwise take every core. Heartbeats need milliseconds of CPU — they just must not be starved for 20 straight minutes.

Preserves the zstd image output and its pull-time win (measured ~7× faster decode, ~10.8× faster cold download+decompress in a controlled A/B). The pinned Buildkite stack base (v6.21.0, AL2023) is cgroup-v2, so `CPUWeight` is effective. Rolls out on the next daily CPU AMI rebuild.

## Exposure

Transition-shaped: only genuinely-cold / expired-cache / new-base builds; main's cache is already converted, so warm builds pass. Not hard-blocking (retries pass).

## Test plan / merge gate

Merge is gated on evidence that distinguishes CPU starvation from a real agent restart — either retained host journals, or an instrumented cold repro on an **isolated candidate AMI** (one-off build-only pipeline; no SSM/launch-template/ASG changes) that captures, during saturated export:

- `/sys/fs/cgroup` type (confirm cgroup-v2)
- buildkitd's effective `Nice`, `CPUWeight`, `ControlGroup`, and resolved `cpu.weight`
- CPU utilization and PSI (pressure) on the box
- buildkite-agent heartbeat continuity while export remains CPU-saturated

Pass = with the weighting applied, the agent stays connected and the export completes (no `lost`/`-1`). Rollout after merge is the existing daily 11:00 UTC AMI rebuild; instances cycle via `TerminateInstanceAfterJob`.
