### PR TITLE
Revert "[CI] zstd-compress the CI test image (#481)" — regressing cold main image builds

### DIFF
--- a/docker/ci.hcl
+++ b/docker/ci.hcl
@@ -145,10 +145,7 @@ target "test-ci" {
     IMAGE_TAG,
     IMAGE_TAG_LATEST,
   ])
-  # zstd is faster to decompress than the default gzip (multi-threaded), which
-  # is the bottleneck when agents pull this ~30GB image. The cache exports above
-  # already use zstd; apply it to the pushed image too.
-  output = ["type=registry,compression=zstd,force-compression=true,oci-mediatypes=true"]
+  output = ["type=registry"]
 }
 
 target "cache-warm" {


### PR DESCRIPTION
Reverts #481 (zstd compression of the CI test image).

## Why

#481 turned out to regress `image-build` on cold-cache main/postmerge builds: the step intermittently dies at ~20 min with the buildkite-agent declared lost (`exit_status=-1`) during registry cache export, while the image itself finished. Investigation falsified the initial CPU-starvation theory (the box was ~92% idle at loss) and points to a network/connection-level failure during the mass parallel push of freshly-compressed layers, but the definitive mechanism is still blocked on AWS ENA/CloudWatch access we don't yet have.

Rather than keep main bleeding while that adjudication is stuck, this reverts to the known-good gzip output. Reverting removes `force-compression`, so cold builds no longer re-push the full layer set in parallel — which is the behavior that regressed.

## Scope

- One line in `docker/ci.hcl`: `test-ci` output back to `type=registry`.
- Does not touch #482 (buildkitd `Nice`/`CPUWeight`); that change is work-conserving, harmless, and not deployed (its rollout was parked), so it's left in place.

## Re-apply plan

zstd is a real ~7-10x pull-decode win and we want it back — but only once the parallel-push mechanism is confirmed (ENA counters or an in-band cold repro) and the targeted transport fix is in with a cold validation. Tracked in #proj-ci-infra.
