### PR TITLE
[CI] Bake ethtool + net-diag tools into the CPU build AMI

### DIFF
--- a/packer/cpu/scripts/install-build-tools.sh
+++ b/packer/cpu/scripts/install-build-tools.sh
@@ -12,6 +12,22 @@ set -eu -o pipefail
 echo "=== Installing BuildKit as standalone systemd service ==="
 
 # -----------------------------------------------------------------------------
+# Install network diagnostic tools
+# ethtool exposes the ENA driver's allowance counters
+# (bw_in/out, pps, conntrack, linklocal *_allowance_exceeded) that are otherwise
+# invisible. Their absence blocked root-causing a CI image-build network
+# incident, so bake them into the AMI. conntrack-tools and sysstat round out
+# on-box network/resource diagnosis.
+# -----------------------------------------------------------------------------
+echo "=== Installing network diagnostic tools (ethtool, conntrack-tools, sysstat) ==="
+if command -v dnf >/dev/null 2>&1; then
+  sudo dnf install -y ethtool conntrack-tools sysstat
+else
+  sudo yum install -y ethtool conntrack-tools sysstat
+fi
+ethtool --version
+
+# -----------------------------------------------------------------------------
 # Install BuildKit binary
 # Extract buildkitd from the official moby/buildkit image
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds `ethtool`, `conntrack-tools`, and `sysstat` to the CPU build AMI (`packer/cpu/scripts/install-build-tools.sh`).

## Why

While root-causing the cold `image-build` heartbeat-loss incident, the on-box sampler couldn't read the ENA driver's allowance counters (`bw_in/out`, `pps`, `conntrack`, `linklocal` `*_allowance_exceeded`) because **`ethtool` is absent from the AMI** — those counters are ethtool-only and are the single most direct signal for EC2 network-allowance throttling, which is the current leading mechanism. Baking the tools in means the next diagnostic run (and any future one) has the observability without a runtime install.

- `ethtool` — ENA allowance/queue counters (`ethtool -S ens5`)
- `conntrack-tools` — host conntrack visibility (`conntrack -S/-C`)
- `sysstat` — `sar`/`pidstat` for network + resource timelines

## Scope / risk

- Package install only; `dnf` with a `yum` fallback; `ethtool --version` verifies. Mirrors the #482-style single-purpose AMI-script change.
- **Rides the normal daily AMI rebuild — no expedite.** Independent of the zstd revert and unrelated to the mainline image path.

## Test plan

- `bash -n` + `git diff --check` clean.
- On the next AMI rebuild: confirm `ethtool -S ens5` lists the `*_allowance_exceeded` counters, `conntrack -S` and `sar` present. Cuong's take-6 runtime-install of ethtool is the interim path for the immediate diagnostic; this makes it permanent.
