### PR TITLE
[CI] Stop TPU agents from accepting jobs mid-provisioning

### DIFF
--- a/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
@@ -46,6 +46,18 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
     "startup-script" = <<-STARTUP_SCRIPT
       #!/bin/bash
 
+      # Keep the agent offline until provisioning finishes (unmasked at the
+      # end). This script re-runs on every boot and the unit is enabled from
+      # the previous run, so systemd starts the agent seconds into boot. A
+      # `stop` is not enough: it waits for an in-flight job rather than
+      # preventing it, and the agent's postinst restarts the unit on upgrade.
+      # Masking blocks both.
+      systemctl mask buildkite-agent 2>/dev/null || true
+      # Any job picked up since boot is running against a half-provisioned host.
+      timeout 30 systemctl stop buildkite-agent 2>/dev/null \
+        || systemctl kill -s SIGKILL buildkite-agent 2>/dev/null \
+        || true
+
       apt-get update
       apt-get install -y curl build-essential jq git python3 python3-pip
 
@@ -58,9 +70,6 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
       apt-get update
       apt-get install -y buildkite-agent
-     
-      # Force stop the buildkite-agent and start at the end to avoid race condition
-      sudo systemctl stop buildkite-agent
 
       # ==========================================
       # Setup In-Memory GitHub App Authentication
@@ -158,6 +167,11 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
 
       # Add to /etc/fstab using UUID
       disk_uuid=$(blkid -s UUID -o value /dev/nvme0n2)
+      # An empty UUID= produces an fstab line that can never mount.
+      if [ -z "$disk_uuid" ]; then
+        echo "FATAL: no UUID on /dev/nvme0n2; leaving the agent masked." >&2
+        exit 1
+      fi
       if ! grep -q "/mnt/disks/persist" /etc/fstab; then
        echo "UUID=$disk_uuid /mnt/disks/persist ext4 defaults,discard 0 2" | sudo tee -a /etc/fstab
       fi
@@ -166,6 +180,22 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       if ! mountpoint -q /mnt/disks/persist; then
         sudo mount /mnt/disks/persist
       fi
+
+      # CI jobs bind-mount /mnt/disks/persist unconditionally, so without it
+      # this host would just drain the queue into failures. Bail, agent masked.
+      if ! mountpoint -q /mnt/disks/persist; then
+        echo "FATAL: /mnt/disks/persist is not mounted; leaving the agent masked." >&2
+        exit 1
+      fi
+
+      # Backstop for the mask: hold the agent until the disk is mounted,
+      # however it comes to be started.
+      sudo mkdir -p /etc/systemd/system/buildkite-agent.service.d
+      cat <<'DROPIN' | sudo tee /etc/systemd/system/buildkite-agent.service.d/10-persist-disk.conf > /dev/null
+      [Unit]
+      RequiresMountsFor=/mnt/disks/persist
+      DROPIN
+      sudo systemctl daemon-reload
 
       jq ". + {\"data-root\": \"/mnt/disks/persist\"}" /etc/docker/daemon.json > /tmp/daemon.json.tmp && mv /tmp/daemon.json.tmp /etc/docker/daemon.json
       systemctl stop docker
@@ -207,6 +237,7 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       # Force rotate once
       sudo logrotate -f /etc/logrotate.conf
 
+      systemctl unmask buildkite-agent
       systemctl enable buildkite-agent
       systemctl start buildkite-agent
     STARTUP_SCRIPT

--- a/terraform/gcp_old/tpu-inference/modules/ci_v7x/startup-script.sh.tftpl
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v7x/startup-script.sh.tftpl
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# Keep the agent offline until provisioning finishes (unmasked at the end).
+# This script re-runs on every boot and the unit is enabled from the previous
+# run, so systemd starts the agent seconds into boot. A `stop` is not enough:
+# it waits for an in-flight job rather than preventing it, and the agent's
+# postinst restarts the unit on upgrade. Masking blocks both.
+systemctl mask buildkite-agent 2>/dev/null || true
+# Any job picked up since boot is running against a half-provisioned host.
+timeout 30 systemctl stop buildkite-agent 2>/dev/null \
+  || systemctl kill -s SIGKILL buildkite-agent 2>/dev/null \
+  || true
+
 apt-get update
 apt-get install -y curl build-essential jq git python3 python3-pip
 
@@ -12,9 +23,6 @@ curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC
 echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
 apt-get update
 apt-get install -y buildkite-agent
-
-# Force stop the buildkite-agent and start at the end to avoid race condition
-sudo systemctl stop buildkite-agent
 
 %{ if is_multi_host ~}
 # ==========================================
@@ -146,8 +154,20 @@ printf '#!/bin/bash\nexport HF_TOKEN=%q\nexport BUILDKITE_ANALYTICS_TOKEN=%q\n' 
 %{ if has_attached_disk ~}
 sudo mkdir -p /mnt/disks/persist
 
-DISK_NAME=$(lsblk -d -o NAME,SIZE -b | grep -i "${disk_size_bytes}" | awk '{print $1}')
-DISK_NAME=$${DISK_NAME:-nvme0n1}
+# Exclude the boot disk: the old `$${DISK_NAME:-nvme0n1}` fallback pointed
+# straight at it, putting the root filesystem's UUID in fstab.
+BOOT_DISK=$(lsblk -no PKNAME "$(findmnt -no SOURCE /)" 2>/dev/null | head -1)
+
+# Exact size match, then largest remaining non-boot disk.
+DISK_NAME=$(lsblk -dn -o NAME,SIZE -b | awk -v want="${disk_size_bytes}" -v boot="$BOOT_DISK" '$1 != boot && $2 == want { print $1; exit }')
+if [ -z "$DISK_NAME" ]; then
+  DISK_NAME=$(lsblk -dn -o NAME,SIZE -b | awk -v boot="$BOOT_DISK" '$1 != boot' | sort -k2 -n | tail -1 | awk '{print $1}')
+fi
+if [ -z "$DISK_NAME" ]; then
+  echo "FATAL: no attached data disk found; leaving the agent masked." >&2
+  lsblk -dn -o NAME,SIZE -b >&2
+  exit 1
+fi
 
 # Format if not already formatted
 if ! blkid /dev/$DISK_NAME; then
@@ -157,6 +177,11 @@ fi
 
 # Add to /etc/fstab using UUID
 disk_uuid=$(blkid -s UUID -o value /dev/$DISK_NAME)
+# An empty UUID= produces an fstab line that can never mount.
+if [ -z "$disk_uuid" ]; then
+  echo "FATAL: no UUID on /dev/$DISK_NAME; leaving the agent masked." >&2
+  exit 1
+fi
 if ! grep -q "/mnt/disks/persist" /etc/fstab; then
   echo "UUID=$disk_uuid /mnt/disks/persist ext4 defaults,discard 0 2" | sudo tee -a /etc/fstab
 fi
@@ -165,6 +190,22 @@ fi
 if ! mountpoint -q /mnt/disks/persist; then
   sudo mount /mnt/disks/persist
 fi
+
+# CI jobs bind-mount /mnt/disks/persist unconditionally, so without it this
+# host would just drain the queue into failures. Bail with the agent masked.
+if ! mountpoint -q /mnt/disks/persist; then
+  echo "FATAL: /mnt/disks/persist is not mounted; leaving the agent masked." >&2
+  exit 1
+fi
+
+# Backstop for the mask: hold the agent until the disk is mounted, however it
+# comes to be started.
+sudo mkdir -p /etc/systemd/system/buildkite-agent.service.d
+cat <<'DROPIN' | sudo tee /etc/systemd/system/buildkite-agent.service.d/10-persist-disk.conf > /dev/null
+[Unit]
+RequiresMountsFor=/mnt/disks/persist
+DROPIN
+sudo systemctl daemon-reload
 
 jq ". + {\"data-root\": \"/mnt/disks/persist\"}" /etc/docker/daemon.json > /tmp/daemon.json.tmp && mv /tmp/daemon.json.tmp /etc/docker/daemon.json
 systemctl stop docker
@@ -210,10 +251,11 @@ sudo bash add-google-cloud-ops-agent-repo.sh --also-install
 # TPU Multi-host logic: Only start the agent on worker 0
 if [ "$WORKER_ID" == "0" ]; then
   echo "Host 0: Starting Buildkite Agent..."
+  systemctl unmask buildkite-agent
   systemctl enable buildkite-agent
   systemctl start buildkite-agent
 else
   echo "Host $WORKER_ID: Dependencies installed, skipping Agent startup."
   systemctl disable buildkite-agent
-  systemctl stop buildkite-agent
+  # Left masked on purpose: non-zero workers must never join the queue.
 fi


### PR DESCRIPTION
## Problem

On `tpu7x-8-ci-3` ([build 3470](https://buildkite.com/tpu-commons/vllm-torchtpu-ci/builds/3470)), a freshly-booted v7x-8 agent failed four jobs in 60 seconds with:

```
mkdir: cannot create directory '/mnt/disks/persist': Permission denied
```

The agent registered with Buildkite ~1s into boot and started taking jobs long before the startup script mounted the data disk:

| time (UTC, 2026-08-21) | event |
|---|---|
| 05:07:40.600 | agent `01a022b7` (v3.135.0) registers — systemd at boot, script is ~line 5 |
| 05:07:41 / :45 / :47 | jobs 1–3 → all failed |
| 05:08:41.573 | agent `01a022b8` (**v3.137.0**) registers — the apt upgrade's restart, blocked on job 3, lands 0.3s after it ends |
| 05:08:42.742 | job 4 → failed |
| 05:09:35.088 | agent `01a022b9` registers — the script's own `systemctl start` |
| 05:09:36.347 | job 5 → **passed** |

`tpu7x-8-ci-8` did the same to 5 jobs across builds 3471–3472 that morning.

## Why the existing `systemctl stop` didn't help

Three independent reasons:

1. **Too late.** The script re-runs on every boot and the unit is `enable`d from the previous run, so systemd starts the agent seconds into boot — the stop doesn't run until after `cargo install minijinja-cli`.
2. **`stop` is graceful.** With `TimeoutStopSec=0` the agent finishes its current job on SIGTERM, so the stop *waits for* a bad job instead of preventing it.
3. **The apt install restarts the unit** right before the stop. The 3.135.0 → 3.137.0 bump across the boundary above is the proof.

## Fix

**Mask the unit at the top of the script, before any apt work; unmask once provisioning completes.** systemd won't start a masked unit at boot, and the postinst restart becomes a no-op.

Masking a not-yet-installed unit is the one risky case, so I checked the package's actual `postinst` (fpm-generated, not `dh_installsystemd`): the fresh-install path never starts the service (it only prints the command for the operator), and the upgrade path restarts only `if systemctl is-active`, which a masked unit isn't. Both paths `exit 0` with no `set -e`, so this can't leave dpkg half-configured.

Plus, fail closed on the disk rather than let a broken host drain the queue at ~2s/job:

- **Never fall back to `nvme0n1`** — that's the boot disk, and its UUID in fstab mounts `/` over `/mnt/disks/persist`. Now matches on exact size excluding the boot disk, then largest non-boot disk, else fatal.
- **Refuse to write an empty `UUID=`** fstab line, which can never mount.
- **Exit before unmasking** if `/mnt/disks/persist` isn't mounted.
- **`RequiresMountsFor=/mnt/disks/persist` drop-in** as a backstop, so systemd holds the agent until the disk is up however it's started.

## Diskless hosts (v7x-16) are unaffected

The drop-in is written only inside the `has_attached_disk` branch, so v7x-16 never gets it — the rendered script has zero `/mnt/disks` references. Non-zero multi-host workers are now left *masked* rather than merely `disable`d.

## Scope

`ci_v7x` (16× v7x-8, 12× v7x-2, 3× v7x-16, + test pool) and `ci_v6e` (39 instances) — the two live TPU modules. `ci_v5` and `ci_v6` have the same race but aren't instantiated anywhere and don't currently parse as HCL, so they're left for a separate change.

## Verification

`terraform fmt -check` clean. Rendered the v7x template for both `disk_size=4096` and `disk_size=0, is_multi_host=true`, and de-indented the v6e heredoc the way HCL does — all pass `bash -n`. Unit-tested the disk-selection `awk` against synthetic `lsblk` output (exact match, size-mismatch fallback, boot-disk-only → correctly fatal); it never returns the boot disk. **Not yet run on a live host.**

## Rollout

`metadata.startup-script` updates **in place** — `terraform apply` alone changes nothing on a running host, since the startup script only executes at boot. The fix goes live only when a VM is rebooted or recreated.

Rolling out v6e with `scripts/rolling_restart.py` (batched `-replace`), canarying one v6e-1 and one v6e-8 before the rest. Note the fail-closed behavior means a bad provision leaves a host masked and off the queue rather than failing jobs — deliberate, but it needs watching during rollout.

## Follow-ups not in this PR

- `ci_cpu` / `ci_cpu_64_core` have the same race (no `/mnt/disks` dependency, so a different symptom; no evidence of failures there).
- `modules/benchmark` mounts `/dev/sdb` with no fstab entry and no stop at all.
- `ci_v5` re-runs `mkfs.ext4 /dev/sdb` on every boot, wiping the disk each reboot.
- A host that bails on a disk error goes dark with no signal — `ci_monitoring` alerting on agents-per-queue would catch it.
