### PR TITLE
tpu-inference: vllm-org CPU fleets, agent watchdog, name SSOT

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -3,6 +3,11 @@ data "google_secret_manager_secret_version" "buildkite_agent_token_ci_cluster" {
   version = "latest"
 }
 
+data "google_secret_manager_secret_version" "buildkite_agent_token_vllm" {
+  secret  = "projects/${var.secret_project_id}/secrets/vllm_buildkite_agent_token"
+  version = "latest"
+}
+
 data "google_secret_manager_secret_version" "buildkite_analytics_token_ci_cluster" {
   secret  = "projects/${var.secret_project_id}/secrets/tpu_commons_buildkite_analytics_token"
   version = "latest"
@@ -104,15 +109,16 @@ module "ci_v7x_16" {
   # disk_size defaults to 0, disable attached disk
 }
 
-module "ci_cpu_64_core" {
+# The whole tpu-commons 64-core fleet.
+module "ci_cpu_64_core_zone_c" {
   source = "../modules/ci_cpu_64_core"
   providers = {
-    google-beta = google-beta.us-central1-b
+    google-beta = google-beta.us-central1-c
   }
-
+  resource_suffix      = "-zone-c"
   project_id           = var.project_id
-  instance_count       = 4
-  machine_type         = "n2-standard-64"
+  instance_count       = 8
+  machine_type         = "n2d-standard-64"
   disk_size            = 250
   disk_type            = "pd-balanced"
   buildkite_queue_name = "cpu_64_core"
@@ -121,20 +127,54 @@ module "ci_cpu_64_core" {
   huggingface_token_value = data.google_secret_manager_secret_version.huggingface_token.secret_data
 }
 
-module "ci_cpu_64_core_zone_c" {
+# CPU fleets registered against the vllm org's TPU cluster. Additive: the
+# tpu-commons fleet above (and module.ci_cpu in cloud-tpu-inference-test) keeps
+# running until traffic is cut over. purpose = "vllm" switches these onto the
+# self-describing naming scheme: vllm-ci-<kind>-vllm-<zone>-<index>, shared by
+# the VM, its disk, its address, and the Buildkite agent.
+module "ci_cpu_vllm_zone_b" {
+  source = "../modules/ci_cpu"
+  providers = {
+    google-beta = google-beta.us-central1-b
+  }
+  purpose                 = "vllm"
+  project_id              = var.project_id
+  instance_count          = 8
+  buildkite_token_value   = data.google_secret_manager_secret_version.buildkite_agent_token_vllm.secret_data
+  huggingface_token_value = data.google_secret_manager_secret_version.huggingface_token.secret_data
+}
+
+module "ci_cpu_64_core_vllm_zone_b" {
   source = "../modules/ci_cpu_64_core"
   providers = {
-    google-beta = google-beta.us-central1-c
+    google-beta = google-beta.us-central1-b
   }
-  resource_suffix      = "-zone-c"
+  purpose              = "vllm"
   project_id           = var.project_id
   instance_count       = 4
-  machine_type         = "n2-standard-64"
+  machine_type         = "n2d-standard-64"
   disk_size            = 250
   disk_type            = "pd-balanced"
   buildkite_queue_name = "cpu_64_core"
 
-  buildkite_token_value   = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
+  buildkite_token_value   = data.google_secret_manager_secret_version.buildkite_agent_token_vllm.secret_data
+  huggingface_token_value = data.google_secret_manager_secret_version.huggingface_token.secret_data
+}
+
+module "ci_cpu_64_core_vllm_zone_f" {
+  source = "../modules/ci_cpu_64_core"
+  providers = {
+    google-beta = google-beta.us-central1-f
+  }
+  purpose              = "vllm"
+  project_id           = var.project_id
+  instance_count       = 4
+  machine_type         = "n2d-standard-64"
+  disk_size            = 250
+  disk_type            = "pd-balanced"
+  buildkite_queue_name = "cpu_64_core"
+
+  buildkite_token_value   = data.google_secret_manager_secret_version.buildkite_agent_token_vllm.secret_data
   huggingface_token_value = data.google_secret_manager_secret_version.huggingface_token.secret_data
 }
 

--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/providers.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/providers.tf
@@ -12,6 +12,13 @@ provider "google-beta" {
   alias   = "us-central1-c"
 }
 
+provider "google-beta" {
+  project = var.project_id
+  region  = "us-central1"
+  zone    = "us-central1-f"
+  alias   = "us-central1-f"
+}
+
 terraform {
   backend "gcs" {
     bucket = "tpu_commons_ci-infra_tf"

--- a/terraform/gcp_old/tpu-inference/modules/ci_cpu/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cpu/main.tf
@@ -7,14 +7,28 @@ data "google_client_config" "gcp_client" {
   provider = google-beta
 }
 
+locals {
+  # The zone comes from the provider, not the caller, so a fleet cannot be
+  # mislabelled by passing the wrong suffix.
+  zone = data.google_client_config.gcp_client.zone
+
+  # One name for the VM, its disk, its address, and the Buildkite agent, so a
+  # queue entry in the Buildkite UI maps straight onto a GCE instance.
+  # An empty purpose keeps the original names, so the tpu-commons fleet is not
+  # renamed and therefore not recreated.
+  node_names = [for i in range(var.instance_count) :
+    var.purpose == "" ? "vllm-ci-cpu-${i}" : "vllm-ci-cpu-${var.purpose}-${local.zone}-${i}"
+  ]
+}
+
 resource "google_compute_instance" "buildkite-agent-instance" {
   provider = google-beta
   count    = var.instance_count
-  name     = "vllm-ci-cpu-${count.index}"
+  name     = local.node_names[count.index]
 
   boot_disk {
     auto_delete = true
-    device_name = "vllm-ci-cpu-${count.index}"
+    device_name = local.node_names[count.index]
 
     initialize_params {
       image = "projects/ubuntu-os-cloud/global/images/ubuntu-2404-noble-amd64-v20251021"
@@ -65,7 +79,12 @@ resource "google_compute_instance" "buildkite-agent-instance" {
       echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
       apt-get update
       apt-get install -y bk buildkite-agent
-           
+      # No `set -e` in this script, so a failed install would otherwise sail on
+      # and the config writes below would create a cfg for a binary that isn't
+      # there, leaving a VM in the fleet running nothing while the startup
+      # script reports success.
+      dpkg -s buildkite-agent >/dev/null 2>&1 || { echo "FATAL: buildkite-agent not installed" >&2; exit 1; }
+
       # Force stop the buildkite-agent and start at the end to avoid race condition
       sudo systemctl stop buildkite-agent
 
@@ -132,22 +151,31 @@ resource "google_compute_instance" "buildkite-agent-instance" {
       sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
       sudo -u buildkite-agent gcloud auth configure-docker us-docker.pkg.dev --quiet
 
-      sudo sed -i "s/xxx/${var.buildkite_token_value}/g" /etc/buildkite-agent/buildkite-agent.cfg
-      sudo sed -i 's/name="%hostname-%spawn"/name="vllm-cpu-vm-${count.index}"/' /etc/buildkite-agent/buildkite-agent.cfg
+      # This script re-runs on every boot, so match the whole line rather than
+      # the pristine package default, which is gone after the first boot. The
+      # name below needs no such treatment: it is the instance name, which is
+      # ForceNew, so a rename recreates the VM and this sed always runs against
+      # a freshly installed cfg.
+      sudo sed -i -E 's|^token=.*|token="${var.buildkite_token_value}"|' /etc/buildkite-agent/buildkite-agent.cfg
+      sudo sed -i 's/name="%hostname-%spawn"/name="${local.node_names[count.index]}"/' /etc/buildkite-agent/buildkite-agent.cfg
+      sudo sed -i '/^tags=/d' /etc/buildkite-agent/buildkite-agent.cfg
       echo 'tags="queue=cpu"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
+      sudo sed -i '/^HF_TOKEN=/d' /etc/environment
       echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment
+
+      ${file("${path.module}/../shared/keep-agent-connected.sh")}
 
       systemctl stop docker
       systemctl start docker
 
       systemctl enable buildkite-agent
-      systemctl start buildkite-agent
+      systemctl restart buildkite-agent
     STARTUP_SCRIPT
   }
 }
 
 resource "google_compute_address" "static" {
   provider = google-beta
-  name     = "vllm-ci-cpu-${count.index}-ip"
+  name     = "${local.node_names[count.index]}-ip"
   count    = var.instance_count
 }

--- a/terraform/gcp_old/tpu-inference/modules/ci_cpu/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cpu/variables.tf
@@ -16,6 +16,19 @@ variable "huggingface_token_value" {
   type        = string
   description = "Hugging Face token for vLLM model serving usage."
 }
+
+variable "purpose" {
+  type        = string
+  description = <<-DESC
+    What this fleet is for, e.g. "vllm" for the fleet registered against the
+    vllm Buildkite org. When set, every name this module creates -- the VM, its
+    boot disk, the static address, and the Buildkite agent -- becomes
+    vllm-ci-cpu-<purpose>-<zone>-<index>. The zone is read from the provider, so
+    it is never passed in. Empty keeps the original unsuffixed names.
+  DESC
+  default     = ""
+}
+
 variable "github_app_secret_name" {
   type        = string
   description = "The Buildkite secret name for the GitHub App PEM key."

--- a/terraform/gcp_old/tpu-inference/modules/ci_cpu_64_core/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cpu_64_core/main.tf
@@ -2,14 +2,34 @@ data "google_client_config" "gcp_client" {
   provider = google-beta
 }
 
+locals {
+  # The zone comes from the provider, not the caller, so a fleet cannot be
+  # mislabelled by passing the wrong suffix.
+  zone = data.google_client_config.gcp_client.zone
+
+  # One name for the VM, its disk, its address, and the Buildkite agent, so a
+  # queue entry in the Buildkite UI maps straight onto a GCE instance.
+  # An empty purpose keeps the original names, so the tpu-commons fleet is not
+  # renamed and therefore not recreated.
+  node_names = [for i in range(var.instance_count) :
+    var.purpose == "" ? "vllm-ci-cpu-64-core-${i}" : "vllm-ci-cpu-64-core-${var.purpose}-${local.zone}-${i}"
+  ]
+
+  # Addresses are regional, so under the legacy naming they had to carry a zone
+  # suffix of their own. purpose puts the zone in the name, so it needs none.
+  address_names = [for i in range(var.instance_count) :
+    var.purpose == "" ? "vllm-ci-cpu-64-core${var.resource_suffix}-${i}-ip" : "${local.node_names[i]}-ip"
+  ]
+}
+
 resource "google_compute_instance" "buildkite-agent-instance" {
   provider = google-beta
   count    = var.instance_count
-  name     = "vllm-ci-cpu-64-core-${count.index}"
+  name     = local.node_names[count.index]
 
   boot_disk {
     auto_delete = true
-    device_name = "vllm-ci-cpu-64-core-${count.index}"
+    device_name = local.node_names[count.index]
 
     initialize_params {
       image = "projects/ubuntu-os-cloud/global/images/ubuntu-2404-noble-amd64-v20251021"
@@ -28,6 +48,11 @@ resource "google_compute_instance" "buildkite-agent-instance" {
   deletion_protection = false
   enable_display      = false
   machine_type        = var.machine_type
+
+  # Resizing a running instance is refused unless this is set. These are
+  # disposable CI agents, and a stop/start re-runs the startup script, which is
+  # now idempotent, so the agent comes back configured rather than duplicated.
+  allow_stopping_for_update = true
 
   network_interface {
     access_config {
@@ -61,7 +86,7 @@ resource "google_compute_instance" "buildkite-agent-instance" {
       echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | sudo tee /etc/apt/sources.list.d/buildkite-agent.list
       apt-get update
       apt-get install -y bk buildkite-agent
-           
+
       # Force stop the buildkite-agent and start at the end to avoid race condition
       sudo systemctl stop buildkite-agent
 
@@ -128,22 +153,31 @@ resource "google_compute_instance" "buildkite-agent-instance" {
       sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
       sudo -u buildkite-agent gcloud auth configure-docker us-docker.pkg.dev --quiet
 
-      sudo sed -i "s/xxx/${var.buildkite_token_value}/g" /etc/buildkite-agent/buildkite-agent.cfg
-      sudo sed -i 's/name="%hostname-%spawn"/name="vllm-cpu-64-core-vm-${count.index}"/' /etc/buildkite-agent/buildkite-agent.cfg
-      grep -q 'tags="queue=${var.buildkite_queue_name}"' /etc/buildkite-agent/buildkite-agent.cfg || echo 'tags="queue=${var.buildkite_queue_name}"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
-      grep -q "HF_TOKEN=" /etc/environment || echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment
+      # This script re-runs on every boot, so match the whole line rather than
+      # the pristine package default, which is gone after the first boot. The
+      # name below needs no such treatment: it is the instance name, which is
+      # ForceNew, so a rename recreates the VM and this sed always runs against
+      # a freshly installed cfg.
+      sudo sed -i -E 's|^token=.*|token="${var.buildkite_token_value}"|' /etc/buildkite-agent/buildkite-agent.cfg
+      sudo sed -i 's/name="%hostname-%spawn"/name="${local.node_names[count.index]}"/' /etc/buildkite-agent/buildkite-agent.cfg
+      sudo sed -i '/^tags=/d' /etc/buildkite-agent/buildkite-agent.cfg
+      echo 'tags="queue=${var.buildkite_queue_name}"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
+      sudo sed -i '/^HF_TOKEN=/d' /etc/environment
+      echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment
+
+      ${file("${path.module}/../shared/keep-agent-connected.sh")}
 
       systemctl stop docker
       systemctl start docker
 
       systemctl enable buildkite-agent
-      systemctl start buildkite-agent
+      systemctl restart buildkite-agent
     STARTUP_SCRIPT
   }
 }
 
 resource "google_compute_address" "static" {
   provider = google-beta
-  name     = "vllm-ci-cpu-64-core${var.resource_suffix}-${count.index}-ip"
+  name     = local.address_names[count.index]
   count    = var.instance_count
 }

--- a/terraform/gcp_old/tpu-inference/modules/ci_cpu_64_core/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cpu_64_core/variables.tf
@@ -45,7 +45,23 @@ variable "huggingface_token_value" {
 }
 
 variable "resource_suffix" {
-  description = "Suffix to append to resource names to avoid collisions across zones"
+  description = <<-DESC
+    Legacy: suffixes only the regional static address. Kept so the original
+    us-central1-c fleet holds its address names. Prefer purpose.
+  DESC
+  type        = string
+  default     = ""
+}
+
+variable "purpose" {
+  description = <<-DESC
+    What this fleet is for, e.g. "vllm" for the fleet registered against the
+    vllm Buildkite org. When set, every name this module creates -- the VM, its
+    boot disk, the static address, and the Buildkite agent -- becomes
+    vllm-ci-cpu-64-core-<purpose>-<zone>-<index>, and resource_suffix is
+    ignored. The zone is read from the provider, so it is never passed in.
+    Empty keeps the original unsuffixed names.
+  DESC
   type        = string
   default     = ""
 }

--- a/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
@@ -5,10 +5,19 @@ data "google_client_config" "config" {
   provider = google-beta
 }
 
+locals {
+  # The one place this name is spelled out. The TPU VM, its label, its disk, and
+  # the Buildkite agent inside it all derive from here, so an agent in the
+  # Buildkite UI always maps onto a `gcloud compute tpus` entry.
+  node_names = [for i in range(var.instance_count) :
+    "${var.accelerator_type}-ci-${i}-${var.project_short_name}-${data.google_client_config.config.zone}"
+  ]
+}
+
 resource "google_compute_disk" "tpu_disk" {
   provider = google-beta
   count    = var.instance_count
-  name     = "${var.accelerator_type}-ci-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}-disk"
+  name     = "${local.node_names[count.index]}-disk"
   size     = var.disk_size
   type     = "hyperdisk-balanced"
 }
@@ -16,13 +25,13 @@ resource "google_compute_disk" "tpu_disk" {
 resource "google_tpu_v2_vm" "tpu_v6_ci" {
   provider = google-beta
   count    = var.instance_count
-  name     = "${var.accelerator_type}-ci-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}"
+  name     = local.node_names[count.index]
 
   runtime_version  = "v2-alpha-tpuv6e"
   accelerator_type = var.accelerator_type
 
   labels = {
-    vm_name = "${var.accelerator_type}-ci-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}"
+    vm_name = local.node_names[count.index]
   }
 
   dynamic "scheduling_config" {
@@ -134,9 +143,11 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
       sudo -u buildkite-agent gcloud auth configure-docker us-docker.pkg.dev --quiet
 
-      sudo sed -i "s/xxx/${var.buildkite_token_value}/g" /etc/buildkite-agent/buildkite-agent.cfg
+      # This script re-runs on every boot, so match the whole line rather than
+      # the pristine "xxx" placeholder, which is gone after the first boot.
+      sudo sed -i -E 's|^token=.*|token="${var.buildkite_token_value}"|' /etc/buildkite-agent/buildkite-agent.cfg
       
-      HOST_NAME_VAL="${var.accelerator_type}-ci-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}"
+      HOST_NAME_VAL="${local.node_names[count.index]}"
       # Set the system-wide environment variable, avoid using the default HOSTNAME because it's too vague to be useful. For example, t1v-n-01667781-w-0
       echo "HOST_NAME=$HOST_NAME_VAL" | sudo tee -a /etc/environment
       sudo sed -i "s/name=\"%hostname-%spawn\"/name=\"$HOST_NAME_VAL\"/" /etc/buildkite-agent/buildkite-agent.cfg
@@ -236,6 +247,8 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       
       # Force rotate once
       sudo logrotate -f /etc/logrotate.conf
+
+      ${file("${path.module}/../shared/keep-agent-connected.sh")}
 
       systemctl unmask buildkite-agent
       systemctl enable buildkite-agent

--- a/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
@@ -15,8 +15,13 @@ locals {
   is_multi_host  = local.tpu_core_size > 8
 
   has_attached_disk = var.disk_size > 0
-  # Use "ci-bk" for multi-host to avoid naming conflicts with existing v7x TPU resources
-  ci_tmp = local.is_multi_host ? "ci-bk" : "ci"
+
+  # The one place this name is spelled out. The TPU VM, its label, its disk, and
+  # the Buildkite agent inside it all derive from here, so an agent in the
+  # Buildkite UI always maps onto a `gcloud compute tpus` entry.
+  node_names = [for i in range(var.instance_count) :
+    "${var.accelerator_type}-ci-${i}-${var.project_short_name}-${data.google_client_config.config.zone}"
+  ]
 }
 
 # Generate a SSH key pair for internal multi-host communication
@@ -29,7 +34,7 @@ resource "tls_private_key" "internal_ssh_key" {
 resource "google_compute_disk" "tpu_disk" {
   provider = google-beta
   count    = local.has_attached_disk ? var.instance_count : 0
-  name     = "${var.accelerator_type}-ci-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}-disk"
+  name     = "${local.node_names[count.index]}-disk"
   size     = var.disk_size
   type     = "hyperdisk-balanced"
 }
@@ -38,12 +43,12 @@ resource "google_tpu_v2_vm" "tpu_v7x_ci" {
   provider = google-beta
   count    = var.instance_count
 
-  name             = "${var.accelerator_type}-${local.ci_tmp}-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}"
+  name             = local.node_names[count.index]
   runtime_version  = "v2-alpha-tpu7-ubuntu2404"
   accelerator_type = var.accelerator_type
 
   labels = {
-    vm_name = "${var.accelerator_type}-${local.ci_tmp}-${count.index}-${var.project_short_name}-${data.google_client_config.config.zone}"
+    vm_name = local.node_names[count.index]
   }
 
   dynamic "scheduling_config" {
@@ -74,14 +79,12 @@ resource "google_tpu_v2_vm" "tpu_v7x_ci" {
       buildkite_queue_name            = var.buildkite_queue_name
       github_app_secret_name          = var.github_app_secret_name
       is_multi_host                   = local.is_multi_host
-      accelerator_type                = var.accelerator_type
-      project_short_name              = var.project_short_name
-      instance_index                  = count.index
-      zone                            = data.google_client_config.config.zone
+      host_name                       = local.node_names[count.index]
       private_key_pem                 = local.is_multi_host ? tls_private_key.internal_ssh_key[count.index].private_key_pem : ""
       public_key_openssh              = local.is_multi_host ? tls_private_key.internal_ssh_key[count.index].public_key_openssh : ""
       has_attached_disk               = local.has_attached_disk
       disk_size_bytes                 = var.disk_size * 1073741824
+      keep_agent_connected            = file("${path.module}/../shared/keep-agent-connected.sh")
     })
   }
 }

--- a/terraform/gcp_old/tpu-inference/modules/ci_v7x/startup-script.sh.tftpl
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v7x/startup-script.sh.tftpl
@@ -126,12 +126,14 @@ sudo usermod -a -G docker buildkite-agent
 sudo -u buildkite-agent gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 sudo -u buildkite-agent gcloud auth configure-docker us-docker.pkg.dev --quiet
 
-sudo sed -i "s/xxx/${buildkite_token_value}/g" /etc/buildkite-agent/buildkite-agent.cfg
+# This script re-runs on every boot, so match the whole line rather than the
+# pristine "xxx" placeholder, which is gone after the first boot.
+sudo sed -i -E 's|^token=.*|token="${buildkite_token_value}"|' /etc/buildkite-agent/buildkite-agent.cfg
 
 # Worker ID is provided by GCP metadata for Multi-host slices.
 WORKER_ID=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/agent-worker-number 2>/dev/null || echo "0")
 
-HOST_NAME_VAL="${accelerator_type}-ci-${instance_index}-${project_short_name}-${zone}"
+HOST_NAME_VAL="${host_name}"
 # Set the system-wide environment variable, avoid using the default HOSTNAME because it's too vague to be useful. For example, t1v-n-01667781-w-0
 echo "HOST_NAME=$HOST_NAME_VAL" | sudo tee -a /etc/environment
 sudo sed -i "s/name=\"%hostname-%spawn\"/name=\"$HOST_NAME_VAL\"/" /etc/buildkite-agent/buildkite-agent.cfg
@@ -248,6 +250,8 @@ echo "Installing GCP Ops Agent..."
 curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
 sudo bash add-google-cloud-ops-agent-repo.sh --also-install
 
+${keep_agent_connected}
+
 # TPU Multi-host logic: Only start the agent on worker 0
 if [ "$WORKER_ID" == "0" ]; then
   echo "Host 0: Starting Buildkite Agent..."
@@ -257,5 +261,6 @@ if [ "$WORKER_ID" == "0" ]; then
 else
   echo "Host $WORKER_ID: Dependencies installed, skipping Agent startup."
   systemctl disable buildkite-agent
-  # Left masked on purpose: non-zero workers must never join the queue.
+  # Left masked on purpose: non-zero workers must never join the queue. The
+  # watchdog installed above checks is-enabled, so it no-ops on this host.
 fi

--- a/terraform/gcp_old/tpu-inference/modules/shared/keep-agent-connected.sh
+++ b/terraform/gcp_old/tpu-inference/modules/shared/keep-agent-connected.sh
@@ -1,0 +1,74 @@
+# ==========================================
+# Keep the agent connected
+# ==========================================
+# Injected verbatim into agent startup scripts with file(). Kept in one place
+# because the startup scripts are already long and this logic has no reason to
+# differ between fleets.
+#
+# The packaged unit is Restart=on-failure, so it only recovers when the process
+# exits non-zero. A server-side deregistration makes the agent disconnect but
+# leave its process alive: systemd keeps reporting the unit active while the
+# queue quietly drains, and nothing alerts. Restart=always covers the
+# clean-exit case; the watchdog covers the wedged-but-alive case.
+#
+# Safe to run before the agent is unmasked -- the watchdog no-ops until the
+# unit is actually enabled.
+
+sudo sed -i '/^health-check-addr=/d' /etc/buildkite-agent/buildkite-agent.cfg
+echo 'health-check-addr="localhost:8123"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg > /dev/null
+
+sudo mkdir -p /etc/systemd/system/buildkite-agent.service.d
+cat <<'DROPIN' | sudo tee /etc/systemd/system/buildkite-agent.service.d/10-restart.conf > /dev/null
+[Service]
+Restart=always
+RestartSec=10
+DROPIN
+
+cat <<'WATCHDOG' | sudo tee /usr/local/bin/buildkite-agent-watchdog > /dev/null
+#!/bin/bash
+set -u
+
+# Multi-host TPU workers other than 0 leave the agent masked or disabled on
+# purpose so they never join the queue. Nothing to watch on those hosts.
+systemctl is-enabled --quiet buildkite-agent || exit 0
+
+# The health endpoint stops returning 200 once the agent is no longer pinging
+# Buildkite. It stays healthy while a job runs, so a miss means the agent is
+# wedged, not busy. Three in a row rules out a network blip.
+STATE=/run/buildkite-agent-watchdog.fails
+fails=$(cat "$STATE" 2>/dev/null || echo 0)
+if curl -fsS --max-time 10 http://localhost:8123/ >/dev/null 2>&1; then
+  echo 0 > "$STATE"
+  exit 0
+fi
+fails=$((fails + 1))
+echo "$fails" > "$STATE"
+if [ "$fails" -ge 3 ]; then
+  logger -t buildkite-agent-watchdog "health check failed $fails times, restarting agent"
+  echo 0 > "$STATE"
+  systemctl restart buildkite-agent
+fi
+WATCHDOG
+sudo chmod +x /usr/local/bin/buildkite-agent-watchdog
+
+cat <<'UNIT' | sudo tee /etc/systemd/system/buildkite-agent-watchdog.service > /dev/null
+[Unit]
+Description=Restart the Buildkite agent when it stops reporting healthy
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/buildkite-agent-watchdog
+UNIT
+
+cat <<'TIMER' | sudo tee /etc/systemd/system/buildkite-agent-watchdog.timer > /dev/null
+[Unit]
+Description=Periodic Buildkite agent health check
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=1min
+[Install]
+WantedBy=timers.target
+TIMER
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now buildkite-agent-watchdog.timer
+# ==========================================


### PR DESCRIPTION
Groundwork for moving `tpu-inference` CI from the `tpu-commons` Buildkite org to the `vllm` org, plus fixes for an agent outage found along the way.

## Add parallel CPU fleets for the vllm org

New `ci_cpu` and `ci_cpu_64_core` fleets registered against the vllm org's agent token. These are **additive** — the tpu-commons fleets keep serving CI until traffic is cut over.

A new `purpose` variable switches a fleet onto self-describing names (`vllm-ci-cpu-64-core-vllm-us-central1-b-0`) shared by the VM, its boot disk, its static address, and the Buildkite agent, so a queue entry in the Buildkite UI maps straight onto a GCE instance. Empty `purpose` keeps the original names, so no existing fleet is renamed — and therefore none is recreated.

They run `n2d-standard-64` rather than `n2-standard-64`: n2 is persistently stocked out in us-central1, and n2d is the same 64 vCPU / 256 GB shape on AMD, so jobs need no retuning and `pd-balanced` still works.

## Keep the agent connected

Seven of eight CPU agents were found disconnected, with no alert. The packaged unit is `Restart=on-failure`, so it only recovers when the process exits non-zero — a server-side deregistration leaves the process alive, and systemd keeps reporting the unit active while the queue quietly drains.

Adds `modules/shared/keep-agent-connected.sh`, injected with `file()` into all four agent fleets. It sets `Restart=always` and installs a systemd timer that restarts the agent after three consecutive failures of the agent's own health endpoint. The endpoint stays healthy *during* a job, so a miss means wedged, not busy. The watchdog checks `systemctl is-enabled` first, so it no-ops on multi-host TPU workers that deliberately never join the queue.

This already caught a real failure during testing: a VM whose `buildkite-agent` install had flaked logged `health check failed 3 times, restarting agent`.

## Make the startup scripts reboot-safe

These scripts re-run on every boot, but were written as if they ran once.

- `sed s/xxx/<token>/` matched a pristine package placeholder that is gone by the second boot, so a rotated or re-pointed token never landed on a rebooted VM. Now rewrites the whole `token=` line.
- `tags=` and `HF_TOKEN=` were appended unconditionally, accumulating one duplicate per boot — a sampled VM had **eleven** of each. Now deleted before being written.
- `ci_cpu` has no `set -e`, so a flaked `apt-get install buildkite-agent` left a VM with no agent while the startup script reported success. Now asserts the package is installed.
- `ci_cpu_64_core` gains `allow_stopping_for_update` so the provider can resize a running instance.

## One local per module for resource names

The v6e/v7x name was spelled out four times per module — disk, VM, label, and again inside the startup script — and the copies had drifted. Multi-host v7x named the VM `tpu7x-16-ci-bk-0-…` while the agent inside it registered as `tpu7x-16-ci-0-…`.

All four now derive from one `node_names` local, and the v7x template no longer rebuilds the name at all — it receives it as `host_name`, so it cannot drift again.

That drift came from `ci_tmp`, added to dodge a collision with pre-existing v7x resources. Nothing named `tpu7x-16-ci-*` remains in the project, and the `accelerator_type` prefix already namespaces fleets against each other, so it is removed.

## Applied and verified

Already applied to both roots.

- `cloud-ullm-inference-ci-cd`: `2 added, 54 changed, 2 destroyed` — clean.
- `cloud-tpu-inference-test`: partial, see below.

The two adds/destroys are the `tpu7x-16` VMs, replaced by the `ci-bk` → `ci` rename. Both came back `READY`, and both agents reconnected with names matching their VMs:

```
GCE:       tpu7x-16-ci-0-cicd-us-central1-c   tpu7x-16-ci-1-cicd-us-central1-c
Buildkite: tpu7x-16-ci-0-cicd-us-central1-c   tpu7x-16-ci-1-cicd-us-central1-c
```

Reboot-idempotency was verified on a real stop/start: the VM came back with exactly one each of `tags=`, `token=`, `health-check-addr=`, and `HF_TOKEN=`, `Restart=always` in effect, watchdog timer active, and the health endpoint returning 200. Both rendered startup scripts were extracted from the plan and checked with `bash -n`.

Everything else is metadata-only and therefore **inert until each VM reboots or is recreated** — no running agent was disturbed.

## Known blockers, pre-existing and unrelated

Two items in `cloud-tpu-inference-test` could not be applied. Both predate this PR:

- **10 creates fail** — `ci_v6e_1` hits `Insufficient capacity` for v6e in us-east5-a, and `ci_v6e_8`'s `tpu_disk[8]` hits `Quota 'HDB_TOTAL_GB' exceeded` in southamerica-west1 (limit 98956 GB).
- **8 `ci_v6e_8` metadata updates** are stuck behind that disk: targeting them individually still pulls `disk[8]` in as a dependency. They will land once the quota is raised.