### PR TITLE
[CI] Retire the tpu-commons half of CI monitoring

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -228,16 +228,12 @@ module "ci_monitoring" {
   project_id               = var.project_id
   bq_puller_pipeline_slugs = ["tpu-inference-ci", "vllm-torchtpu-ci"]
 
-  # Drop the tpu-commons entries once its agents are gone.
   buildkite_token_secret_ids = {
-    "tpu-commons" = "projects/${var.secret_project_id}/secrets/tpu_commons_buildkite_agent_token"
-    "vllm"        = "projects/${var.secret_project_id}/secrets/vllm_buildkite_agent_token"
+    "vllm" = "projects/${var.secret_project_id}/secrets/vllm_buildkite_agent_token"
   }
 
-  # vllm_buildkite_rest_api_token is the tpu-commons token despite its name.
   bq_puller_orgs = {
-    "tpu-commons" = "vllm_buildkite_rest_api_token"
-    "vllm"        = "vllm_org_buildkite_rest_api_token"
+    "vllm" = "vllm_org_buildkite_rest_api_token"
   }
 }
 


### PR DESCRIPTION
## ⚠️ Merge inside the cutover window, Friday 2026-09-04

**After steps 30–31** have rolled the fleets onto the vllm agent token. Merged early, this stops monitoring an org that still has all the builds.

## What

Phase 4, step 32. Drops the `tpu-commons` entry from the two maps that drive monitoring:

| | Effect |
|---|---|
| `buildkite_token_secret_ids` | stops the `bk-metrics-tpu-commons` exporter; `tpu_commons/*` metrics stop advancing |
| `bq_puller_orgs` | stops polling the old org; rows already in `step_execution_logs` keep their `org_slug` and stay queryable |

Both orgs have been live in Stackdriver and BigQuery since #495 and #497, so this only retires the old half — nothing starts here. The Ops View dashboard can be repointed from `tpu_commons/*` to `vllm/*` ahead of the window, and rollback needs no monitoring action.

## Plan against live state

`0 to add, 2 to change, 2 to destroy` — both functions in-place, both `tpu-commons` IAM bindings destroyed. No source rebuild.

The metrics VM change is metadata-only, so the retired exporter keeps running until the box next boots. Harmless, and no in-window step is needed for it.

## Risk

Low mechanically, but correct **only after** the fleets have moved. Rollback is revert and re-apply.