### PR TITLE
tpu-inference/k8s: attach to a dispatched workload without naming its cluster

### DIFF
--- a/terraform/gcp_old/tpu-inference/k8s/README.md
+++ b/terraform/gcp_old/tpu-inference/k8s/README.md
@@ -166,6 +166,102 @@ Expect LocalQueues matching the profile names, the JobSet CRD, and exactly one
 agent-stack pod - more than one means an older per-profile controller survived
 and will compete for jobs.
 
+### Attaching to a running workload
+
+MultiKueue decides which worker a job lands on, so the person who submitted it
+does not know where its pods are - and a worker's pods are invisible from the
+manager, since MultiKueue skips pod creation there. `scripts/mkexec.sh` closes
+that gap by asking the manager, which is the component that made the decision:
+
+```
+job name ──► Workload            (ownerReferences)
+         ──► worker cluster      (Workload .status.clusterName)
+         ──► ClusterProfile      (MultiKueueCluster .spec.clusterSource)
+         ──► Connect Gateway URL (ClusterProfile .status.accessProviders)
+```
+
+```bash
+scripts/mkexec.sh <job-name>                      # interactive shell
+scripts/mkexec.sh <job-name> -- cat /etc/hostname # one-shot command
+scripts/mkexec.sh <job-name> -i 2 -c main         # third pod of a JobSet
+```
+
+The caller names a job and the manager context; the worker is never typed. It
+is an ordinary CLI, so a workstation or a plain VM with `gcloud` configured
+works the same way - nothing about it needs to run inside a cluster. A
+throwaway kubeconfig is synthesized per invocation and the caller's own
+credentials are used, so no shared worker kubeconfig is distributed and the
+user's real kubeconfig is left untouched.
+
+`scripts/mkexec-demo-queues.yaml` and `scripts/mkexec-demo-job.yaml` exercise
+the whole path on a CPU-only queue that rides the same MultiKueue admission
+check, so the resolver can be demonstrated without spending TPU.
+
+#### Access required
+
+**The terraform in this directory does not provision human access to the
+workers.** It grants Connect Gateway only to the Kueue controller
+(`gatewayEditor`) and the launcher (`gatewayReader`). An operator needs both of
+the following before `mkexec.sh` can reach a pod, or it stops at a 403:
+
+1. **GCP IAM.** `exec` is a `create` on `pods/exec`, a write verb, so
+   `gatewayReader` is not sufficient:
+
+   | role | project |
+   |---|---|
+   | `roles/gkehub.gatewayEditor` | each worker project |
+   | `roles/gkehub.viewer` | the manager project, to resolve Fleet memberships |
+
+2. **Kubernetes RBAC on each worker.** Over Connect Gateway the subject is the
+   caller's identity, not a ServiceAccount, so bind a group rather than
+   maintaining a list of emails:
+
+   ```yaml
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRole
+   metadata:
+     name: tpu-workload-debugger
+   rules:
+     - apiGroups: [""]
+       resources: ["pods", "pods/log"]
+       verbs: ["get", "list", "watch"]
+     - apiGroups: [""]
+       resources: ["pods/exec"]
+       verbs: ["create"]
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRoleBinding
+   metadata:
+     name: tpu-workload-debugger
+   roleRef:
+     apiGroup: rbac.authorization.k8s.io
+     kind: ClusterRole
+     name: tpu-workload-debugger
+   subjects:
+     - kind: Group
+       name: tpu-ci-debuggers@your-domain.example
+       apiGroup: rbac.authorization.k8s.io
+   ```
+
+   This is deliberately not generated into `generated/`: who may exec into a
+   shared CI cluster is an access-control decision, not a topology one, and it
+   should not follow the same "regenerate and apply" path as the queues.
+
+On the manager the caller additionally needs read on `workloads`,
+`multikueueclusters` and `clusterprofiles` - the four lookups above.
+
+#### Holding a TPU for development
+
+A long-running job is a workable way to claim a chip and develop against it,
+but note that the v6e lanes in `prod.auto.tfvars` are sized `nominal == max`
+and sum to the whole 18-chip reservation. There is no slack, so a claim job on
+those queues takes chips straight out of CI. Before pointing this at v6e, give
+it a ClusterQueue in the same cohort with `nominalQuota: 0` - it can then only
+borrow what is idle, and `reclaimWithinCohort: Any` hands the chips back when
+CI needs them - and set `maximumExecutionTimeSeconds` so a session forgotten on
+a Friday releases itself. Preemption kills the pod and therefore the shell;
+that is the tradeoff for not reserving capacity.
+
 ---
 
 ## 4. Best Practices & Troubleshooting

--- a/terraform/gcp_old/tpu-inference/k8s/scripts/mkexec-demo-job.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/scripts/mkexec-demo-job.yaml
@@ -1,0 +1,38 @@
+# The demo workload. Submit to the MANAGER only - MultiKueue creates the copy
+# on whichever worker admits it, which is the whole point of the exercise.
+#
+#   kubectl --context=$MANAGER apply -f mkexec-demo-job.yaml
+#   ./mkexec.sh mkexec-demo -- sh -c 'cat /etc/hostname'
+#
+# The sleep is what makes it attachable: a job that exits immediately leaves no
+# Running pod to exec into. Thirty minutes is long enough to demonstrate and
+# short enough that a forgotten one clears itself.
+#
+# Note this is the same shape as a "claim a TPU and develop against it" job. On
+# a real TPU queue that pattern holds quota for as long as it runs, and the v6e
+# lanes in prod.auto.tfvars are sized nominal == max with no slack, so a claim
+# job takes chips directly from CI. Give such a job its own borrow-only queue
+# and an execution-time cap before pointing this pattern at v6e.
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mkexec-demo
+  namespace: buildkite
+  labels:
+    kueue.x-k8s.io/queue-name: demo-cpu
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: main
+        image: alpine:3.20
+        command: ["sh", "-c", "echo started on $(hostname); sleep 1800"]
+        resources:
+          requests:
+            cpu: "200m"
+            memory: 256Mi

--- a/terraform/gcp_old/tpu-inference/k8s/scripts/mkexec-demo-queues.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/scripts/mkexec-demo-queues.yaml
@@ -1,0 +1,61 @@
+# A CPU-only queue for exercising the mkexec.sh resolver path, with no TPU
+# required. It rides the SAME MultiKueue admission check as the v6e queues, so
+# a job submitted to the manager is dispatched to a worker exactly as a real
+# TPU job would be - which is the part being demonstrated.
+#
+# Applies to both clusters, with one difference: workers run plain Kueue and
+# must not carry the admission check, or the mirrored workload would try to
+# dispatch onward from the worker.
+#
+#   MANAGER=gke_cloud-ullm-inference-ci-cd_us-central1_tpu-ci-manager
+#   WORKER=connectgateway_cloud-ullm-inference-ci-cd_global_tpu-ci-southamerica-west1-a
+#
+#   kubectl --context=$MANAGER apply -f mkexec-demo-queues.yaml
+#   sed '/admissionChecksStrategy:/,+2d' mkexec-demo-queues.yaml \
+#     | kubectl --context=$WORKER apply -f -
+#
+# Then submit the job (manager only) and attach - see mkexec-demo-job.yaml.
+#
+# Teardown, after deleting the job on the manager so MultiKueue garbage-collects
+# the worker copy:
+#
+#   kubectl --context=$MANAGER delete -f mkexec-demo-queues.yaml
+#   sed '/admissionChecksStrategy:/,+2d' mkexec-demo-queues.yaml \
+#     | kubectl --context=$WORKER delete -f -
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: demo-cpu
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: demo-cpu
+spec:
+  # Manager only. The sed above strips these three lines for the worker copy.
+  admissionChecksStrategy:
+    admissionChecks:
+    - name: v6e-multikueue-dispatch
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: buildkite
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources: ["cpu", "memory"]
+    flavors:
+    - name: demo-cpu
+      resources:
+      - name: cpu
+        nominalQuota: "4"
+      - name: memory
+        nominalQuota: 8Gi
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: demo-cpu
+  namespace: buildkite
+spec:
+  clusterQueue: demo-cpu
+  stopPolicy: None

--- a/terraform/gcp_old/tpu-inference/k8s/scripts/mkexec.sh
+++ b/terraform/gcp_old/tpu-inference/k8s/scripts/mkexec.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+#
+# mkexec — attach to a pod for a job you submitted to the MultiKueue manager,
+# without knowing (or having pre-configured) the worker cluster that ran it.
+#
+# The user only ever names the manager. Everything else is discovered:
+#
+#   Job -> Workload            (manager: ownerReferences)
+#   Workload -> worker cluster (manager: .status.clusterName)
+#   worker -> ClusterProfile   (manager: MultiKueueCluster.spec.clusterSource)
+#   ClusterProfile -> endpoint (manager: .status.accessProviders[].cluster.server,
+#                               a Connect Gateway URL published by the GKE fleet)
+#
+# This is an ordinary CLI - kubectl, python3, and gcloud application-default
+# credentials. Nothing in it needs to run inside a cluster, so a workstation or
+# a plain VM with gcloud configured behaves identically.
+#
+# Auth is the caller's own credentials through gke-gcloud-auth-plugin against
+# the gateway URL: no shared worker kubeconfig is handed out, and what you may
+# do on the worker is whatever your own IAM and RBAC allow. Those grants are
+# NOT provisioned by this repo's terraform - see "Attaching to a running
+# workload" in ../README.md for what an operator has to be given first.
+#
+# Usage:
+#   mkexec.sh <job-name> [-n namespace] [-c container] [-i index] [-- cmd ...]
+#
+# Env:
+#   MK_MANAGER_CONTEXT  kubectl context for the manager cluster
+#   MK_NAMESPACE        default namespace (default: buildkite)
+
+set -euo pipefail
+
+MANAGER_CONTEXT="${MK_MANAGER_CONTEXT:-gke_cloud-ullm-inference-ci-cd_us-central1_tpu-ci-manager}"
+NAMESPACE="${MK_NAMESPACE:-buildkite}"
+CONTAINER=""
+POD_INDEX=0
+JOB=""
+CMD=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--namespace) NAMESPACE="$2"; shift 2 ;;
+    -c|--container) CONTAINER="$2"; shift 2 ;;
+    -i|--index)     POD_INDEX="$2"; shift 2 ;;
+    --context)      MANAGER_CONTEXT="$2"; shift 2 ;;
+    --)             shift; CMD=("$@"); break ;;
+    -h|--help)      sed -n '2,30p' "$0"; exit 0 ;;
+    -*)             echo "unknown flag: $1" >&2; exit 2 ;;
+    *)              JOB="$1"; shift ;;
+  esac
+done
+
+[[ -n "$JOB" ]] || { echo "usage: $(basename "$0") <job-name> [-n ns] [-c container] [-- cmd ...]" >&2; exit 2; }
+[[ ${#CMD[@]} -gt 0 ]] || CMD=(/bin/sh -c 'exec /bin/bash || exec /bin/sh')
+
+mgr() { kubectl --context="$MANAGER_CONTEXT" --request-timeout=30s "$@"; }
+note() { printf '\033[2m%s\033[0m\n' "$*" >&2; }
+
+# 1+2. Job -> Workload -> the worker cluster MultiKueue dispatched it to.
+#
+# Kueue names workloads unpredictably, so the Job is matched on ownership
+# rather than on a derived name. The winning cluster is read from the typed
+# .status.clusterName, which MultiKueue sets once and never changes; the
+# admission check message is only consulted as a fallback, because it is
+# human-readable prose that Kueue is free to reword between releases.
+note "resolving workload for job/$JOB in $NAMESPACE on $MANAGER_CONTEXT ..."
+set +e
+WORKER="$(mgr -n "$NAMESPACE" get workloads -o json | python3 -c '
+import json, re, sys
+
+job = sys.argv[1]
+wl = None
+for w in json.load(sys.stdin)["items"]:
+    for o in w["metadata"].get("ownerReferences", []):
+        if o["name"] == job and o["kind"] in ("Job", "JobSet", "RayJob", "MPIJob"):
+            wl = w
+            break
+    if wl:
+        break
+
+if wl is None:
+    sys.exit(2)
+
+status = wl.get("status", {})
+cluster = status.get("clusterName")
+if not cluster:
+    for check in status.get("admissionChecks", []):
+        m = re.search(r"\"([^\"]+)\"", check.get("message") or "")
+        if m:
+            cluster = m.group(1)
+            break
+
+if not cluster:
+    nominated = status.get("nominatedClusterNames") or []
+    if nominated:
+        print("  nominated, not yet admitted: " + ", ".join(nominated), file=sys.stderr)
+    for c in status.get("conditions", []):
+        print("  %s=%s: %s" % (c.get("type"), c.get("status"), c.get("message", "")),
+              file=sys.stderr)
+    sys.exit(3)
+
+print(cluster)
+' "$JOB")"
+rc=$?
+set -e
+case "$rc" in
+  0) ;;
+  2) echo "no Workload owned by '$JOB' in namespace $NAMESPACE on the manager." >&2; exit 1 ;;
+  3) echo "workload for '$JOB' is not dispatched to a worker yet (still queued?)." >&2; exit 1 ;;
+  *) echo "could not read workloads from the manager." >&2; exit 1 ;;
+esac
+note "dispatched to worker cluster: $WORKER"
+
+# 3+4. MultiKueueCluster -> ClusterProfile -> Connect Gateway endpoint.
+#      Several ClusterProfiles can share a name across namespaces; only the one
+#      reconciled by the fleet controller carries a populated status.
+PROFILE_REF="$(mgr get multikueuecluster "$WORKER" -o jsonpath='{.spec.clusterSource.clusterProfileRef.name}')"
+[[ -n "$PROFILE_REF" ]] || { echo "MultiKueueCluster/$WORKER has no clusterProfileRef" >&2; exit 1; }
+
+SERVER="$(mgr get clusterprofile -A -o json | python3 -c '
+import json, sys
+ref = sys.argv[1]
+for p in json.load(sys.stdin)["items"]:
+    if p["metadata"]["name"] != ref:
+        continue
+    for ap in (p.get("status") or {}).get("accessProviders", []):
+        server = (ap.get("cluster") or {}).get("server")
+        if server:
+            print(server); sys.exit(0)
+sys.exit(1)
+' "$PROFILE_REF")" || { echo "no access endpoint published for ClusterProfile/$PROFILE_REF" >&2; exit 1; }
+note "endpoint: $SERVER"
+
+# 5. Synthesize a throwaway kubeconfig for that endpoint, authenticated as the
+#    caller. Nothing is written to the user's real kubeconfig.
+KUBECONFIG_TMP="$(mktemp -t mkexec-kubeconfig)"
+trap 'rm -f "$KUBECONFIG_TMP"' EXIT
+cat >"$KUBECONFIG_TMP" <<EOF
+apiVersion: v1
+kind: Config
+current-context: worker
+clusters:
+- name: worker
+  cluster:
+    server: ${SERVER}
+users:
+- name: caller
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: gke-gcloud-auth-plugin
+      args: ["--use_application_default_credentials"]
+      provideClusterInfo: true
+      interactiveMode: IfAvailable
+contexts:
+- name: worker
+  context:
+    cluster: worker
+    user: caller
+    namespace: ${NAMESPACE}
+EOF
+
+wrk() { kubectl --kubeconfig="$KUBECONFIG_TMP" --request-timeout=30s "$@"; }
+
+# 6. Check the caller may actually exec before hunting for a pod, so the common
+#    failure - being able to resolve the cluster but not having been granted
+#    access to it - reports what is missing instead of a bare 403. Only an
+#    explicit "no" is fatal: if the check itself cannot run, fall through and
+#    let the real request produce the real error.
+if [[ "$(wrk auth can-i create pods/exec -n "$NAMESPACE" 2>/dev/null || true)" == "no" ]]; then
+  cat >&2 <<EOF
+$(gcloud config get-value account 2>/dev/null) cannot exec in $NAMESPACE on $WORKER.
+
+Reaching a worker pod needs two grants, neither of which this repo provisions:
+
+  1. GCP IAM. exec is a create on pods/exec, a write verb, so gatewayReader is
+     not enough:
+       roles/gkehub.gatewayEditor  on the worker project
+       roles/gkehub.viewer         on the manager project (to resolve memberships)
+
+  2. Kubernetes RBAC on the worker, binding your identity to pods, pods/log and
+     pods/exec. Over Connect Gateway the subject is your email, not a
+     ServiceAccount - see kueue/templates/launcher_rbac_worker.yaml.tpl for the
+     shape, and ../README.md for a ready-to-apply group binding.
+EOF
+  exit 1
+fi
+
+# 7. Find the pod on the worker. Plain Jobs and JobSets label their pods
+#    differently. Names are sorted rather than taken in list order, so -i is
+#    stable: a JobSet's pods carry their job and completion indices in the
+#    name, and index 0 is the slice's worker 0.
+POD=""
+for selector in "batch.kubernetes.io/job-name=$JOB" "jobset.sigs.k8s.io/jobset-name=$JOB"; do
+  POD="$(wrk -n "$NAMESPACE" get pods -l "$selector" \
+    --field-selector=status.phase=Running \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+    | sort | sed -n "$((POD_INDEX + 1))p")"
+  [[ -n "$POD" ]] && break
+done
+[[ -n "$POD" ]] || { echo "no Running pod for '$JOB' on $WORKER (still pending or already finished?)" >&2; exit 1; }
+
+note "exec into $WORKER/$NAMESPACE/$POD"
+exec_args=(-n "$NAMESPACE" exec -it "$POD")
+[[ -n "$CONTAINER" ]] && exec_args+=(-c "$CONTAINER")
+wrk "${exec_args[@]}" -- "${CMD[@]}"


### PR DESCRIPTION
MultiKueue decides which worker a job lands on, and a worker's pods are
invisible from the manager because MultiKueue skips pod creation there. So the
person who submitted a job has no way to reach it without first finding out
where it went and configuring credentials for that cluster.

mkexec.sh asks the manager instead, which is the component that made the
decision: Job -> Workload by ownership, Workload -> worker by
.status.clusterName, worker -> ClusterProfile, ClusterProfile -> the Connect
Gateway URL the fleet publishes. A throwaway kubeconfig is synthesized for that
endpoint and authenticated as the caller, so no shared worker kubeconfig is
distributed and the user's own kubeconfig is untouched. It is an ordinary CLI -
a workstation or a plain VM with gcloud works the same as anything in-cluster.

The winning cluster is read from the typed .status.clusterName, falling back to
parsing the admission check message only if that field is absent; the message
is human-readable prose Kueue may reword between releases.

Access is documented, not provisioned. exec is a create on pods/exec, so a
human needs gatewayEditor rather than the launcher's gatewayReader, plus an
RBAC binding on each worker. Who may exec into a shared CI cluster is an
access-control decision rather than a topology one, so it does not belong on
the generate-and-apply path that builds the queues.

The demo pair exercises the whole resolver on a CPU-only queue riding the same
MultiKueue admission check, so the path can be shown without spending TPU.