### PR TITLE
[CI] Reconcile the tpu-inference v6e config with the running fleet

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-tpu-inference-test/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-tpu-inference-test/main.tf
@@ -23,6 +23,16 @@ data "google_secret_manager_secret_version" "buildkite_analytics_token_ci_cluste
   version = "latest"
 }
 
+data "google_secret_manager_secret_version" "buildkite_agent_token_vllm" {
+  secret  = "projects/${var.project_id}/secrets/vllm_buildkite_agent_token"
+  version = "latest"
+}
+
+data "google_secret_manager_secret_version" "buildkite_analytics_token_vllm" {
+  secret  = "projects/${var.project_id}/secrets/vllm_buildkite_analytics_token"
+  version = "latest"
+}
+
 
 module "ci_v6e_1" {
   source = "../modules/ci_v6e"
@@ -32,7 +42,7 @@ module "ci_v6e_1" {
 
   accelerator_type                = "v6e-1"
   reserved                        = true
-  instance_count                  = 30
+  instance_count                  = 20
   disk_size                       = 1024
   buildkite_queue_name            = "tpu_v6e_queue"
   project_id                      = var.project_id
@@ -50,13 +60,53 @@ module "ci_v6e_8" {
 
   accelerator_type                = "v6e-8"
   reserved                        = true
-  instance_count                  = 9
+  instance_count                  = 6
   disk_size                       = 4096
   buildkite_queue_name            = "tpu_v6e_8_queue"
   project_id                      = var.project_id
   project_short_name              = var.project_short_name
   buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
   buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
+  huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
+}
+
+# v6e fleets registered against the vllm org's TPU cluster, running alongside the
+# tpu-commons fleets above until traffic is cut over.
+module "ci_v6e_1_vllm" {
+  source = "../modules/ci_v6e"
+  providers = {
+    google-beta = google-beta.us-east5-a
+  }
+
+  accelerator_type                = "v6e-1"
+  purpose                         = "vllm"
+  reserved                        = true
+  instance_count                  = 10
+  disk_size                       = 1024
+  buildkite_queue_name            = "tpu_v6e_queue"
+  project_id                      = var.project_id
+  project_short_name              = var.project_short_name
+  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_vllm.secret_data
+  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_vllm.secret_data
+  huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
+}
+
+module "ci_v6e_8_vllm" {
+  source = "../modules/ci_v6e"
+  providers = {
+    google-beta = google-beta.southamerica-west1-a
+  }
+
+  accelerator_type                = "v6e-8"
+  purpose                         = "vllm"
+  reserved                        = true
+  instance_count                  = 2
+  disk_size                       = 4096
+  buildkite_queue_name            = "tpu_v6e_8_queue"
+  project_id                      = var.project_id
+  project_short_name              = var.project_short_name
+  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_vllm.secret_data
+  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_vllm.secret_data
   huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
 }
 

--- a/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
@@ -8,9 +8,13 @@ data "google_client_config" "config" {
 locals {
   # The one place this name is spelled out. The TPU VM, its label, its disk, and
   # the Buildkite agent inside it all derive from here, so an agent in the
-  # Buildkite UI always maps onto a `gcloud compute tpus` entry.
+  # Buildkite UI always maps onto a `gcloud compute tpus` entry. An empty
+  # purpose reproduces the original name, so adding this knob does not rename
+  # -- and so does not recreate -- an existing fleet.
   node_names = [for i in range(var.instance_count) :
-    "${var.accelerator_type}-ci-${i}-${var.project_short_name}-${data.google_client_config.config.zone}"
+    var.purpose == "" ?
+    "${var.accelerator_type}-ci-${i}-${var.project_short_name}-${data.google_client_config.config.zone}" :
+    "${var.accelerator_type}-ci-${var.purpose}-${i}-${var.project_short_name}-${data.google_client_config.config.zone}"
   ]
 }
 

--- a/terraform/gcp_old/tpu-inference/modules/ci_v6e/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6e/variables.tf
@@ -14,6 +14,18 @@ variable "instance_count" {
   description = "Number of TPU instance"
 }
 
+variable "purpose" {
+  type        = string
+  description = <<-DESC
+    What this fleet is for. When set, every name this module creates -- the TPU
+    VM, its label, its disk, and the Buildkite agent -- becomes
+    <accelerator_type>-ci-<purpose>-<index>-<project_short_name>-<zone>. The
+    zone is read from the provider, so it is never passed in. Empty keeps the
+    original unsuffixed names.
+  DESC
+  default     = ""
+}
+
 variable "disk_size" {
   type        = number
   description = "The mount disk size"


### PR DESCRIPTION
`terraform plan` on `cloud-tpu-inference-test` came back dirty. The v6e fleets were split for the vllm-org migration and resized out of band, so `main` has been describing infrastructure that has not existed for a while.

This brings the config back in line with what is actually running. Nothing here changes any machine.

## What is running

| module | zone | type | count | org |
|---|---|---|---|---|
| `ci_v6e_1` | us-east5-a | v6e-1 | 20 (was 30) | tpu-commons |
| `ci_v6e_1_vllm` | us-east5-a | v6e-1 | 10 (new module) | vllm |
| `ci_v6e_8` | southamerica-west1-a | v6e-8 | 6 (was 9) | tpu-commons |
| `ci_v6e_8_vllm` | southamerica-west1-a | v6e-8 | 2 (new module) | vllm |

Verified against `gcloud compute tpus tpu-vm list` in both zones: exactly `v6e-1-ci-{0..19}`, `v6e-1-ci-vllm-{0..9}`, `v6e-8-ci-{0..5}` and `v6e-8-ci-vllm-{0..1}`, all READY.

The `9` that `main` declares for `ci_v6e_8` was never fully realised — index 8 has been un-createable in southamerica-west1-a on a hyperdisk-balanced quota shortfall.

## `purpose`

`modules/ci_v6e` gains the same `purpose` knob that `modules/ci_cpu` and `modules/ci_cpu_64_core` got in #486. It is what names the vllm-org nodes `v6e-1-ci-vllm-<i>-<project>-<zone>` instead of colliding with the tpu-commons fleet. An empty `purpose` reproduces the original name exactly, so the existing fleets are not renamed and therefore not recreated.

## Proof this is a no-op

```
$ terraform plan
...
No changes. Your infrastructure matches the configuration.
```

`terraform fmt -check` and `terraform validate` both clean.

## Not in this PR

The relocation of all four v6e fleets into `cloud-ullm-inference-ci-cd`/us-east5-a, which is gated on the reservation move. That is #487, stacked on this branch.