### PR TITLE
[CI] Add four tpu7x-2 CI hosts in cloud-ullm-inference-ci-cd

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -107,7 +107,7 @@ module "ci_v7x_2" {
 
   accelerator_type                = "tpu7x-2"
   reserved                        = true
-  instance_count                  = 12
+  instance_count                  = 16
   buildkite_queue_name            = "tpu_v7x_2_queue"
   disk_size                       = 2048
   project_id                      = var.project_id


### PR DESCRIPTION
Grows `tpu_v7x_2_queue` from 12 to 16 hosts in `cloud-ullm-inference-ci-cd` (`us-central1-c`).

| module | accelerator | before | after |
| --- | --- | --- | --- |
| `ci_v7x_2` | `tpu7x-2` | 12 | **16** |
| `ci_v7x_8` | `tpu7x-8` | 18 | 18 (unchanged) |

### Where the capacity came from

The zone's `tpu7x` reservation was pinned at **128/128 chips**, so there was no headroom. The first commit here paid for the new hosts by giving up one `tpu7x-8`; that trade turned out to be unnecessary.

`vllm-tpu-tpu7x-8-tune-0` was holding `reserved = true` on 4 chips:

- created **2026-04-16** by patrickji@google.com via Terraform (google-beta 7.16.0), from a local state
- tracked by **none** of the three state files in `tpu_commons_ci-infra_tf`, and no `tune` reference exists anywhere in this repo
- **no** Buildkite agent registered against it

It was deleted, freeing exactly the 4 chips four `tpu7x-2` need. The reservation lands back at 128/128 with the new hosts.

### Plan

`8 to add, 22 to change, 0 to destroy` — creates `tpu7x-2-ci-12..15-cicd-us-central1-c` plus their 2048 GiB hyperdisks. **No CI host is destroyed** and no existing VM is renamed or replaced.

The 22 in-place updates are all pre-existing drift, unrelated to this change: Terraform reverting `metadata.ssh-keys` entries injected out-of-band by `gcloud compute tpus tpu-vm ssh`. Harmless — gcloud re-injects on next SSH.
