### PR TITLE
terraform/aws: add gpu-ci-eks EKS cluster for GPU queue migration

### DIFF
--- a/infra-k8s/install-buildkite-k8s-eks.sh
+++ b/infra-k8s/install-buildkite-k8s-eks.sh
@@ -32,12 +32,17 @@ kubectl -n buildkite create serviceaccount buildkite-gpu-jobs \
 # which would masquerade as an autoscaling failure; 0 = unlimited (node group max
 # is the real cap). Do NOT set config.job-ttl: it hard-kills jobs at the TTL and
 # distributed L4 tests legitimately run 20-40min (learned the hard way, ci#86133).
+# pod-pending-timeout defaults to 10m, which fails jobs when AWS has no
+# g6.12xlarge capacity (pods pend on scale-up); 2h makes capacity shortages
+# queue like they do on the ASGs (ci#86253). The rollout-status deploy name is
+# the release name (agent-stack-k8s-l4), not -controller.
 helm upgrade --install agent-stack-k8s-l4 \
   oci://ghcr.io/buildkite/helm/agent-stack-k8s \
   --version "${CHART_VERSION}" \
   --namespace buildkite \
   --set agentToken="$BUILDKITE_AGENT_TOKEN" \
   --set-json 'config.tags=["queue=l4-k8s"]' \
-  --set config.max-in-flight=0
+  --set config.max-in-flight=0 \
+  --set config.pod-pending-timeout=2h
 
-kubectl -n buildkite rollout status deployment/agent-stack-k8s-l4-controller --timeout=120s
+kubectl -n buildkite rollout status deployment/agent-stack-k8s-l4 --timeout=120s

--- a/infra-k8s/install-buildkite-k8s-eks.sh
+++ b/infra-k8s/install-buildkite-k8s-eks.sh
@@ -30,14 +30,14 @@ kubectl -n buildkite create serviceaccount buildkite-gpu-jobs \
 # NOTE: config.tags is a LIST in the chart schema — --set config.tags="queue=x"
 # silently misconfigures; --set-json is required. max-in-flight defaults to 25,
 # which would masquerade as an autoscaling failure; 0 = unlimited (node group max
-# is the real cap).
+# is the real cap). Do NOT set config.job-ttl: it hard-kills jobs at the TTL and
+# distributed L4 tests legitimately run 20-40min (learned the hard way, ci#86133).
 helm upgrade --install agent-stack-k8s-l4 \
   oci://ghcr.io/buildkite/helm/agent-stack-k8s \
   --version "${CHART_VERSION}" \
   --namespace buildkite \
   --set agentToken="$BUILDKITE_AGENT_TOKEN" \
   --set-json 'config.tags=["queue=l4-k8s"]' \
-  --set config.max-in-flight=0 \
-  --set config.job-ttl=10m
+  --set config.max-in-flight=0
 
 kubectl -n buildkite rollout status deployment/agent-stack-k8s-l4-controller --timeout=120s

--- a/infra-k8s/install-buildkite-k8s-eks.sh
+++ b/infra-k8s/install-buildkite-k8s-eks.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Phase 2 of docs/gpu-queues-eks-migration.md: secrets + agent-stack-k8s controller
+# for the l4-k8s queue on the l4-ci EKS cluster.
+#
+#   BUILDKITE_AGENT_TOKEN=... HF_TOKEN=... BUILDKITE_ANALYTICS_TOKEN=... \
+#     bash infra-k8s/install-buildkite-k8s-eks.sh
+set -euo pipefail
+
+kubectl config current-context | grep l4-ci || { echo "wrong context (want l4-ci)"; exit 1; }
+
+: "${BUILDKITE_AGENT_TOKEN:?agent token for the ci Buildkite cluster}"
+: "${HF_TOKEN:?required}"
+: "${BUILDKITE_ANALYTICS_TOKEN:?required}"
+
+CHART_VERSION=0.44.0   # >=0.28 needs no GraphQL token/org; latest at time of writing 0.49.0
+
+kubectl create namespace buildkite --dry-run=client -o yaml | kubectl apply -f -
+
+# Secrets consumed by the Phase 4 pod template (k8s_plugin.py).
+kubectl -n buildkite create secret generic hf-token-secret \
+  --from-literal=token="$HF_TOKEN" --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n buildkite create secret generic buildkite-analytics-token \
+  --from-literal=token="$BUILDKITE_ANALYTICS_TOKEN" --dry-run=client -o yaml | kubectl apply -f -
+
+# Job pods' service account (plain SA: Phase 0 item 5 found the tests use no AWS
+# APIs; ECR pulls go through the node role).
+kubectl -n buildkite create serviceaccount buildkite-gpu-jobs \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# NOTE: config.tags is a LIST in the chart schema — --set config.tags="queue=x"
+# silently misconfigures; --set-json is required. max-in-flight defaults to 25,
+# which would masquerade as an autoscaling failure; 0 = unlimited (node group max
+# is the real cap).
+helm upgrade --install agent-stack-k8s-l4 \
+  oci://ghcr.io/buildkite/helm/agent-stack-k8s \
+  --version "${CHART_VERSION}" \
+  --namespace buildkite \
+  --set agentToken="$BUILDKITE_AGENT_TOKEN" \
+  --set-json 'config.tags=["queue=l4-k8s"]' \
+  --set config.max-in-flight=0 \
+  --set config.job-ttl=10m
+
+kubectl -n buildkite rollout status deployment/agent-stack-k8s-l4-controller --timeout=120s

--- a/terraform/aws/.terraform.lock.hcl
+++ b/terraform/aws/.terraform.lock.hcl
@@ -26,46 +26,129 @@ provider "registry.terraform.io/buildkite/buildkite" {
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.56.1"
-  constraints = ">= 5.0.0, ~> 5.0"
+  version     = "5.100.0"
+  constraints = ">= 4.33.0, >= 5.0.0, ~> 5.0, >= 5.40.0"
   hashes = [
-    "h1:3c0jJCaLRgXrOZoGMAOjH+omtHUo96AkukUF4/h9gaE=",
-    "h1:LRmSNnudFVTkMSnEXJSKCojpknVVYEnls2UTeoxCxtc=",
-    "zh:0fff674596251d3f46b5a9e242220871d6c634f7cf69f2741d1c3c8f4baa708c",
-    "zh:1495d0f71bbd849ad286e7afa9d531a45217e6af7e3d165a447809dab364bd9b",
-    "zh:3eab136bd5b6c58a99f5cb588220819c70061b48da98f2b40061ebabfcbe1957",
-    "zh:3faa780ae84db4751d32ce3e7c4797711c9b5c537b67884037f0951a2f93c1ee",
-    "zh:47455bd243986893cc79f3d884633961244faeeef678fd64a37fcc77f3dabe24",
-    "zh:4a26df74f018ea25f3b543e9bc9d5763c7adc0cec647fc1cb1acec47cc331953",
-    "zh:592cebca964f297f569dc86e99789bfcc301904a9c26cd7294dab99e106acf59",
-    "zh:75d5ed50f1f56c484f7fcb1bd1c4ad33e2679ed249cc8db05e561233f8f5781f",
-    "zh:7ec8cce722a91ba141a3b2db0e833acc3be91e4eec6abb41f012bc9d641ca24e",
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:cba68f518f794e695b0448be4ff90906a7817f65ca5e4d987720e37fbeea7c90",
-    "zh:e29712ab48d6527253ae4aef3851bd8e831b7b0bb57b5097bef16cbb69af6e85",
-    "zh:ef34bd8ff4e1fb8cc222b78217df917d4833361ea514465e7dae9122a7c7cf7a",
-    "zh:fece9ac372653ab3195630cc9d817ad0f81cce1d2880bec03ffc624591f3702b",
-    "zh:ffd1c3b3e4fa447dd2a78f6696d0dac969cb2996d640e3efbf2a96c49892d298",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.4.0"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:4fp7byXJGbOU8zqxFM4yYGHzf1kUH8ChT41KK4n9q98=",
+    "zh:1b0fe71b8e87a068f7cd9faaa733100ab72ab61ce812b8bd2b8e3e6ea3907b2d",
+    "zh:2aa9631ad64cfda1eb58f147619b631dadedfaf9453b422aa5ada2d3861183c1",
+    "zh:2c5f35463bdfb2f87d3576b81e62c30f8109e67bb6f21ffcbc46a855811455c0",
+    "zh:5970bcad151ea236bd262ada1a5a23bfbc1716f94a4e8b16ab2bcdda91d6a671",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79a0676909732b6ec0441a733af6383513cde3bd2cef5c1ad0a74131e1286a04",
+    "zh:818f16141481a1202b3977becd19a12d4d46cd2e3f5753f5d0d0049adacf8f8c",
+    "zh:948d98716831087e69eca99f91ed7964cc537f3aca279f7494645ee56c9dc4ec",
+    "zh:a75e78889565a51df3e8e3af207e36e5ddb25e47ce1780a784c82dc3c3109b67",
+    "zh:a9c6e455d52b1bba5272bd87a35cfabcfd6d903dcbe42e2de926228dbb1e39b2",
+    "zh:b846805d8c2f5d1d6c2ffeeaf32109d9af7db7fa3c56929bfc1dcfaadf9c8bd8",
+    "zh:c3e5279756b46c4f49a6f4c81347fbe2fffebb2bf18a5c24664830304a1f6a8e",
+    "zh:c8be7b31893163d0046b0137a6100533f07e8efd192a1903b6bb4c42be12dceb",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.3.1"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:m5FqidbIgh+E9OigiZh8/xbkvpUQFSj3hZo/jqNLCLQ=",
+    "zh:08c59776542ea16e5a8545752787b17ff412922182b4cfabe16139197be8ac44",
+    "zh:123109cc7e5ed6d515787fbc212f2a3fd5e75647bb24ab7c801ccd4d4ed42451",
+    "zh:14b3fa4372754b54844b41d5dbd4671a292d8d6828b90169061feb4d7b15dd05",
+    "zh:56a4daaa3212f57b764bf3d1f333141c6610c5f21abb240e0111221f7c7fa4d4",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7e888a026dbacd2474a42264227ae35f639780f0f0c613529d10a95cd61988b3",
+    "zh:85a53646267e87d600df7124e4767ffde9bba3b6356d45d961618bdd68131cc7",
+    "zh:8ffa0e9c7c39b2ab0905b472465d6e35ef0b776b3f6273bb34c150340b61bff1",
+    "zh:9846510a1841530d4403f4818e233f91e3b3bade7441047599fbf800742f65be",
+    "zh:afa98d44860875f037c6def0a7e6ff208e042712ba771f620482b143cd336891",
+    "zh:bdca130d9ef27488ae0b13bc8fd8019e8bbdd4f2ceff29da066bd333165d68c5",
+    "zh:cb3b94cbca88210dd0d1f11e2b8a89333f48c3857faf8f70f589072ce7c28610",
+    "zh:f0c0ba87925fe32f84b80f7513b1efb1b0866f51f899ba825e95ad59ff09b018",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.6.2"
+  version     = "3.9.0"
   constraints = "~> 3.3"
   hashes = [
-    "h1:VavG5unYCa3SYISMKF9pzc3718M0bhPlcbUZZGl7wuo=",
-    "h1:wmG0QFjQ2OfyPy6BB7mQ57WtoZZGGV07uAPQeDmIrAE=",
-    "zh:0ef01a4f81147b32c1bea3429974d4d104bbc4be2ba3cfa667031a8183ef88ec",
-    "zh:1bcd2d8161e89e39886119965ef0f37fcce2da9c1aca34263dd3002ba05fcb53",
-    "zh:37c75d15e9514556a5f4ed02e1548aaa95c0ecd6ff9af1119ac905144c70c114",
-    "zh:4210550a767226976bc7e57d988b9ce48f4411fa8a60cd74a6b246baf7589dad",
-    "zh:562007382520cd4baa7320f35e1370ffe84e46ed4e2071fdc7e4b1a9b1f8ae9b",
-    "zh:5efb9da90f665e43f22c2e13e0ce48e86cae2d960aaf1abf721b497f32025916",
-    "zh:6f71257a6b1218d02a573fc9bff0657410404fb2ef23bc66ae8cd968f98d5ff6",
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:9647e18f221380a85f2f0ab387c68fdafd58af6193a932417299cdcae4710150",
-    "zh:bb6297ce412c3c2fa9fec726114e5e0508dd2638cad6a0cb433194930c97a544",
-    "zh:f83e925ed73ff8a5ef6e3608ad9225baa5376446349572c2449c0c0b3cf184b7",
-    "zh:fbef0781cb64de76b1df1ca11078aecba7800d82fd4a956302734999cfd9a4af",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.14.1"
+  constraints = ">= 0.9.0"
+  hashes = [
+    "h1:r93SxP++6gUlwCHDQ5OkRmcU8B0yv6ZA9nF0Dh6NJmA=",
+    "zh:0837ca5b057e5cff94dff7de2fcccafb4abaa33c45de193fe2853e684818a267",
+    "zh:15a122f72d9e0f34fc5384cc7ec089319641fee5c319748a3aa02fc42f459969",
+    "zh:342fb83093a280ea7ee0654feae1f5867c62eb8eebc1ab46f9a7ab0b4c878a62",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:99f169834d3370b8341381c6a9c7a8b01fb26027531faa38e6fb49cc23916f68",
+    "zh:9f482917c7a28cf2436578be7aa9f04f8c811aba8b5949e0223ea987a2757a91",
+    "zh:ac6b5b8732826f2d1129a8a4a038ac7a7a9ca7b77d2a4608e5703be1a1e2bff0",
+    "zh:c54782a27d58ce04f6696c6fc0b2cf1e2fba6bed239fb520521a7bce7d7193cb",
+    "zh:c8d0ddc8f575ecb44f025d54edbfe118e26397fe328a67be62325766f31eb6e7",
+    "zh:d043b96f204edd2353bf6b2a34e645ffdee2e9634d9bb747331320444810a538",
+    "zh:e32c288501ca9a6c9d22b52e839dd391fc7083d54ee6b8dc296ce0e6bd3e57ef",
+    "zh:e47fcc7bb4e9ab5cc522c3b06e4fa9c0bf94b84be8210bc6b1655c44acb2addc",
+    "zh:f61bf218322bcbe0bd2d56bba738e7fa485e9b54244e13aa12de741b37d450c0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.3.0"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
+    "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
+    "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",
+    "zh:6889be32640349230de3f23856e6f04e0e9ced4a84a27d3f552fa54684448218",
+    "zh:73f8e1ecf7135033165fb14b7e8bf4d656f3ce13065ec35762ea0481975328c7",
+    "zh:94ce25ee253eca0b42cae9c856b36bca8103b6453012d1b279c3623c805f2d42",
+    "zh:96bc6de9fd67bc446fd11257872e1ffb1029a996ed1d65a3f6b43f6d408ad9ab",
+    "zh:97c609a310a51bfd504d704e036d72064a84bf0bdb36cc08cd4cc66098212b41",
+    "zh:a12c16e94533c5bd123f75032576b9dc91dd5d5ccd5f7cf331d0f2e1adc55cf8",
+    "zh:c4f014f876adf7af57188795050bda5b0029d8c7d7773031102b6c36dcf1fc21",
+    "zh:d9b0a21583aaa3df3a95394fb949a3c515ff71c2ff5a1fc4a73d364aa90bfca5",
+    "zh:da510d22f0c6d71ad19a76406f106b782448f512375787ecfabb338ed1e311a7",
+    "zh:f0e9447a9ce3a24cdaa113089e65663c836d8b9bfdb915a1c0284e0112cab5c0",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/terraform/aws/eks.tf
+++ b/terraform/aws/eks.tf
@@ -17,6 +17,13 @@
 # terraform aws provider support for kube_scheduler_config did not exist at
 # that time ("planned" per AWS), so this is NOT in code: fold it in when the
 # provider lands, and re-apply after any cluster recreate.
+#
+# OUT-OF-BAND CONFIG WARNING 2 (2026-08-30): the l4x4 node group's ASG was set
+# to AvailabilityZoneDistribution=balanced-only via update-auto-scaling-group.
+# EKS managed node groups default to balanced-best-effort, which terminates
+# instances for AZ rebalancing WITHOUT draining pods (kills CI jobs mid-run;
+# safe-to-evict only governs cluster-autoscaler, not the ASG). Re-apply after
+# node group recreation.
 
 locals {
   eks_cluster_name = "l4-ci"

--- a/terraform/aws/eks.tf
+++ b/terraform/aws/eks.tf
@@ -27,9 +27,9 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  # Pinned to the last version compatible with the locked aws provider (5.56.1);
-  # 20.17+ requires aws >= 5.61. Bump provider and module together, deliberately.
-  version = "20.16.0"
+  # AL2023_x86_64_NVIDIA support (nodeadm user-data) requires module >= 20.23;
+  # 20.37.2 is the last 20.x and needs aws provider >= 5.95 (lock is at 5.100.0).
+  version = "20.37.2"
 
   cluster_name    = local.eks_cluster_name
   cluster_version = "1.32"

--- a/terraform/aws/eks.tf
+++ b/terraform/aws/eks.tf
@@ -1,0 +1,217 @@
+# EKS cluster for GPU CI (migration plan: docs/gpu-queues-eks-migration.md)
+#
+# Replaces the gpu_1_queue / gpu_4_queue Elastic CI Stack ASGs with one
+# autoscaling GPU node pool (g6.12xlarge, 4x L4) behind a single Buildkite
+# agent-stack-k8s controller queue (l4-k8s).
+#
+# FSx note: there are four Lustre filesystems, one per AZ (see Phase 0 audit).
+# Nodes mount their AZ-local filesystem at /fsx via user-data (same behavior as
+# s3://vllm-ci/bootstrap.sh on the ASGs) and pods consume it through a hostPath
+# volume. The FSx CSI driver / static PV design was dropped because a static PV
+# cannot select among the four per-AZ filesystems by node AZ.
+
+locals {
+  eks_cluster_name = "gpu-ci-eks"
+
+  # From the Phase 0 audit (aws fsx describe-file-systems, us-west-2).
+  # us-west-2a is the odd one out: 500 MB/s/TiB (others 1000) and missing the
+  # ci-model-weights security group — fix in console (filesystems are not
+  # managed by this terraform).
+  fsx_lustre_by_az = {
+    "us-west-2a" = { dns = "fs-0c88a6d0c07e7579b.fsx.us-west-2.amazonaws.com", mount = "7wycbb4v" }
+    "us-west-2b" = { dns = "fs-0e20a97e78295dc40.fsx.us-west-2.amazonaws.com", mount = "7szcbb4v" }
+    "us-west-2c" = { dns = "fs-0ad82609009496582.fsx.us-west-2.amazonaws.com", mount = "zgzcbb4v" }
+    "us-west-2d" = { dns = "fs-0337adaa59ddb88f5.fsx.us-west-2.amazonaws.com", mount = "ygzcbb4v" }
+  }
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  # Pinned to the last version compatible with the locked aws provider (5.56.1);
+  # 20.17+ requires aws >= 5.61. Bump provider and module together, deliberately.
+  version = "20.16.0"
+
+  cluster_name    = local.eks_cluster_name
+  cluster_version = "1.32"
+
+  cluster_endpoint_public_access           = true
+  enable_cluster_creator_admin_permissions = true
+
+  # The CI VPC has public subnets only (same ones the ASGs and FSx ENIs use).
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.public_subnets
+
+  cluster_addons = {
+    eks-pod-identity-agent = {}
+  }
+
+  eks_managed_node_groups = {
+    # Controllers, CoreDNS, CSI, cluster-autoscaler, device plugin, Datadog.
+    system = {
+      instance_types = ["m6i.large"]
+      capacity_type  = "ON_DEMAND"
+      min_size       = 2
+      max_size       = 3
+      desired_size   = 2
+    }
+
+    # Single GPU pool: 4x L4 per node, serves 1/2/4-GPU pods (bin-packed by
+    # resource requests).
+    l4x4 = {
+      ami_type       = "AL2023_x86_64_NVIDIA"
+      instance_types = ["g6.12xlarge"]
+      capacity_type  = "ON_DEMAND"
+      # 5 warm nodes at all times (fast job pickup, warm FSx clients), CA scales
+      # to 30 under load. Note: 5x g6.12xlarge on-demand 24/7 is a real standing
+      # cost (~$9.7k/mo) — revisit min_size once Phase 5 has wait-time data.
+      min_size     = 5
+      max_size     = 30
+      desired_size = 5
+
+      labels = {
+        "vllm.ci/gpu-pool"              = "l4x4"
+        "k8s.amazonaws.com/accelerator" = "nvidia-l4"
+      }
+
+      taints = {
+        gpu = {
+          key    = "nvidia.com/gpu"
+          value  = "true"
+          effect = "NO_SCHEDULE"
+        }
+      }
+
+      # 512 GB root, parity with the ASGs (RootVolumeSize=512).
+      # Fast-follow (plan Phase 5): move containerd/kubelet onto the 2x940GB
+      # instance-store NVMe (nodeadm localStorage RAID0) and shrink this.
+      block_device_mappings = {
+        xvda = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_size           = 512
+            volume_type           = "gp3"
+            delete_on_termination = true
+          }
+        }
+      }
+
+      # Kubelet pulls private ECR images using the node role (no
+      # imagePullSecrets needed).
+      iam_role_additional_policies = {
+        ecr_readonly = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+      }
+
+      # Node bootstrap, adapted from s3://vllm-ci/bootstrap.sh:
+      # disable algif_aead, install the Lustre client, mount the AZ-local FSx
+      # filesystem at /fsx (relatime,flock — flock is required by
+      # huggingface_hub's cache locking).
+      enable_bootstrap_user_data = true
+      cloudinit_pre_nodeadm = [
+        {
+          content_type = "text/x-shellscript"
+          content      = <<-EOT
+            #!/bin/bash
+            set -euo pipefail
+
+            echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif-aead.conf
+            rmmod algif_aead 2>/dev/null || true
+
+            dnf install -y lustre-client
+
+            TOKEN=$(curl -sX PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+            AZ=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/availability-zone)
+
+            case "$AZ" in
+            %{ for az, fsx in local.fsx_lustre_by_az ~}
+              ${az}) FSX_DNS_NAME="${fsx.dns}"; MOUNT_NAME="${fsx.mount}" ;;
+            %{ endfor ~}
+              *) echo "unknown AZ $AZ" >&2; exit 1 ;;
+            esac
+
+            mkdir -p /fsx
+            # fstab entry so the mount survives a node reboot.
+            echo "$${FSX_DNS_NAME}@tcp:/$${MOUNT_NAME} /fsx lustre relatime,flock,_netdev 0 0" >> /etc/fstab
+            mount -t lustre -o relatime,flock $${FSX_DNS_NAME}@tcp:/$${MOUNT_NAME} /fsx
+            mkdir -p /fsx/hf_cache
+          EOT
+        }
+      ]
+
+      # Cluster Autoscaler scale-from-zero: managed-node-group tags do NOT
+      # propagate to the ASG, so these must be set explicitly. The
+      # resources/nvidia.com/gpu tag works around CA modeling a zero-size GPU
+      # group as having no GPU capacity.
+      autoscaling_group_tags = {
+        "k8s.io/cluster-autoscaler/enabled"                                            = "true"
+        "k8s.io/cluster-autoscaler/${local.eks_cluster_name}"                          = "owned"
+        "k8s.io/cluster-autoscaler/node-template/label/vllm.ci/gpu-pool"               = "l4x4"
+        "k8s.io/cluster-autoscaler/node-template/label/k8s.amazonaws.com/accelerator"  = "nvidia-l4"
+        "k8s.io/cluster-autoscaler/node-template/taint/nvidia.com/gpu"                 = "true:NoSchedule"
+        "k8s.io/cluster-autoscaler/node-template/resources/nvidia.com/gpu"             = "4"
+      }
+    }
+  }
+}
+
+# --- Cluster Autoscaler IAM (helm install of CA is a separate step; this gives
+# its kube-system/cluster-autoscaler service account AWS permissions via EKS Pod
+# Identity) ---
+
+data "aws_iam_policy_document" "cluster_autoscaler_assume" {
+  statement {
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "cluster_autoscaler" {
+  name               = "${local.eks_cluster_name}-cluster-autoscaler"
+  assume_role_policy = data.aws_iam_policy_document.cluster_autoscaler_assume.json
+}
+
+data "aws_iam_policy_document" "cluster_autoscaler" {
+  statement {
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeScalingActivities",
+      "autoscaling:DescribeTags",
+      "ec2:DescribeImages",
+      "ec2:DescribeInstanceTypes",
+      "ec2:DescribeLaunchTemplateVersions",
+      "ec2:GetInstanceTypesFromInstanceRequirements",
+      "eks:DescribeNodegroup",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/k8s.io/cluster-autoscaler/${local.eks_cluster_name}"
+      values   = ["owned"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "cluster_autoscaler" {
+  name   = "cluster-autoscaler"
+  role   = aws_iam_role.cluster_autoscaler.id
+  policy = data.aws_iam_policy_document.cluster_autoscaler.json
+}
+
+resource "aws_eks_pod_identity_association" "cluster_autoscaler" {
+  cluster_name    = module.eks.cluster_name
+  namespace       = "kube-system"
+  service_account = "cluster-autoscaler"
+  role_arn        = aws_iam_role.cluster_autoscaler.arn
+}

--- a/terraform/aws/eks.tf
+++ b/terraform/aws/eks.tf
@@ -9,6 +9,14 @@
 # s3://vllm-ci/bootstrap.sh on the ASGs) and pods consume it through a hostPath
 # volume. The FSx CSI driver / static PV design was dropped because a static PV
 # cannot select among the four per-AZ filesystems by node AZ.
+#
+# OUT-OF-BAND CONFIG WARNING: the cluster runs kube-scheduler
+# nodeResourcesFit.scoringStrategy=MostAllocated (weights nvidia.com/gpu:10,
+# cpu:1, memory:1), applied 2026-08-29 via `aws eks update-cluster-config
+# --kube-scheduler-config` (EKS advanced control plane configuration).
+# terraform aws provider support for kube_scheduler_config did not exist at
+# that time ("planned" per AWS), so this is NOT in code: fold it in when the
+# provider lands, and re-apply after any cluster recreate.
 
 locals {
   eks_cluster_name = "l4-ci"

--- a/terraform/aws/eks.tf
+++ b/terraform/aws/eks.tf
@@ -37,6 +37,23 @@ module "eks" {
   cluster_endpoint_public_access           = true
   enable_cluster_creator_admin_permissions = true
 
+  # Console/kubectl access for humans. The cluster creator (the vllm-ci IAM user
+  # running terraform) is admin via the flag above; everyone else needs an
+  # explicit access entry or the EKS console shows "Unauthorized" on the
+  # Nodes/Resources tabs. Add SSO/federated role ARNs in terraform.tfvars, e.g.
+  #   eks_admin_principal_arns = ["arn:aws:iam::936637512419:role/aws-reserved/sso.amazonaws.com/..."]
+  access_entries = {
+    for i, arn in var.eks_admin_principal_arns : "admin_${i}" => {
+      principal_arn = arn
+      policy_associations = {
+        admin = {
+          policy_arn   = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = { type = "cluster" }
+        }
+      }
+    }
+  }
+
   # The CI VPC has public subnets only (same ones the ASGs and FSx ENIs use).
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.public_subnets

--- a/terraform/aws/eks.tf
+++ b/terraform/aws/eks.tf
@@ -93,12 +93,13 @@ module "eks" {
       ami_type       = "AL2023_x86_64_NVIDIA"
       instance_types = ["g6.12xlarge"]
       capacity_type  = "ON_DEMAND"
-      # 5 warm nodes at all times (fast job pickup, warm FSx clients), CA scales
-      # to 30 under load. Note: 5x g6.12xlarge on-demand 24/7 is a real standing
-      # cost (~$9.7k/mo) — revisit min_size once Phase 5 has wait-time data.
-      min_size     = 5
+      # 15 warm nodes at all times (fast job pickup, warm FSx clients, and holds
+      # g6.12xlarge capacity against frequent AWS InsufficientInstanceCapacity
+      # in us-west-2), CA scales to 30 under load. Note: 15x g6.12xlarge
+      # on-demand 24/7 is ~$29k/mo — revisit with utilization data.
+      min_size     = 15
       max_size     = 30
-      desired_size = 5
+      desired_size = 15
 
       labels = {
         "vllm.ci/gpu-pool"              = "l4x4"

--- a/terraform/aws/eks.tf
+++ b/terraform/aws/eks.tf
@@ -11,7 +11,7 @@
 # cannot select among the four per-AZ filesystems by node AZ.
 
 locals {
-  eks_cluster_name = "gpu-ci-eks"
+  eks_cluster_name = "l4-ci"
 
   # From the Phase 0 audit (aws fsx describe-file-systems, us-west-2).
   # us-west-2a is the odd one out: 500 MB/s/TiB (others 1000) and missing the

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -36,6 +36,29 @@ resource "aws_security_group" "ci-model-weights-sg" {
       prefix_list_ids  = []
       security_groups  = ["sg-0c83698515e47eb5b"]
       self             = true
+    },
+    # EKS GPU CI nodes (terraform/aws/eks.tf) mounting the FSx filesystems
+    {
+      cidr_blocks      = []
+      description      = "Lustre LNet from gpu-ci-eks nodes"
+      from_port        = 1018
+      to_port          = 1023
+      protocol         = "tcp"
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      security_groups  = [module.eks.node_security_group_id]
+      self             = false
+    },
+    {
+      cidr_blocks      = []
+      description      = "Lustre LNet from gpu-ci-eks nodes"
+      from_port        = 988
+      to_port          = 988
+      protocol         = "tcp"
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      security_groups  = [module.eks.node_security_group_id]
+      self             = false
     }
   ]
 

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -7,3 +7,11 @@ variable "ci_hf_token" {
   type        = string
   description = "Huggingface token used to run CI tests"
 }
+
+variable "eks_admin_principal_arns" {
+  type        = list(string)
+  description = "IAM principal ARNs (e.g. SSO roles) granted AmazonEKSClusterAdminPolicy on the l4-ci cluster"
+  default = [
+    "arn:aws:iam::936637512419:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_AdminAccess_e8f1a24c3a971e07",
+  ]
+}


### PR DESCRIPTION
## Summary

Phase 1 of the gpu_1_queue / gpu_4_queue migration off the Elastic CI Stack ASGs onto EKS + agent-stack-k8s.

- **`terraform/aws/eks.tf`** (new): `gpu-ci-eks` cluster (k8s 1.32, pod-identity add-on) in the existing us-west-2 VPC public subnets; `system` node group (2x m6i.large); `l4x4` GPU node group (`g6.12xlarge`, 4x L4, **min 5 / max 30** on-demand, AL2023 NVIDIA AMI, 512 GB gp3, GPU taint, CA scale-up ASG tags, ECR-readonly node role). Node user-data ports `s3://vllm-ci/bootstrap.sh`: disables `algif_aead`, installs the Lustre client, mounts the **AZ-local** FSx filesystem at `/fsx` with `relatime,flock` (there are four per-AZ filesystems — one shared FSx was a wrong assumption; a CSI static PV can't select by AZ, hence user-data + hostPath instead of the FSx CSI driver).
- **`security_groups.tf`**: EKS node SG allowed on `ci-model-weights-sg` (Lustre TCP 988, 1018-1023).
- **CA IAM**: role + pod identity association for `kube-system/cluster-autoscaler`.
- **`.terraform.lock.hcl`**: aws provider 5.56.1 -> 5.100.0 (5.56 predates the `AL2023_x86_64_NVIDIA` AMI type; eks module pinned to 20.16.0 accordingly).

## Plan / apply

Targeted plan was clean: **45 to add, 1 to change (the SG), 0 to destroy**. A blanket plan shows 7 change / 21 destroy — all pre-existing CFN drift (live `MinSize=20`/`terminate=false` on gpu-4, `BootstrapScriptUrl` on premerge CPU stacks) plus knock-on IAM attachment replacements; the targeted apply does not touch it. That drift needs a separate decision (tracked in the doc).

Applied with:

```
terraform apply -target=module.eks -target=aws_iam_role.cluster_autoscaler \
  -target=aws_iam_role_policy.cluster_autoscaler \
  -target=aws_eks_pod_identity_association.cluster_autoscaler \
  -target=aws_security_group.ci-model-weights-sg
```

## Follow-ups (not in this PR)

- Helm: NVIDIA device plugin, cluster-autoscaler, agent-stack-k8s controller (`l4-k8s` queue), secrets (Phase 2)
- Fix us-west-2a FSx filesystem (half throughput, missing ci-model-weights SG) — manual, filesystems aren't terraformed
- Phase 4: `device: l4` marking in vllm test configs + generator k8s plugin

## Cost note

min 5 warm g6.12xlarge ~= $9.7k/mo standing cost; revisit min_size with Phase 5 wait-time data.
