### PR TITLE
[CI] Export Buildkite metrics for both orgs during the migration

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -228,10 +228,16 @@ module "ci_monitoring" {
     google-beta = google-beta.us-central1-b
   }
 
-  project_id                = var.project_id
-  pipeline_slug             = "tpu-inference-ci"
-  org_slug                  = "tpu-commons"
-  buildkite_token_secret_id = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret
+  project_id    = var.project_id
+  pipeline_slug = "tpu-inference-ci"
+  org_slug      = "tpu-commons"
+
+  # Both orgs are exported while the migration is in flight. Drop the
+  # tpu-commons entry once its agents are gone.
+  buildkite_token_secret_ids = {
+    "tpu-commons" = "projects/${var.secret_project_id}/secrets/tpu_commons_buildkite_agent_token"
+    "vllm"        = "projects/${var.secret_project_id}/secrets/vllm_buildkite_agent_token"
+  }
 }
 
 module "ci_cache_storage" {

--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/main.tf
@@ -4,15 +4,53 @@
 # buildkite-agent-metrics binary to export queue/agent metrics.
 # =====================================================================
 # Provision the e2-micro compute instance for monitoring
+resource "google_service_account" "metrics_sa" {
+  account_id   = "ci-metrics-exporter-sa"
+  project      = var.project_id
+  display_name = "SA for the Buildkite agent-metrics exporter VM"
+}
+
+resource "google_project_iam_member" "metrics_sa_roles" {
+  for_each = toset([
+    "roles/monitoring.metricWriter",
+    "roles/logging.logWriter",
+  ])
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.metrics_sa.email}"
+}
+
+# Read access to each org's agent token. The tokens live in a different project
+# from the VM, so the grant is made against the secret's own project.
+resource "google_secret_manager_secret_iam_member" "metrics_token_access" {
+  for_each = var.buildkite_token_secret_ids
+
+  project   = split("/", each.value)[1]
+  secret_id = split("/", each.value)[3]
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.metrics_sa.email}"
+}
+
 resource "google_compute_instance" "monitoring_instance" {
   provider     = google-beta
   project      = var.project_id
   name         = "vllm-ci-monitoring-cpu-0"
   machine_type = "e2-micro"
 
+  # Changing the service account, and re-running the startup script for a new
+  # set of exporters, both require a stop/start.
+  allow_stopping_for_update = true
+
   service_account {
+    email  = google_service_account.metrics_sa.email
     scopes = ["cloud-platform"]
   }
+
+  depends_on = [
+    google_secret_manager_secret_iam_member.metrics_token_access,
+    google_project_iam_member.metrics_sa_roles,
+  ]
 
   boot_disk {
     auto_delete = true
@@ -29,41 +67,11 @@ resource "google_compute_instance" "monitoring_instance" {
   }
 
   metadata = {
-    enable-oslogin   = "true"
-    "startup-script" = <<-EOF
-      #!/bin/bash
-      
-      # Step 1: Download the official buildkite-agent-metrics binary
-      wget -q https://github.com/buildkite/buildkite-agent-metrics/releases/download/v5.5.0/buildkite-agent-metrics-linux-amd64 -O /usr/local/bin/buildkite-agent-metrics
-      chmod +x /usr/local/bin/buildkite-agent-metrics
-
-      BK_TOKEN=$(gcloud secrets versions access latest --secret="${var.buildkite_token_secret_id}")
-
-      # Step 2: Configure Systemd background service
-      cat << 'SERVICE_EOF' > /etc/systemd/system/bk-metrics.service
-      [Unit]
-      Description=Buildkite Agent Metrics Exporter
-      After=network.target
-
-      [Service]
-      Type=simple
-      ExecStart=/usr/local/bin/buildkite-agent-metrics \
-        -backend stackdriver \
-        -stackdriver-projectid ${var.project_id} \
-        -token $${BK_TOKEN} \
-        -interval 15s
-      Restart=always
-      RestartSec=10
-
-      [Install]
-      WantedBy=multi-user.target
-      SERVICE_EOF
-
-      # Step 3: Enable and start the systemd service
-      systemctl daemon-reload
-      systemctl enable bk-metrics
-      systemctl start bk-metrics
-    EOF
+    enable-oslogin = "true"
+    "startup-script" = templatefile("${path.module}/startup.sh.tftpl", {
+      project_id       = var.project_id
+      token_secret_ids = var.buildkite_token_secret_ids
+    })
   }
 }
 

--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/startup.sh.tftpl
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/startup.sh.tftpl
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+# Step 1: Stop any exporter already running, so the binary is not busy when we
+# replace it. This runs on every boot, not just the first.
+for unit in /etc/systemd/system/bk-metrics*.service; do
+  [ -e "$unit" ] || continue
+  systemctl stop "$(basename "$unit")" || true
+done
+
+# Retire the single-org unit from before per-org exporters
+if [ -f /etc/systemd/system/bk-metrics.service ]; then
+  systemctl disable bk-metrics.service || true
+  rm -f /etc/systemd/system/bk-metrics.service
+fi
+
+# Step 2: Download the official buildkite-agent-metrics binary. Stage it and
+# rename into place: writing the destination directly fails with ETXTBSY if
+# anything still holds the old binary open.
+wget -q https://github.com/buildkite/buildkite-agent-metrics/releases/download/v5.5.0/buildkite-agent-metrics-linux-amd64 -O /tmp/buildkite-agent-metrics
+chmod +x /tmp/buildkite-agent-metrics
+mv -f /tmp/buildkite-agent-metrics /usr/local/bin/buildkite-agent-metrics
+
+install -d -m 0700 /etc/bk-metrics
+umask 077
+
+# Step 3: One exporter per Buildkite org. The token selects the org, and
+# buildkite-agent-metrics namespaces its Stackdriver metrics under the org slug,
+# so the two never collide. The token reaches systemd via EnvironmentFile so it
+# stays out of both instance metadata and the unit file.
+%{ for org, secret in token_secret_ids ~}
+# --secret takes a bare name and resolves it against --project; handing it a
+# full resource path yields a 404. Assert the result too, since a failure
+# inside a command substitution would otherwise slip past set -e.
+BK_TOKEN="$(gcloud secrets versions access latest --project='${split("/", secret)[1]}' --secret='${split("/", secret)[3]}')"
+[ -n "$BK_TOKEN" ] || { echo "empty token for org ${org}" >&2; exit 1; }
+printf 'BK_TOKEN=%s\n' "$BK_TOKEN" > /etc/bk-metrics/${org}.env
+
+cat << 'SERVICE_EOF' > /etc/systemd/system/bk-metrics-${org}.service
+[Unit]
+Description=Buildkite Agent Metrics Exporter (${org})
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/bk-metrics/${org}.env
+ExecStart=/usr/local/bin/buildkite-agent-metrics \
+  -backend stackdriver \
+  -stackdriver-projectid ${project_id} \
+  -token $${BK_TOKEN} \
+  -interval 15s
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+SERVICE_EOF
+%{ endfor ~}
+
+# Step 4: Enable and start the per-org services
+systemctl daemon-reload
+%{ for org, secret in token_secret_ids ~}
+systemctl enable --now bk-metrics-${org}
+%{ endfor ~}

--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/variables.tf
@@ -3,9 +3,9 @@ variable "project_id" {
   description = "The GCP project ID where the instance and metrics will live."
 }
 
-variable "buildkite_token_secret_id" {
-  type        = string
-  description = "The Secret Manager ID for the Agent Registration Token (e.g., projects/.../secrets/...)"
+variable "buildkite_token_secret_ids" {
+  type        = map(string)
+  description = "Buildkite org slug => Secret Manager resource name of that org's Agent Registration Token (projects/.../secrets/...). One metrics exporter runs per entry."
 }
 
 variable "pipeline_slug" {


### PR DESCRIPTION
## What

The metrics VM ran a single `buildkite-agent-metrics` process against one org, so the 28 agents already registered in the **vllm** org were invisible on the Ops View dashboard. This takes a map of org slug → token secret and runs one exporter per entry.

`buildkite-agent-metrics` namespaces its Stackdriver metrics under the org slug (`custom.googleapis.com/buildkite/<org>/*`), so the two coexist with no collision. After the cutover, drop the `tpu-commons` entry from the map.

This lands ahead of #488 so we have visibility into the vllm fleet *before* the 09-04 window, and so #488 can drop its `buildkite_token_secret_id` hunk.

## The startup script had never run

Worth flagging separately. `vllm-ci-monitoring-cpu-0` last booted **2026-03-31** and was still serving the pre-#370 unit with the token baked into instance metadata. #370 rewrote the script in June, but metadata updates don't reboot an instance — so the new script sat there unexecuted. It could not have worked:

- the unit was built inside a **quoted** heredoc, so `${BK_TOKEN}` reached it literally, and systemd does not expand shell variables in `ExecStart`;
- `gcloud` was passed a bare secret name, which resolves against the instance's own project, while the token lives in `cloud-tpu-inference-test`;
- the instance ran as the **default compute SA**, which has no `secretAccessor` on either token.

**Any reboot of that box would have silently ended all Buildkite metrics**, cutover or not. Nothing alerts on it.

The token now reaches systemd via a `0600` `EnvironmentFile`, so it stays out of both instance metadata and the unit file — preserving what #370 was after.

## Other changes

- **Dedicated service account** (`ci-metrics-exporter-sa`) rather than granting the default compute account read on the agent tokens, which would extend that access to every VM in the project.
- **Explicit `--project` + non-empty assertion** on the secret fetch. A failure inside a command substitution doesn't trip `set -e`, so a missing token would otherwise write an empty `EnvironmentFile` and leave both exporters silently unauthenticated.
- **Stop exporters before replacing the binary**, staging the download through `/tmp`. On reboot the enabled unit holds the binary open, so `wget` onto it fails with `ETXTBSY`.
- **Script moved to `startup.sh.tftpl`** — the `for`-directive's whitespace trimming defeats the heredoc de-indent, which would leave `SERVICE_EOF` indented and the inner heredoc unterminated.

## Verification

Already applied. `terraform plan` was 5 add / 1 in-place update / 0 destroy.

```
$ systemctl  # both units running, startup-script exit status 0
Org=tpu-commons ... Org=vllm

$ metricDescriptors, custom.googleapis.com/buildkite/
tpu_commons: 8 metric types
vllm:        8 metric types

$ TotalAgentCount (last 10m)
tpu_commons: 11 queues, latest 03:28:00Z
vllm:        10 queues, latest 03:27:58Z
```

vllm's count matches the known fleet (10 v6e-1, 2 v6e-8, 8 cpu, 8 cpu_64_core).