### PR TITLE
Fix the AMD template input reference in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ A Python tool (`buildkite/pipeline_generator/`) that reads step definitions from
 
 #### Jinja2 Template (AMD CI)
 
-`buildkite/test-template-amd.j2` renders vLLM's [`test-pipeline.yaml`](https://github.com/vllm-project/vllm/blob/main/.buildkite/test-pipeline.yaml) into Buildkite YAML using [minijinja-cli](https://github.com/mitsuhiko/minijinja).
+`buildkite/test-template-amd.j2` renders vLLM's [`.buildkite/test-amd.yaml`](https://github.com/vllm-project/vllm/blob/main/.buildkite/test-amd.yaml) into Buildkite YAML using [minijinja-cli](https://github.com/mitsuhiko/minijinja).
 
 ### Bootstrap Scripts
 


### PR DESCRIPTION
## Summary

- point the AMD CI section of the README at `.buildkite/test-amd.yaml`, the file `bootstrap-amd.sh` actually renders

## Why

`buildkite/bootstrap-amd.sh` invokes:

```
minijinja-cli test-template-amd.j2 test-amd.yaml \
```

but the README says the template renders vLLM's `test-pipeline.yaml`. Both files exist on vLLM `main`, so the stale link resolves instead of 404ing, which is why the error has gone unnoticed.

## Validation

- `buildkite/bootstrap-amd.sh:170` confirms the rendered input is `test-amd.yaml`
- `.buildkite/test-amd.yaml` exists on `vllm-project/vllm@main`
- `pre-commit run --files README.md` — all applicable hooks pass

## AI assistance

AI assistance was used to locate and prepare this change. The submitter has reviewed every changed line.
