### PR TITLE
[CI] Poll both Buildkite orgs from the BigQuery puller

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -228,15 +228,22 @@ module "ci_monitoring" {
     google-beta = google-beta.us-central1-b
   }
 
-  project_id    = var.project_id
-  pipeline_slug = "tpu-inference-ci"
-  org_slug      = "tpu-commons"
+  project_id              = var.project_id
+  bq_puller_pipeline_slug = "tpu-inference-ci"
 
   # Both orgs are exported while the migration is in flight. Drop the
   # tpu-commons entry once its agents are gone.
   buildkite_token_secret_ids = {
     "tpu-commons" = "projects/${var.secret_project_id}/secrets/tpu_commons_buildkite_agent_token"
     "vllm"        = "projects/${var.secret_project_id}/secrets/vllm_buildkite_agent_token"
+  }
+
+  # A Buildkite API token belongs to a single org, so the puller needs one per
+  # org. vllm_buildkite_rest_api_token predates the migration and 404s on the
+  # vllm org despite its name.
+  bq_puller_orgs = {
+    "tpu-commons" = "vllm_buildkite_rest_api_token"
+    "vllm"        = "vllm_org_buildkite_rest_api_token"
   }
 }
 

--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -228,8 +228,8 @@ module "ci_monitoring" {
     google-beta = google-beta.us-central1-b
   }
 
-  project_id              = var.project_id
-  bq_puller_pipeline_slug = "tpu-inference-ci"
+  project_id               = var.project_id
+  bq_puller_pipeline_slugs = ["tpu-inference-ci", "vllm-torchtpu-ci"]
 
   # Both orgs are exported while the migration is in flight. Drop the
   # tpu-commons entry once its agents are gone.

--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/main.tf
@@ -102,7 +102,8 @@ resource "google_bigquery_table" "step_logs" {
   {"name": "state", "type": "STRING", "mode": "NULLABLE"},
   {"name": "wait_duration_sec", "type": "FLOAT", "mode": "NULLABLE"},
   {"name": "run_duration_sec", "type": "FLOAT", "mode": "NULLABLE"},
-  {"name": "created_at", "type": "TIMESTAMP", "mode": "NULLABLE"}
+  {"name": "created_at", "type": "TIMESTAMP", "mode": "NULLABLE"},
+  {"name": "org_slug", "type": "STRING", "mode": "NULLABLE"}
 ]
 EOF
 }
@@ -135,12 +136,6 @@ resource "google_storage_bucket_object" "source_object" {
 # PART 4: SECURITY & PERMISSIONS (IAM)
 # =====================================================================
 
-data "google_secret_manager_secret_version" "webhook_secret_val" {
-  project = var.project_id
-  secret  = "vllm_buildkite_rest_api_token"
-  version = "latest"
-}
-
 resource "google_service_account" "function_sa" {
   account_id   = "ci-webhook-receiver-sa"
   project      = var.project_id
@@ -154,8 +149,10 @@ resource "google_project_iam_member" "bq_editor" {
 }
 
 resource "google_secret_manager_secret_iam_member" "secret_access" {
+  for_each = var.bq_puller_orgs
+
   project   = var.project_id
-  secret_id = data.google_secret_manager_secret_version.webhook_secret_val.secret
+  secret_id = each.value
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.function_sa.email}"
 }
@@ -170,6 +167,8 @@ resource "google_cloudfunctions2_function" "webhook_receiver" {
   location    = "us-central1"
   description = "Polls Buildkite API and stores events into BigQuery"
 
+  depends_on = [google_secret_manager_secret_iam_member.secret_access]
+
   build_config {
     runtime     = "python310"
     entry_point = "handle_webhook"
@@ -182,22 +181,35 @@ resource "google_cloudfunctions2_function" "webhook_receiver" {
   }
 
   service_config {
-    max_instance_count    = 3
-    available_memory      = "256M"
-    timeout_seconds       = 60
+    max_instance_count = 3
+    available_memory   = "256M"
+    # One Buildkite round trip per org, done sequentially.
+    timeout_seconds       = 120
     service_account_email = google_service_account.function_sa.email
 
     environment_variables = {
       BQ_TABLE_ID   = "${var.project_id}.${google_bigquery_dataset.ci_analytics.dataset_id}.${google_bigquery_table.step_logs.table_id}"
-      PIPELINE_SLUG = var.pipeline_slug
-      ORG_SLUG      = var.org_slug
+      PIPELINE_SLUG = var.bq_puller_pipeline_slug
+
+      # Which orgs to poll, and the env var holding each one's token.
+      ORGS_JSON = jsonencode([
+        for org, secret in var.bq_puller_orgs : {
+          org       = org
+          token_env = "BK_TOKEN_${upper(replace(org, "-", "_"))}"
+        }
+      ])
     }
 
-    secret_environment_variables {
-      key        = "WEBHOOK_SECRET"
-      project_id = var.project_id
-      secret     = data.google_secret_manager_secret_version.webhook_secret_val.secret
-      version    = "latest"
+    dynamic "secret_environment_variables" {
+      for_each = var.bq_puller_orgs
+      iterator = org
+
+      content {
+        key        = "BK_TOKEN_${upper(replace(org.key, "-", "_"))}"
+        project_id = var.project_id
+        secret     = org.value
+        version    = "latest"
+      }
     }
   }
 }

--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/main.tf
@@ -183,13 +183,14 @@ resource "google_cloudfunctions2_function" "webhook_receiver" {
   service_config {
     max_instance_count = 3
     available_memory   = "256M"
-    # One Buildkite round trip per org, done sequentially.
-    timeout_seconds       = 120
+    # One Buildkite round trip per org/pipeline pair, done sequentially, each
+    # capped at 30s client-side. Stays under the scheduler's 320s deadline.
+    timeout_seconds       = 240
     service_account_email = google_service_account.function_sa.email
 
     environment_variables = {
-      BQ_TABLE_ID   = "${var.project_id}.${google_bigquery_dataset.ci_analytics.dataset_id}.${google_bigquery_table.step_logs.table_id}"
-      PIPELINE_SLUG = var.bq_puller_pipeline_slug
+      BQ_TABLE_ID    = "${var.project_id}.${google_bigquery_dataset.ci_analytics.dataset_id}.${google_bigquery_table.step_logs.table_id}"
+      PIPELINE_SLUGS = jsonencode(var.bq_puller_pipeline_slugs)
 
       # Which orgs to poll, and the env var holding each one's token.
       ORGS_JSON = jsonencode([

--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/src/main.py
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/src/main.py
@@ -10,7 +10,10 @@ from google.cloud import bigquery
 # Global clients
 client = bigquery.Client()
 TABLE_ID = os.environ.get("BQ_TABLE_ID")
-PIPELINE_SLUG = os.environ.get("PIPELINE_SLUG")
+
+# Every pipeline is polled in every org. A pipeline that does not exist in a
+# given org just 404s and is skipped.
+PIPELINE_SLUGS = json.loads(os.environ.get("PIPELINE_SLUGS", "[]"))
 
 # One entry per Buildkite org to poll: {"org": ..., "token_env": ...}. A
 # Buildkite API token is scoped to a single org, so each org names the env var
@@ -20,14 +23,15 @@ ORGS = json.loads(os.environ.get("ORGS_JSON", "[]"))
 @functions_framework.http
 def handle_webhook(request):
     """
-    Triggered by Cloud Scheduler to poll a SPECIFIC Buildkite pipeline in every
-    configured org.
+    Triggered by Cloud Scheduler to poll every configured Buildkite pipeline in
+    every configured org.
     """
     # Define time window: look back 15 mins to ensure no gaps with 10-min cron
     now = datetime.datetime.now(datetime.timezone.utc)
     finished_from = (now - datetime.timedelta(minutes=15)).isoformat()
 
-    rows_to_insert = []
+    # (row_id, row) pairs; the id is what BigQuery dedups on.
+    pairs = []
     failures = []
 
     for entry in ORGS:
@@ -36,36 +40,37 @@ def handle_webhook(request):
         if not token:
             failures.append(f"{org}: {entry['token_env']} is unset")
             continue
-        try:
-            rows_to_insert.extend(fetch_org_rows(org, token, finished_from))
-        except requests.RequestException as e:
-            # Keep going: one org being down should not stop the others from
-            # landing, and the 15-min lookback re-covers this window next run.
-            failures.append(f"{org}: {e}")
+
+        for pipeline in PIPELINE_SLUGS:
+            try:
+                pairs.extend(fetch_rows(org, token, pipeline, finished_from))
+            except requests.RequestException as e:
+                # Keep going: one org or pipeline being unreachable should not
+                # stop the others from landing, and the 15-min lookback
+                # re-covers this window on the next run.
+                failures.append(f"{org}/{pipeline}: {e}")
+
+    rows_to_insert = [row for _, row in pairs]
 
     if rows_to_insert:
-        # Generate Deterministic Row IDs for Idempotency
-        # Format: {build_uuid}_{step_name_hash}. build_id is a UUID, so it is
-        # already unique across orgs.
-        row_ids = [f"{row['build_id']}_{row['step_name']}" for row in rows_to_insert]
-
         # Stream to BigQuery with deduplication
+        row_ids = [row_id for row_id, _ in pairs]
         errors = client.insert_rows_json(TABLE_ID, rows_to_insert, row_ids=row_ids)
         if errors:
             print(f"BigQuery Errors: {errors}")
             return "Partial Success", 500
 
     if failures:
-        print(f"Failed orgs: {'; '.join(failures)}")
-        return f"Processed {len(rows_to_insert)} items, {len(failures)} org(s) failed", 500
+        print(f"Failed: {'; '.join(failures)}")
+        return f"Processed {len(rows_to_insert)} items, {len(failures)} target(s) failed", 500
 
-    return f"Processed {len(rows_to_insert)} items for pipeline {PIPELINE_SLUG}", 200
+    targets = len(ORGS) * len(PIPELINE_SLUGS)
+    return f"Processed {len(rows_to_insert)} items across {targets} org/pipeline pair(s)", 200
 
-def fetch_org_rows(org, token, finished_from):
+def fetch_rows(org, token, pipeline, finished_from):
     headers = {"Authorization": f"Bearer {token}"}
 
-    # Filtered by single pipeline
-    url = f"https://api.buildkite.com/v2/organizations/{org}/pipelines/{PIPELINE_SLUG}/builds"
+    url = f"https://api.buildkite.com/v2/organizations/{org}/pipelines/{pipeline}/builds"
     params = {
         "finished_from": finished_from,
         "state": "finished"
@@ -74,15 +79,25 @@ def fetch_org_rows(org, token, finished_from):
     response = requests.get(url, headers=headers, params=params, timeout=30)
     response.raise_for_status()
 
+    # Deterministic row IDs for idempotency, since the 15-min lookback re-sends
+    # builds the previous run already inserted. Keyed on the job UUID, not the
+    # step name: a step with parallelism emits several jobs sharing one name,
+    # and a name-keyed ID makes BigQuery dedup all but one of them away.
     rows = []
     for build in response.json():
         # 1. Capture E2E Summary
-        rows.append(construct_bq_row(org, build, "E2E_SUMMARY", build))
+        rows.append((
+            f"{build['id']}_E2E_SUMMARY",
+            construct_bq_row(org, build, "E2E_SUMMARY", build),
+        ))
 
         # 2. Capture Individual Steps
         for job in build.get("jobs", []):
             if job.get("type") == "script" and job.get("finished_at"):
-                rows.append(construct_bq_row(org, build, job.get("name"), job))
+                rows.append((
+                    f"{build['id']}_{job['id']}",
+                    construct_bq_row(org, build, job.get("name"), job),
+                ))
 
     return rows
 

--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/src/main.py
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/src/main.py
@@ -1,6 +1,7 @@
 # modules/ci_monitoring/src/main.py
 
 import os
+import json
 import datetime
 import requests
 import functions_framework
@@ -9,59 +10,83 @@ from google.cloud import bigquery
 # Global clients
 client = bigquery.Client()
 TABLE_ID = os.environ.get("BQ_TABLE_ID")
-BK_API_TOKEN = os.environ.get("WEBHOOK_SECRET") 
-ORG_SLUG = os.environ.get("ORG_SLUG")
 PIPELINE_SLUG = os.environ.get("PIPELINE_SLUG")
+
+# One entry per Buildkite org to poll: {"org": ..., "token_env": ...}. A
+# Buildkite API token is scoped to a single org, so each org names the env var
+# holding its own token, injected from Secret Manager by Terraform.
+ORGS = json.loads(os.environ.get("ORGS_JSON", "[]"))
 
 @functions_framework.http
 def handle_webhook(request):
     """
-    Triggered by Cloud Scheduler to poll a SPECIFIC Buildkite pipeline.
+    Triggered by Cloud Scheduler to poll a SPECIFIC Buildkite pipeline in every
+    configured org.
     """
     # Define time window: look back 15 mins to ensure no gaps with 10-min cron
     now = datetime.datetime.now(datetime.timezone.utc)
     finished_from = (now - datetime.timedelta(minutes=15)).isoformat()
 
-    headers = {"Authorization": f"Bearer {BK_API_TOKEN}"}
-    
-    # Updated URL to filter by single pipeline
-    url = f"https://api.buildkite.com/v2/organizations/{ORG_SLUG}/pipelines/{PIPELINE_SLUG}/builds"
-    params = {
-        "finished_from": finished_from,
-        "state": "finished"
-    }
-
-    response = requests.get(url, headers=headers, params=params)
-    if response.status_code != 200:
-        print(f"Failed to fetch from Buildkite: {response.text}")
-        return "Error", 500
-
-    builds = response.json()
     rows_to_insert = []
+    failures = []
 
-    for build in builds:
-        # 1. Capture E2E Summary
-        rows_to_insert.append(construct_bq_row(build, "E2E_SUMMARY", build))
-        
-        # 2. Capture Individual Steps
-        for job in build.get("jobs", []):
-            if job.get("type") == "script" and job.get("finished_at"):
-                rows_to_insert.append(construct_bq_row(build, job.get("name"), job))
+    for entry in ORGS:
+        org = entry["org"]
+        token = os.environ.get(entry["token_env"])
+        if not token:
+            failures.append(f"{org}: {entry['token_env']} is unset")
+            continue
+        try:
+            rows_to_insert.extend(fetch_org_rows(org, token, finished_from))
+        except requests.RequestException as e:
+            # Keep going: one org being down should not stop the others from
+            # landing, and the 15-min lookback re-covers this window next run.
+            failures.append(f"{org}: {e}")
 
     if rows_to_insert:
         # Generate Deterministic Row IDs for Idempotency
-        # Format: {build_uuid}_{step_name_hash}
+        # Format: {build_uuid}_{step_name_hash}. build_id is a UUID, so it is
+        # already unique across orgs.
         row_ids = [f"{row['build_id']}_{row['step_name']}" for row in rows_to_insert]
-        
+
         # Stream to BigQuery with deduplication
         errors = client.insert_rows_json(TABLE_ID, rows_to_insert, row_ids=row_ids)
         if errors:
             print(f"BigQuery Errors: {errors}")
             return "Partial Success", 500
 
+    if failures:
+        print(f"Failed orgs: {'; '.join(failures)}")
+        return f"Processed {len(rows_to_insert)} items, {len(failures)} org(s) failed", 500
+
     return f"Processed {len(rows_to_insert)} items for pipeline {PIPELINE_SLUG}", 200
 
-def construct_bq_row(build, step_name, timing_source):
+def fetch_org_rows(org, token, finished_from):
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Filtered by single pipeline
+    url = f"https://api.buildkite.com/v2/organizations/{org}/pipelines/{PIPELINE_SLUG}/builds"
+    params = {
+        "finished_from": finished_from,
+        "state": "finished"
+    }
+
+    response = requests.get(url, headers=headers, params=params, timeout=30)
+    response.raise_for_status()
+
+    rows = []
+    for build in response.json():
+        # 1. Capture E2E Summary
+        rows.append(construct_bq_row(org, build, "E2E_SUMMARY", build))
+
+        # 2. Capture Individual Steps
+        for job in build.get("jobs", []):
+            if job.get("type") == "script" and job.get("finished_at"):
+                rows.append(construct_bq_row(org, build, job.get("name"), job))
+
+    return rows
+
+def construct_bq_row(org, build, step_name, timing_source):
     runnable_at = parse_ts(timing_source.get("runnable_at"))
     started_at = parse_ts(timing_source.get("started_at"))
     finished_at = parse_ts(timing_source.get("finished_at"))
@@ -80,6 +105,7 @@ def construct_bq_row(build, step_name, timing_source):
 
     return {
         "build_id": build.get("id"),
+        "org_slug": org,
         "commit_hash": build.get("commit"),
         "step_name": step_name,
         "pipeline_slug": build.get("pipeline", {}).get("slug"),

--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/variables.tf
@@ -8,9 +8,9 @@ variable "buildkite_token_secret_ids" {
   description = "Buildkite org slug => Secret Manager resource name of that org's Agent Registration Token (projects/.../secrets/...). One metrics exporter runs per entry."
 }
 
-variable "bq_puller_pipeline_slug" {
-  type        = string
-  description = "Buildkite pipeline slug the BigQuery puller reads. The same slug is used in every org in bq_puller_orgs."
+variable "bq_puller_pipeline_slugs" {
+  type        = list(string)
+  description = "Buildkite pipeline slugs the BigQuery puller reads. Every slug is polled in every org in bq_puller_orgs; a slug missing from an org is reported and skipped rather than failing the run."
 }
 
 variable "bq_puller_orgs" {

--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/variables.tf
@@ -8,12 +8,12 @@ variable "buildkite_token_secret_ids" {
   description = "Buildkite org slug => Secret Manager resource name of that org's Agent Registration Token (projects/.../secrets/...). One metrics exporter runs per entry."
 }
 
-variable "pipeline_slug" {
+variable "bq_puller_pipeline_slug" {
   type        = string
-  description = "The specific Buildkite pipeline slug to monitor (e.g., tpu-inference-ci)"
+  description = "Buildkite pipeline slug the BigQuery puller reads. The same slug is used in every org in bq_puller_orgs."
 }
 
-variable "org_slug" {
-  type        = string
-  description = "The specific Buildkite org slug to monitor (e.g., tpu-commons)"
+variable "bq_puller_orgs" {
+  type        = map(string)
+  description = "Buildkite org slug => name of a Secret Manager secret in project_id holding a REST API token for that org. A token is scoped to one org, so each entry needs its own. The puller polls every entry and stamps each BigQuery row with its org."
 }


### PR DESCRIPTION
The BigQuery puller read one org and one pipeline. This makes both a list, so `vllm-torchtpu-ci` and the `vllm` org land in `step_execution_logs` alongside the existing data instead of replacing it at cutover.

- `bq_puller_orgs` maps org slug => REST token secret. A Buildkite token is scoped to one org, so each brings its own; Terraform injects one secret env var per org.
- `bq_puller_pipeline_slugs` is a list. Every slug is polled in every org; one missing from an org is skipped rather than failing the run.
- Rows are stamped with a new nullable `org_slug` column. Existing rows keep `NULL`, and are all tpu-commons.
- `pipeline_slug`/`org_slug` renamed to `bq_puller_*`, since they drive only the BigQuery half of the module and not the metrics VM.

**Also fixes a data-loss bug.** Row IDs were `{build_id}_{step_name}`, but a step with `parallelism` emits several jobs sharing a name, so BigQuery deduped all but one away at insert. `vllm-torchtpu-ci` was worst hit: `Perf/Eval: General suite (TPU v7x-8)` runs `parallelism: 3` and kept 1 of 43 rows across 30 builds. Row IDs are now keyed on the job UUID. Rows already in the table are untouched.

Applied before merge. The BigQuery table updated in place — the column appends, `deletion_protection` untouched. Dry run across all four org/pipeline pairs: every row stamped, 0 row ID collisions, down from 50. A `vllm-torchtpu-ci` build has since landed in the table.

Rollback: revert and re-apply. The `org_slug` column is nullable and can stay.