### PR TITLE
[CI] Trim the CI monitoring comments to what stays true

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -231,16 +231,13 @@ module "ci_monitoring" {
   project_id               = var.project_id
   bq_puller_pipeline_slugs = ["tpu-inference-ci", "vllm-torchtpu-ci"]
 
-  # Both orgs are exported while the migration is in flight. Drop the
-  # tpu-commons entry once its agents are gone.
+  # Drop the tpu-commons entries once its agents are gone.
   buildkite_token_secret_ids = {
     "tpu-commons" = "projects/${var.secret_project_id}/secrets/tpu_commons_buildkite_agent_token"
     "vllm"        = "projects/${var.secret_project_id}/secrets/vllm_buildkite_agent_token"
   }
 
-  # A Buildkite API token belongs to a single org, so the puller needs one per
-  # org. vllm_buildkite_rest_api_token predates the migration and 404s on the
-  # vllm org despite its name.
+  # vllm_buildkite_rest_api_token is the tpu-commons token despite its name.
   bq_puller_orgs = {
     "tpu-commons" = "vllm_buildkite_rest_api_token"
     "vllm"        = "vllm_org_buildkite_rest_api_token"

--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/main.tf
@@ -21,8 +21,8 @@ resource "google_project_iam_member" "metrics_sa_roles" {
   member  = "serviceAccount:${google_service_account.metrics_sa.email}"
 }
 
-# Read access to each org's agent token. The tokens live in a different project
-# from the VM, so the grant is made against the secret's own project.
+# The agent tokens live in a different project from the VM, so each grant is
+# made against the secret's own project.
 resource "google_secret_manager_secret_iam_member" "metrics_token_access" {
   for_each = var.buildkite_token_secret_ids
 
@@ -38,8 +38,8 @@ resource "google_compute_instance" "monitoring_instance" {
   name         = "vllm-ci-monitoring-cpu-0"
   machine_type = "e2-micro"
 
-  # Changing the service account, and re-running the startup script for a new
-  # set of exporters, both require a stop/start.
+  # Startup-script metadata is only re-read on boot, so exporter changes need
+  # a stop/start to take effect.
   allow_stopping_for_update = true
 
   service_account {
@@ -183,8 +183,8 @@ resource "google_cloudfunctions2_function" "webhook_receiver" {
   service_config {
     max_instance_count = 3
     available_memory   = "256M"
-    # One Buildkite round trip per org/pipeline pair, done sequentially, each
-    # capped at 30s client-side. Stays under the scheduler's 320s deadline.
+    # One request per org/pipeline pair, sequential, 30s each. Under the
+    # scheduler's 320s deadline.
     timeout_seconds       = 240
     service_account_email = google_service_account.function_sa.email
 

--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/src/main.py
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/src/main.py
@@ -11,13 +11,11 @@ from google.cloud import bigquery
 client = bigquery.Client()
 TABLE_ID = os.environ.get("BQ_TABLE_ID")
 
-# Every pipeline is polled in every org. A pipeline that does not exist in a
-# given org just 404s and is skipped.
+# Every pipeline is polled in every org; a pipeline absent from an org 404s.
 PIPELINE_SLUGS = json.loads(os.environ.get("PIPELINE_SLUGS", "[]"))
 
-# One entry per Buildkite org to poll: {"org": ..., "token_env": ...}. A
-# Buildkite API token is scoped to a single org, so each org names the env var
-# holding its own token, injected from Secret Manager by Terraform.
+# [{"org": ..., "token_env": ...}]. A Buildkite token is scoped to one org, so
+# each names the env var holding its own, injected by Terraform.
 ORGS = json.loads(os.environ.get("ORGS_JSON", "[]"))
 
 @functions_framework.http
@@ -45,9 +43,8 @@ def handle_webhook(request):
             try:
                 pairs.extend(fetch_rows(org, token, pipeline, finished_from))
             except requests.RequestException as e:
-                # Keep going: one org or pipeline being unreachable should not
-                # stop the others from landing, and the 15-min lookback
-                # re-covers this window on the next run.
+                # Keep going so one bad target cannot drop the others; the
+                # lookback re-covers this window next run.
                 failures.append(f"{org}/{pipeline}: {e}")
 
     rows_to_insert = [row for _, row in pairs]
@@ -79,10 +76,8 @@ def fetch_rows(org, token, pipeline, finished_from):
     response = requests.get(url, headers=headers, params=params, timeout=30)
     response.raise_for_status()
 
-    # Deterministic row IDs for idempotency, since the 15-min lookback re-sends
-    # builds the previous run already inserted. Keyed on the job UUID, not the
-    # step name: a step with parallelism emits several jobs sharing one name,
-    # and a name-keyed ID makes BigQuery dedup all but one of them away.
+    # Row IDs dedup the builds the lookback re-sends. Key on the job UUID, not
+    # the step name: parallel jobs share a name and would collapse into one.
     rows = []
     for build in response.json():
         # 1. Capture E2E Summary

--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/startup.sh.tftpl
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/startup.sh.tftpl
@@ -1,22 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
-# Step 1: Stop any exporter already running, so the binary is not busy when we
-# replace it. This runs on every boot, not just the first.
+# Runs on every boot, so stop the exporters before touching their binary.
 for unit in /etc/systemd/system/bk-metrics*.service; do
   [ -e "$unit" ] || continue
   systemctl stop "$(basename "$unit")" || true
 done
 
-# Retire the single-org unit from before per-org exporters
+# Retire the single-org unit that predates the per-org exporters.
 if [ -f /etc/systemd/system/bk-metrics.service ]; then
   systemctl disable bk-metrics.service || true
   rm -f /etc/systemd/system/bk-metrics.service
 fi
 
-# Step 2: Download the official buildkite-agent-metrics binary. Stage it and
-# rename into place: writing the destination directly fails with ETXTBSY if
-# anything still holds the old binary open.
+# Stage and rename; writing the destination directly fails with ETXTBSY.
 wget -q https://github.com/buildkite/buildkite-agent-metrics/releases/download/v5.5.0/buildkite-agent-metrics-linux-amd64 -O /tmp/buildkite-agent-metrics
 chmod +x /tmp/buildkite-agent-metrics
 mv -f /tmp/buildkite-agent-metrics /usr/local/bin/buildkite-agent-metrics
@@ -24,14 +21,12 @@ mv -f /tmp/buildkite-agent-metrics /usr/local/bin/buildkite-agent-metrics
 install -d -m 0700 /etc/bk-metrics
 umask 077
 
-# Step 3: One exporter per Buildkite org. The token selects the org, and
-# buildkite-agent-metrics namespaces its Stackdriver metrics under the org slug,
-# so the two never collide. The token reaches systemd via EnvironmentFile so it
-# stays out of both instance metadata and the unit file.
+# One exporter per org. The token selects the org and metrics are namespaced
+# under the org slug, so the exporters never collide. EnvironmentFile keeps the
+# token out of instance metadata and out of the unit file.
 %{ for org, secret in token_secret_ids ~}
-# --secret takes a bare name and resolves it against --project; handing it a
-# full resource path yields a 404. Assert the result too, since a failure
-# inside a command substitution would otherwise slip past set -e.
+# --secret takes a bare name, resolved against --project. Assert non-empty:
+# set -e does not catch a failure inside $( ).
 BK_TOKEN="$(gcloud secrets versions access latest --project='${split("/", secret)[1]}' --secret='${split("/", secret)[3]}')"
 [ -n "$BK_TOKEN" ] || { echo "empty token for org ${org}" >&2; exit 1; }
 printf 'BK_TOKEN=%s\n' "$BK_TOKEN" > /etc/bk-metrics/${org}.env
@@ -57,7 +52,6 @@ WantedBy=multi-user.target
 SERVICE_EOF
 %{ endfor ~}
 
-# Step 4: Enable and start the per-org services
 systemctl daemon-reload
 %{ for org, secret in token_secret_ids ~}
 systemctl enable --now bk-metrics-${org}

--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/variables.tf
@@ -10,10 +10,10 @@ variable "buildkite_token_secret_ids" {
 
 variable "bq_puller_pipeline_slugs" {
   type        = list(string)
-  description = "Buildkite pipeline slugs the BigQuery puller reads. Every slug is polled in every org in bq_puller_orgs; a slug missing from an org is reported and skipped rather than failing the run."
+  description = "Buildkite pipeline slugs the BigQuery puller reads. Every slug is polled in every org in bq_puller_orgs; a slug missing from an org is skipped."
 }
 
 variable "bq_puller_orgs" {
   type        = map(string)
-  description = "Buildkite org slug => name of a Secret Manager secret in project_id holding a REST API token for that org. A token is scoped to one org, so each entry needs its own. The puller polls every entry and stamps each BigQuery row with its org."
+  description = "Buildkite org slug => name of a Secret Manager secret in project_id holding a REST API token for that org. A token is scoped to one org, so each entry needs its own. Rows are stamped with org_slug."
 }


### PR DESCRIPTION
The comments in `ci_monitoring` had accumulated a running account of the migration and of bugs already fixed. That is noise for anyone reading the module later.

Keeps the reasons that still constrain the code — ETXTBSY on the binary swap, `set -e` not catching `$( )`, the single-org token scope, the job-UUID row ID — and drops the narrative around them.

No behaviour change. The startup-script diff is comments only; verified no executable line moved. Applied, and a forced puller run returned 200.