### PR TITLE
pipeline_generator: fix /ci retry for steps with label-derived keys

### DIFF
--- a/buildkite/pipeline_generator/pipeline_generator.py
+++ b/buildkite/pipeline_generator/pipeline_generator.py
@@ -5,6 +5,7 @@ from typing import FrozenSet, List, Optional, Tuple
 import yaml
 
 from buildkite_step import (
+    _generate_step_key,
     add_precommit_dependency,
     convert_group_step_to_buildkite_step,
     create_precommit_group_step,
@@ -93,8 +94,11 @@ def select_steps_and_dependencies(
 
     steps_by_key = {}
     for step in steps:
+        # Steps without an explicit key are uploaded with a label-derived key
+        # (see convert_group_step_to_buildkite_step), so retry builds reference
+        # them by that generated key.
         if not step.key:
-            continue
+            step.key = _generate_step_key(step.label)
         if step.key in steps_by_key:
             raise ValueError(f"Duplicate CI step key: {step.key}")
         steps_by_key[step.key] = step

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -107,6 +107,41 @@ def test_selected_steps_reject_unknown_key():
         )
 
 
+def test_selected_steps_support_label_generated_keys():
+    # Steps without an explicit key are uploaded with a label-derived key, so
+    # retry builds reference them by that generated key.
+    steps = [
+        Step(label="Image", key="image-build", commands=["build"]),
+        Step(
+            label=":nvidia: (H200) Rust Frontend OpenAI Coverage",
+            depends_on=["image-build"],
+            commands=["test"],
+        ),
+    ]
+
+    selected, selected_keys = select_steps_and_dependencies(
+        steps, frozenset({"-nvidia--h200-rust-frontend-openai-coverage"})
+    )
+
+    assert [step.key for step in selected] == [
+        "image-build",
+        "-nvidia--h200-rust-frontend-openai-coverage",
+    ]
+    assert selected_keys == frozenset(
+        {"image-build", "-nvidia--h200-rust-frontend-openai-coverage"}
+    )
+
+
+def test_selected_steps_reject_duplicate_generated_key():
+    steps = [
+        Step(label="Test", key="test", commands=["a"]),
+        Step(label="test", commands=["b"]),
+    ]
+
+    with pytest.raises(ValueError, match="Duplicate CI step key: test"):
+        select_steps_and_dependencies(steps, frozenset({"test"}))
+
+
 def test_selected_steps_reject_unknown_dependency():
     step = Step(
         label="Test",


### PR DESCRIPTION
## Problem

`/ci retry` on a new PR commit can fail at bootstrap:

```
ValueError: Unknown CI step key(s): -nvidia--h200-rust-frontend-openai-coverage, ascend-npu-test
```

Root cause: steps without an explicit `key:` in the vllm job YAMLs are uploaded with a label-derived key (`_generate_step_key` in `buildkite_step.py`), so Buildkite jobs for them **do** carry a step key. The `/ci retry` flow collects failed jobs' step keys and passes them to a new build as `VLLM_CI_ONLY_STEP_KEYS` — but `select_steps_and_dependencies` only indexed steps with an **explicit** key (`if not step.key: continue`), so any retry containing a label-keyed step failed validation.

Even if validation had passed, those steps would have been silently dropped: dependency expansion, the final selection, and `_step_should_run` (via `global_config["only_step_keys"]`) all key off `step.key`, which is still `None` for label-keyed steps at that point.

## Fix

Assign the label-derived key to keyless steps at the start of `select_steps_and_dependencies`, before building the key index. This also extends the duplicate-key check to label-derived keys (verified against vllm main: all 241 steps across the three job dirs have unique effective keys).

Complementary vllm-side hardening (explicit keys for the currently keyless hardware-test steps): https://github.com/vllm-project/vllm/pull/54330 — not required for this fix to work.

## Testing

- Two new cases in `buildkite/tests/pipeline_generator/test_step.py`:
  - selection by a label-derived key (using the exact key shape from the failure, `-nvidia--h200-rust-frontend-openai-coverage`) including transitive dependency expansion;
  - duplicate detection for label-derived keys.
  Both fail without the fix.
- Full suite: `python -m pytest buildkite/tests` — 112 passed.
- End-to-end probe against vllm's real job dirs with `only_step_keys={"-nvidia--h200-rust-frontend-openai-coverage", "ascend-npu-test"}`: both steps now resolve, `image-build` is pulled in as a transitive dependency, and the requested steps render into the generated pipeline.

## AI-assistance disclosure

AI assistance was used in creating this change (diagnosis and fix drafted/verified by an AI agent under human direction). Every changed line was reviewed by the human submitter.
