### PR TITLE
add support for intel cpu for agent tags

### DIFF
--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -195,10 +195,12 @@ def add_precommit_dependency(
 
 def _get_step_agents(step: Step) -> Dict[str, str]:
     agents = {"queue": get_agent_queue(step)}
-    if step.device == DeviceType.INTEL_GPU and step.agent_tags:
+    if step.device in [DeviceType.INTEL_GPU, DeviceType.INTEL_CPU] and step.agent_tags:
         agents.update(
             {key: value for key, value in step.agent_tags.items() if key != "queue"}
         )
+    elif step.device is DeviceType.INTEL_CPU and not step.agent_tags:
+        agents.update({"label": "functional"})
     return agents
 
 

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -199,7 +199,7 @@ def _get_step_agents(step: Step) -> Dict[str, str]:
         agents.update(
             {key: value for key, value in step.agent_tags.items() if key != "queue"}
         )
-    elif step.device is DeviceType.INTEL_CPU and not step.agent_tags:
+    elif step.device == DeviceType.INTEL_CPU and not step.agent_tags:
         agents.update({"label": "functional"})
     return agents
 


### PR DESCRIPTION
This pull request adds optional agent_tags support for Intel CPU CI steps in the Buildkite pipeline generator.

At the moment, Intel CPU jobs are routed through the same intel-cpu queue. In practice, however, the Intel cpu ci will have  heterogeneous and includes multiple device for multiple usage, such as functional and performance. Allowing additional agent tags makes it possible to target these device types more precisely while preserving the existing queue-based scheduling model.

Motivation
The Intel CPU CI fleet consists of multiple hardware variants, and different jobs may be better suited to different Intel CPU device types. Without additional agent tag selection, scheduling flexibility is limited and can place unnecessary pressure on a subset of available machines.

By introducing optional agent tags for Intel GPU jobs, we can make more effective use of the available different types of devices capacity and improve scheduling flexibility without changing the current queue model.

Changes Introduced
This change adds an optional agent_tags field for pipeline steps.
If no agent_tags given, it will using the label as "functional"

For steps configured with device: intel_cpu:

the queue continues to be determined by the existing device -> queue mapping logic
additional Buildkite agent tags may be specified through agent_tags
agent_tags cannot be used to override the queue selection
Scope and Compatibility
This change is intentionally limited in scope:

it applies only to steps using the Intel CPU queue
the existing queue selection logic remains unchanged
existing pipeline structure and YAML configurations continue to work as before
no behavior is changed for non-Intel-CPU steps
Rationale
This approach is intended to be the smallest and safest change that enables more flexible Intel CPU scheduling, without altering the existing queue model or unnecessarily expanding the pipeline schema.