### PR TITLE
Disable AMD GPU tests by default while the AMD cluster is unhealthy

### DIFF
--- a/buildkite/pipeline_generator/README.md
+++ b/buildkite/pipeline_generator/README.md
@@ -76,6 +76,7 @@ The generator relies on several environment variables, typically provided by Bui
 *   `TORCH_NIGHTLY`: Set to "1" to build and run the *entire* test suite against torch nightly (full run, not just the tagged subset). Also forces a full run on the pinned torch. Intended to be set on the scheduled build.
 *   `RUN_ALL`: Set to "1" to force run all steps.
 *   `SKIP_TIMEOUT`: Set to "1" at pipeline generation time to omit all configured step timeouts.
+*   `ENABLE_AMD_TESTS`: AMD GPU test steps (direct AMD steps and AMD mirrors) are disabled by default while the AMD cluster is unhealthy. Set to "1" at pipeline generation time to re-enable them.
 *   `DOCS_ONLY_DISABLE`: Set to "0" to enable skipping CI for doc-only changes.
 *   `VLLM_USE_PRECOMPILED`: Set to "1" to force use of precompiled wheels.
 *   `VLLM_CI_ONLY_STEP_KEYS`: A non-empty JSON array of stable step keys. When

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -37,6 +37,9 @@ PRECOMMIT_MAX_WAIT = 3600  # 30 minutes
 PRECOMMIT_WAIT_INTERVAL = 60
 
 SKIP_TIMEOUT_ENV_VAR = "SKIP_TIMEOUT"
+# AMD GPU tests are disabled by default while the AMD cluster is unhealthy.
+# Set to "1" at pipeline generation time to re-enable AMD GPU test steps.
+ENABLE_AMD_TESTS_ENV_VAR = "ENABLE_AMD_TESTS"
 EXIT_STATUS_NEGATIVE_ONE_RETRY = {"exit_status": -1, "limit": 1}
 
 # Pod-level failures on EKS surface as agent stops / lost pods rather than
@@ -587,12 +590,23 @@ def convert_group_step_to_buildkite_step(
     list_file_diff = global_config["list_file_diff"]
 
     amd_hardware_steps = []
+    # AMD GPU tests are disabled by default while the AMD cluster is
+    # unhealthy. Set ENABLE_AMD_TESTS=1 at pipeline generation time to
+    # re-enable them without reverting this change.
+    amd_tests_disabled = os.getenv(ENABLE_AMD_TESTS_ENV_VAR) != "1"
+    if amd_tests_disabled:
+        print(
+            "AMD GPU test steps are disabled by default; set "
+            f"{ENABLE_AMD_TESTS_ENV_VAR}=1 to re-enable."
+        )
 
     for group, steps in group_steps.items():
         group_steps_list = []
         for step in steps:
             step_key = step.key or _generate_step_key(step.label)
             if is_amd_gpu_device(step.device):
+                if amd_tests_disabled:
+                    continue
                 amd_commands = [f"export VLLM_TEST_GROUP_NAME={step_key}"]
                 amd_commands.extend(
                     _prepare_commands(
@@ -706,7 +720,8 @@ def convert_group_step_to_buildkite_step(
 
             # Create AMD mirror step and its block step if specified/applicable
             if (
-                step.mirror
+                not amd_tests_disabled
+                and step.mirror
                 and step.mirror.get("amd")
                 and global_config["only_step_keys"] is None
             ):

--- a/buildkite/tests/pipeline_generator/conftest.py
+++ b/buildkite/tests/pipeline_generator/conftest.py
@@ -7,6 +7,10 @@ import step as step_module
 @pytest.fixture
 def fake_global_config(monkeypatch):
     monkeypatch.delenv(buildkite_step.SKIP_TIMEOUT_ENV_VAR, raising=False)
+    # AMD GPU tests are disabled by default; existing tests exercise the AMD
+    # step generation path, so opt back in. Tests for the kill switch itself
+    # override this.
+    monkeypatch.setenv(buildkite_step.ENABLE_AMD_TESTS_ENV_VAR, "1")
     config = {
         "name": "vllm_ci",
         "github_repo_name": "vllm-project/vllm",

--- a/buildkite/tests/pipeline_generator/test_amd.py
+++ b/buildkite/tests/pipeline_generator/test_amd.py
@@ -603,3 +603,78 @@ def test_amd_mirror_label_override(fake_global_config, amd_label, expected_amd_l
     # never affected either way.
     assert amd_command_step.label == expected_amd_label
     assert default_command_step.label == "Mirrored label test"
+
+
+def _amd_disabled_test_steps():
+    direct_step = Step(
+        label="AMD direct test",
+        group="Direct AMD",
+        key="amd-direct-disabled",
+        depends_on=["image-build"],
+        device="mi300_4",
+        optional=True,
+        commands=["pytest tests/foo.py"],
+    )
+    mirrored_step = Step(
+        label="Mirrored test",
+        group="Mirrors",
+        key="mirrored-disabled",
+        depends_on=["image-build"],
+        commands=["pytest tests/mirror.py"],
+        source_file_dependencies=["vllm/"],
+        device="h200_18gb",
+        mirror={
+            "amd": {
+                "device": "mi325_1",
+                "depends_on": ["image-build-amd"],
+            }
+        },
+    )
+    return direct_step, mirrored_step
+
+
+def test_amd_tests_disabled_by_default(monkeypatch, fake_global_config):
+    monkeypatch.delenv(buildkite_step.ENABLE_AMD_TESTS_ENV_VAR, raising=False)
+    fake_global_config["list_file_diff"] = ["vllm/foo.py"]
+    direct_step, mirrored_step = _amd_disabled_test_steps()
+
+    group_steps = buildkite_step.convert_group_step_to_buildkite_step(
+        {
+            direct_step.group: [direct_step],
+            mirrored_step.group: [mirrored_step],
+        }
+    )
+
+    # The AMD direct step and the AMD mirror are dropped entirely, while the
+    # non-AMD mirrored step still renders.
+    assert all(group.group != "Hardware-AMD Tests" for group in group_steps)
+    command_steps = [
+        command_step
+        for group_step in group_steps
+        for command_step in group_step.steps
+        if isinstance(command_step, buildkite_step.BuildkiteCommandStep)
+    ]
+    assert [step.label for step in command_steps] == ["Mirrored test"]
+
+
+def test_enable_amd_tests_env_var_restores_amd_steps(monkeypatch, fake_global_config):
+    monkeypatch.setenv(buildkite_step.ENABLE_AMD_TESTS_ENV_VAR, "1")
+    fake_global_config["list_file_diff"] = ["vllm/foo.py"]
+    direct_step, mirrored_step = _amd_disabled_test_steps()
+
+    group_steps = buildkite_step.convert_group_step_to_buildkite_step(
+        {
+            direct_step.group: [direct_step],
+            mirrored_step.group: [mirrored_step],
+        }
+    )
+
+    amd_group = next(
+        group for group in group_steps if group.group == "Hardware-AMD Tests"
+    )
+    amd_command_steps = [
+        step
+        for step in amd_group.steps
+        if isinstance(step, buildkite_step.BuildkiteCommandStep)
+    ]
+    assert len(amd_command_steps) == 2


### PR DESCRIPTION
Re-applies https://github.com/vllm-project/ci-infra/commit/c856f2bb89467bb2bce540dbce33199524c7236f (reverts the revert e1c1f9b).

AMD GPU test steps are skipped at pipeline generation time unless `ENABLE_AMD_TESTS=1` is set, while the AMD cluster is unhealthy.