### PR TITLE
[CI] Stop startup scripts leaking HF and analytics tokens to the serial console

### DIFF
--- a/terraform/gcp_old/tpu-inference/modules/benchmark/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/benchmark/main.tf
@@ -73,7 +73,10 @@ resource "google_tpu_v2_vm" "tpu_v6_benchmark" {
       sudo sed -i "s/xxx/${local.buildkite_token_value}/g" /etc/buildkite-agent/buildkite-agent.cfg
       sudo sed -i 's/name="%hostname-%spawn"/name="vllm-tpu-v6-${count.index}"/' /etc/buildkite-agent/buildkite-agent.cfg
       echo 'tags="queue=tpu_8_v6e_queue"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
-      echo 'HF_TOKEN=${local.huggingface_token_value}' | sudo tee -a /etc/environment
+      # tee echoes to stdout, which the startup script sends to the serial
+      # console, where anyone with compute.instances.getSerialPortOutput can
+      # read it. Secrets go to the file only.
+      echo 'HF_TOKEN=${local.huggingface_token_value}' | sudo tee -a /etc/environment > /dev/null
 
       sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/sdb
       sudo mkdir -p /mnt/disks/persist

--- a/terraform/gcp_old/tpu-inference/modules/ci_cpu/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cpu/main.tf
@@ -161,7 +161,10 @@ resource "google_compute_instance" "buildkite-agent-instance" {
       sudo sed -i '/^tags=/d' /etc/buildkite-agent/buildkite-agent.cfg
       echo 'tags="queue=cpu"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
       sudo sed -i '/^HF_TOKEN=/d' /etc/environment
-      echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment
+      # tee echoes to stdout, which the startup script sends to the serial
+      # console, where anyone with compute.instances.getSerialPortOutput can
+      # read it. Secrets go to the file only.
+      echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment > /dev/null
 
       ${file("${path.module}/../shared/keep-agent-connected.sh")}
 

--- a/terraform/gcp_old/tpu-inference/modules/ci_cpu_64_core/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cpu_64_core/main.tf
@@ -163,7 +163,10 @@ resource "google_compute_instance" "buildkite-agent-instance" {
       sudo sed -i '/^tags=/d' /etc/buildkite-agent/buildkite-agent.cfg
       echo 'tags="queue=${var.buildkite_queue_name}"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
       sudo sed -i '/^HF_TOKEN=/d' /etc/environment
-      echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment
+      # tee echoes to stdout, which the startup script sends to the serial
+      # console, where anyone with compute.instances.getSerialPortOutput can
+      # read it. Secrets go to the file only.
+      echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment > /dev/null
 
       ${file("${path.module}/../shared/keep-agent-connected.sh")}
 

--- a/terraform/gcp_old/tpu-inference/modules/ci_v5/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v5/main.tf
@@ -130,7 +130,10 @@ resource "google_tpu_v2_vm" "tpu_v5" {
       sudo sed -i "s/xxx/${local.buildkite_token_value}/g" /etc/buildkite-agent/buildkite-agent.cfg
       sudo sed -i 's/name="%hostname-%spawn"/name="vllm-tpu-${count.index}"/' /etc/buildkite-agent/buildkite-agent.cfg
       echo 'tags="queue=tpu_v5_queue"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
-      echo 'HF_TOKEN=${local.huggingface_token_value}' | sudo tee -a /etc/environment
+      # tee echoes to stdout, which the startup script sends to the serial
+      # console, where anyone with compute.instances.getSerialPortOutput can
+      # read it. Secrets go to the file only.
+      echo 'HF_TOKEN=${local.huggingface_token_value}' | sudo tee -a /etc/environment > /dev/null
       echo 'TPU_VERSION=tpu5' | sudo tee -a /etc/environment
 
       sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/sdb

--- a/terraform/gcp_old/tpu-inference/modules/ci_v6/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6/main.tf
@@ -121,8 +121,11 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       sudo sed -i "s/xxx/${var.buildkite_token_value}/g" /etc/buildkite-agent/buildkite-agent.cfg
       sudo sed -i 's/name="%hostname-%spawn"/name="vllm-tpu-${count.index}"/' /etc/buildkite-agent/buildkite-agent.cfg
       echo 'tags="queue=tpu_v6e_queue"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
-      echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment
-      echo 'BUILDKITE_ANALYTICS_TOKEN=${var.buildkite_analytics_token_value}' | sudo tee -a /etc/environment
+      # tee echoes to stdout, which the startup script sends to the serial
+      # console, where anyone with compute.instances.getSerialPortOutput can
+      # read it. Secrets go to the file only.
+      echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment > /dev/null
+      echo 'BUILDKITE_ANALYTICS_TOKEN=${var.buildkite_analytics_token_value}' | sudo tee -a /etc/environment > /dev/null
 
       sudo mkdir -p /mnt/disks/persist
 

--- a/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v6e/main.tf
@@ -156,8 +156,11 @@ resource "google_tpu_v2_vm" "tpu_v6_ci" {
       echo "HOST_NAME=$HOST_NAME_VAL" | sudo tee -a /etc/environment
       sudo sed -i "s/name=\"%hostname-%spawn\"/name=\"$HOST_NAME_VAL\"/" /etc/buildkite-agent/buildkite-agent.cfg
       echo 'tags="queue=${var.buildkite_queue_name}"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
-      echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment
-      echo 'BUILDKITE_ANALYTICS_TOKEN=${var.buildkite_analytics_token_value}' | sudo tee -a /etc/environment
+      # tee echoes to stdout, which the startup script sends to the serial
+      # console, where anyone with compute.instances.getSerialPortOutput can
+      # read it. Secrets go to the file only.
+      echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment > /dev/null
+      echo 'BUILDKITE_ANALYTICS_TOKEN=${var.buildkite_analytics_token_value}' | sudo tee -a /etc/environment > /dev/null
       echo 'TPU_VERSION=tpu6e' | sudo tee -a /etc/environment
 
       # Also provide HF_TOKEN and BUILDKITE_ANALYTICS_TOKEN through the agent's

--- a/terraform/gcp_old/tpu-inference/modules/ci_v7x/startup-script.sh.tftpl
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v7x/startup-script.sh.tftpl
@@ -138,8 +138,11 @@ HOST_NAME_VAL="${host_name}"
 echo "HOST_NAME=$HOST_NAME_VAL" | sudo tee -a /etc/environment
 sudo sed -i "s/name=\"%hostname-%spawn\"/name=\"$HOST_NAME_VAL\"/" /etc/buildkite-agent/buildkite-agent.cfg
 echo 'tags="queue=${buildkite_queue_name},hostname='"$HOST_NAME_VAL"'"' | sudo tee -a /etc/buildkite-agent/buildkite-agent.cfg
-echo 'HF_TOKEN=${huggingface_token_value}' | sudo tee -a /etc/environment
-echo 'BUILDKITE_ANALYTICS_TOKEN=${buildkite_analytics_token_value}' | sudo tee -a /etc/environment
+# tee echoes to stdout, which the startup script sends to the serial console,
+# where anyone with compute.instances.getSerialPortOutput can read it. Secrets
+# go to the file only.
+echo 'HF_TOKEN=${huggingface_token_value}' | sudo tee -a /etc/environment > /dev/null
+echo 'BUILDKITE_ANALYTICS_TOKEN=${buildkite_analytics_token_value}' | sudo tee -a /etc/environment > /dev/null
 echo 'TPU_VERSION=tpu7x' | sudo tee -a /etc/environment
 
 # Also provide HF_TOKEN and BUILDKITE_ANALYTICS_TOKEN through the agent's own


### PR DESCRIPTION
## Problem

Every agent module writes secrets to `/etc/environment` like this:

```bash
echo 'HF_TOKEN=${var.huggingface_token_value}' | sudo tee -a /etc/environment
```

`tee` writes to the file **and** to stdout. Startup script stdout goes to the serial console, so each VM publishes its Hugging Face token in cleartext:

```
google_metadata_script_runner[2253]: startup-script: HF_TOKEN=hf_...
```

Reading it needs only `compute.instances.getSerialPortOutput` on the project — no SSH, no instance access, no agent credentials. I hit this incidentally while reading a serial log to debug a wedged agent, which is how routine an exposure path it is. The log persists for the life of the instance, and some of these VMs have been up for over a week.

`BUILDKITE_ANALYTICS_TOKEN` leaks the same way in `ci_v6`, `ci_v6e`, and `ci_v7x`.

## Fix

Redirect the `tee` to `/dev/null` on the ten secret-bearing lines across all seven modules — `benchmark`, `ci_cpu`, `ci_cpu_64_core`, `ci_v5`, `ci_v6`, `ci_v6e`, `ci_v7x`.

This matches the form the newer environment-hook writes in `ci_v6e` and `ci_v7x` already use, which got it right:

```bash
printf '#!/bin/bash\nexport HF_TOKEN=%q\n...' ... | sudo tee /etc/buildkite-agent/hooks/environment > /dev/null
```

Non-secret `tee` lines (apt sources, `tags=`, `TPU_VERSION`, `HOST_NAME`, fstab) are left echoing — they are useful provisioning breadcrumbs and carry nothing sensitive.

## Scope

Startup scripts only run at instance creation, so this takes effect as VMs are recreated. No behavior change beyond the suppressed output — the same bytes still land in `/etc/environment`.

## Follow-up needed

This stops future leakage but does not undo the past. The currently-exposed values should be rotated:

- `tpu_commons_buildkite_hf_token`
- `tpu_commons_buildkite_analytics_token`

Serial port output is also cleared by recreating the instance, so the rolling recreate that picks up this change clears the old logs at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)