### PR TITLE
[CI] Add an agent-health skill for degraded TPU CI agents

### DIFF
--- a/claude-skills/AUTOMATIONS.md
+++ b/claude-skills/AUTOMATIONS.md
@@ -143,6 +143,12 @@ These files guide an agent but do not install timers or send scheduled alerts:
   daily CI runs.
 - [`pytorch-bump-triage.md`](pytorch-bump-triage.md): distinguish PyTorch or
   Triton bump regressions from failures already present on main.
+- [`../terraform/gcp_old/tpu-inference/skills/agent-health/`](../terraform/gcp_old/tpu-inference/skills/agent-health/):
+  find degraded agents in the `tpu-commons` cluster (disk full, silently
+  wedged) and recreate their VMs. It lives next to the Terraform it acts on
+  rather than here, so `terraform state pull` and `rolling_restart.py` resolve
+  relative to it. Driven by `/loop`, not a timer; see its
+  [`references/loop-prompt.md`](../terraform/gcp_old/tpu-inference/skills/agent-health/references/loop-prompt.md).
 
 ## Validate changes
 

--- a/terraform/gcp_old/tpu-inference/cloud-tpu-inference-test-v7x/.terraform.lock.hcl
+++ b/terraform/gcp_old/tpu-inference/cloud-tpu-inference-test-v7x/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/google" {
   version = "7.12.0"
   hashes = [
+    "h1:7zoFK6RIqRGLLMqgt7ioXMLslkzXtENPWoT97ke0dgQ=",
     "h1:axUhrDS/FeAEKHRKS57WfT0AkrNDC3d5DkWMMnk+fT4=",
     "h1:kBKvDUp6GLwHAsoM6CIj9ZTxVBzSnQjyxaVSP8SfqHQ=",
     "zh:38722ec7777543c23e22e02695e53dd5c94644022647c3c79e11e587063d4d2b",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/google" {
 provider "registry.terraform.io/hashicorp/google-beta" {
   version = "7.12.0"
   hashes = [
+    "h1:8STsUu6baExhysah6rQuroykNPj60gZzXGKdLwozL0g=",
     "h1:NemgObZkL0xt2OuT46nsnfFTjUDAbn3Gg56SHveciR8=",
     "h1:vp26U2dNza+E+o45vmEvRszQJZfws9qUC2Z8I2ePO0Q=",
     "zh:297f689ccd89d3b3ca04ae175676bea988abcd3aececa6205303bc3f3bfdc91d",
@@ -38,5 +40,27 @@ provider "registry.terraform.io/hashicorp/google-beta" {
     "zh:ed92ef287c8570ce48f0bcafbd50f2cc865012a39e92389a51e7b009eb30a316",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
     "zh:f6ed8f74eeb03c3651f205cd892cd20bf015fe93d814b1995a499afc26a84a06",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.4.0"
+  hashes = [
+    "h1:A6ZfMZY837Dv3fDy7rezqjg9QjoN4B/WU/5ZASbo3Hs=",
+    "h1:UGag96QCpXWgqem3URwUrAznze+xT4GW/QpcSi9SJqI=",
+    "h1:rHsYfTZ0KM0qQgh3csCtjxAWpluRz1m3RH1go4bwfco=",
+    "zh:018b9c5cc84d383597e1ec93bf5ca2cb8be0ba00df7333dddc7b9dc2f4bf4d6c",
+    "zh:0f46ca82e33e4214938a8d8dc19420233b76ae80dd93589e8864a47f9e5b0433",
+    "zh:246befb7164a4b4f3efba384d8438baa8785847a57e4a3276d3f1443f8c711cc",
+    "zh:658e8f163a00cd4ba99b4b25c2b221a751442428e012586a1628de7065786279",
+    "zh:70d9b321fc47b65f59aff6337e06bf71d75075d3a9c67604625d5253f9eed98f",
+    "zh:7ac0184c1aa6f77edda738d8030d8b867ef5124d08a138b3adac20c8d23dcb0b",
+    "zh:8fbde8bdff9015e1e870ce66efb6812fd786ed18df790b08ff12ed3b5306c5ef",
+    "zh:9636f78deab874910fa369702a797acb259a59ed8f65bafed908f096a967764c",
+    "zh:964d632c53f0e43425f1b3d03b7c9e56bcca01d4dd996efff0ae46cd67af534d",
+    "zh:c7246a41d4a04611f58f28c8ff8c6d3048c2d209600926d58e8d32d808972970",
+    "zh:cc20a3c5210da9b2bc90b5784ec44c8ef136eb3093d3eca3d851c7371ee3b105",
+    "zh:db18aa0da0a54a4c20304718a95b47d125480dd5769236ac47b6996f87a75f72",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/terraform/gcp_old/tpu-inference/cloud-tpu-inference-test/.terraform.lock.hcl
+++ b/terraform/gcp_old/tpu-inference/cloud-tpu-inference-test/.terraform.lock.hcl
@@ -4,6 +4,8 @@
 provider "registry.terraform.io/hashicorp/google" {
   version = "7.39.0"
   hashes = [
+    "h1:9acvx5lIVxB0vNONg+LLSHKsPAv5MI9jJ3esRniDdDY=",
+    "h1:n6fal0gOUI1IbFMFwITnhmqA7453sWeqS229XqpXAB4=",
     "h1:rk2YwbN0TWOWZ/7Hf2043zy/WKy2GpsAFhmAl5JdgAQ=",
     "zh:00eea2ae6d24e580a107574e3a93fcace52e2f1d912c3f7d1cdeadd9f0449443",
     "zh:3b626035e0ea3ec8aa0720cd976cda6f252645cfa90253d5d3b087c56a74d514",
@@ -23,7 +25,9 @@ provider "registry.terraform.io/hashicorp/google" {
 provider "registry.terraform.io/hashicorp/google-beta" {
   version = "7.39.0"
   hashes = [
+    "h1:MMDPuszvcWagelQ8vRb26dE/gy07ro0VbWr0pLkjW8E=",
     "h1:bC3gdJSvat6E6BH7IR4/28QPVtLsT96A5BoJ0gTt/YE=",
+    "h1:vaemmgSG3TMTUI21RmUOq3fZLW7BeMz8rDOfNH4xKyc=",
     "zh:1d65b4c55435e7fbd7adc7cdf70109b1bdd39cb815cc3c538cec2b2578b8324c",
     "zh:29fad3d245a4cd59d88ad421e63cec39384d5fe7c1f1df4f7998b2d3936fff47",
     "zh:41530f0c48ce7dc4dc0f232830dee46ac6961efa74138cfc4ef3a914e7dec14b",

--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/.terraform.lock.hcl
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/.terraform.lock.hcl
@@ -6,6 +6,8 @@ provider "registry.terraform.io/hashicorp/archive" {
   constraints = ">= 2.0.0"
   hashes = [
     "h1:WB6H5ksIZiyq1lQlD/PWeh+tn4FLsbSjVnRW3+4xe2Y=",
+    "h1:jdmKm+xl6ZcQrijxapnZ94RVuz/G4vk7hsIa1N0VT5Q=",
+    "h1:oRWx6ZDIdlNBF90L8TzV9X7pQ+P403hoCDiBfmUfhC0=",
     "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
     "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
     "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
@@ -26,6 +28,8 @@ provider "registry.terraform.io/hashicorp/google" {
   version     = "7.39.0"
   constraints = ">= 5.0.0"
   hashes = [
+    "h1:9acvx5lIVxB0vNONg+LLSHKsPAv5MI9jJ3esRniDdDY=",
+    "h1:n6fal0gOUI1IbFMFwITnhmqA7453sWeqS229XqpXAB4=",
     "h1:rk2YwbN0TWOWZ/7Hf2043zy/WKy2GpsAFhmAl5JdgAQ=",
     "zh:00eea2ae6d24e580a107574e3a93fcace52e2f1d912c3f7d1cdeadd9f0449443",
     "zh:3b626035e0ea3ec8aa0720cd976cda6f252645cfa90253d5d3b087c56a74d514",
@@ -46,7 +50,9 @@ provider "registry.terraform.io/hashicorp/google-beta" {
   version     = "7.39.0"
   constraints = ">= 5.0.0"
   hashes = [
+    "h1:MMDPuszvcWagelQ8vRb26dE/gy07ro0VbWr0pLkjW8E=",
     "h1:bC3gdJSvat6E6BH7IR4/28QPVtLsT96A5BoJ0gTt/YE=",
+    "h1:vaemmgSG3TMTUI21RmUOq3fZLW7BeMz8rDOfNH4xKyc=",
     "zh:1d65b4c55435e7fbd7adc7cdf70109b1bdd39cb815cc3c538cec2b2578b8324c",
     "zh:29fad3d245a4cd59d88ad421e63cec39384d5fe7c1f1df4f7998b2d3936fff47",
     "zh:41530f0c48ce7dc4dc0f232830dee46ac6961efa74138cfc4ef3a914e7dec14b",
@@ -66,6 +72,8 @@ provider "registry.terraform.io/hashicorp/tls" {
   version = "4.3.0"
   hashes = [
     "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
+    "h1:QjGpJjmvOB973D0BM9rPv/h9ln+wM64IGY/tfuOginw=",
+    "h1:j/BqLS2N2AScZyotd9nZpHdieJ7e5S8y+A+ZfIu8kL8=",
     "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
     "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",
     "zh:6889be32640349230de3f23856e6f04e0e9ced4a84a27d3f552fa54684448218",

--- a/terraform/gcp_old/tpu-inference/skills/agent-health/.gitignore
+++ b/terraform/gcp_old/tpu-inference/skills/agent-health/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+.pytest_cache/
+.ruff_cache/
+__pycache__/
+*.egg-info/
+uv.lock

--- a/terraform/gcp_old/tpu-inference/skills/agent-health/SKILL.md
+++ b/terraform/gcp_old/tpu-inference/skills/agent-health/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: agent-health
+description: Find degraded Buildkite agents in the tpu-commons cluster (disk full, silently wedged) and recreate their VMs with rolling_restart.py. Use when asked to check CI agent health, investigate stuck or failing agents, or run a monitoring loop over the fleet.
+---
+
+# TPU inference CI agent health
+
+Degraded agents in this cluster still report `connection_state: connected` and
+`paused: false`. The Buildkite queues page looks fine while they are eating
+jobs, so this skill exists to tell the difference from job history rather than
+from agent state.
+
+## The two failure modes
+
+**disk-full** — the agent keeps accepting jobs and fails them on ENOSPC. It
+never looks idle, so any idleness-based check misses it. The disk can fill
+during a docker pull, a model download, a pip install or a build cache write,
+and those fail on wildly different timescales (seconds to many minutes), so
+detection keys on the ENOSPC marker in the job log, never on failure timing.
+
+**silent-wedge** — the agent stops accepting work while its queue peers cycle
+normally. No failures, just a quiet capacity loss.
+
+A high failure rate with no ENOSPC marker is reported as `high-failure-rate`
+and never auto-remediated: flaky tests and broken pipelines look identical on
+the counters, and recreating a VM fixes neither.
+
+## Discovery
+
+The repo `.gitignore` excludes `.claude/`, so the source lives here, tracked and
+reviewable. To have Claude Code pick it up as a skill, link it in locally — the
+symlink is ignored, the code is not:
+
+```bash
+mkdir -p terraform/gcp_old/tpu-inference/.claude/skills
+ln -s ../../skills/agent-health \
+  terraform/gcp_old/tpu-inference/.claude/skills/agent-health
+```
+
+Nothing depends on that link. Every command below, and every prompt in
+`references/loop-prompt.md`, invokes the script by path and works without it.
+
+## Check status
+
+```bash
+cd terraform/gcp_old/tpu-inference/skills/agent-health
+uv sync --all-groups                      # first time only
+uv run python scripts/agent_health.py scan
+uv run python scripts/agent_health.py scan --json     # for a loop to parse
+```
+
+Read-only. Takes ~15-30s: it walks recent builds because Buildkite has no
+per-agent job history endpoint, then reads a few job logs for any suspect.
+
+`--window-hours` (default 24) sets the history window. Shorten it for a
+fast-cycling loop, lengthen it to catch a slow-burning fleet.
+
+Output splits into `degraded` (actionable) and `needs_review` (reported only).
+
+## Run safely
+
+```bash
+# what would happen
+uv run python scripts/agent_health.py recreate <agent> --dry-run
+# do it
+uv run python scripts/agent_health.py recreate <agent>
+```
+
+`recreate` re-runs the scan itself and refuses to act unless the agent is
+actionable *right now*, so a stale scan cannot trigger a replacement.
+
+Guard rails, all bypassable with `--force`:
+
+- **Not actionable** — the agent must currently classify as disk-full or
+  silent-wedge.
+- **Blast radius** — if more than 25% of a queue is degraded (and more than one
+  agent), it stops. That shape means a fleet-wide or pipeline fault, and
+  recreating VMs one at a time would churn the fleet without fixing anything.
+  A single bad agent never trips this, whatever the queue size.
+- **In-flight job** — blocks a silent-wedge recreate only. A disk-full agent
+  fails whatever it is holding anyway, so waiting protects nothing and just
+  prolongs the outage.
+
+### The disk matters
+
+The TPU fleets attach a **separate** `google_compute_disk` at
+`/mnt/disks/persist` for models and caches. It is not `auto_delete`, and the
+startup script only formats it `if ! blkid`. An instance-only replace hands the
+new VM back the same full disk and the agent returns still degraded.
+
+So `recreate` passes `-d/--replace-disks` for disk-full and withholds it for
+silent-wedge (whose disk is fine, and reformatting would throw away every
+cached model). Override with `--replace-disks` / `--no-replace-disks`.
+
+## How it maps an agent to Terraform
+
+`resolve` prints the address without touching anything:
+
+```bash
+uv run python scripts/agent_health.py resolve <agent>
+```
+
+It runs `terraform state pull` across each fleet directory and matches the VM
+by `attributes.name`, relying on the fleets' name SSOT (agent, VM and disk share
+one name). Legacy fleets predate that, so it also tries the agent's `hostname`.
+Reading state rather than hardcoding a name regex means new fleets work without
+editing the script.
+
+Remediation always shells out to the existing
+`terraform/gcp_old/tpu-inference/scripts/rolling_restart.py`, so the actual
+change stays a reviewable `terraform apply -replace -target`.
+
+## Auth
+
+`BUILDKITE_API_TOKEN` if set, otherwise `bk auth token`. It deliberately does
+not read Secret Manager — it runs under whoever is driving it.
+
+`terraform state pull` needs application-default credentials for the GCS
+backend and an initialised working directory (`terraform init`) in each fleet
+dir it searches.
+
+## Change the automation
+
+Thresholds are module-level constants at the top of `scripts/agent_health.py`,
+each with a comment on why it is set where it is. The pre-filter constants
+(`MIN_JOBS_FOR_RATE`, `MIN_FAILURES_FOR_LOG_CHECK`, `FAILURE_RATE_THRESHOLD`)
+only decide whose logs get read — loosen them freely, since the ENOSPC marker
+is what actually convicts. `DISK_FULL_MARKERS` is where to add a new phrasing
+when some tool renders ENOSPC differently.
+
+```bash
+uv run ruff check scripts && uv run ruff format --check scripts && uv run pytest
+```
+
+See `references/loop-prompt.md` for driving this from `/loop`, and
+`references/detection.md` for the evidence behind the thresholds.

--- a/terraform/gcp_old/tpu-inference/skills/agent-health/pyproject.toml
+++ b/terraform/gcp_old/tpu-inference/skills/agent-health/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=75"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tpu-inference-agent-health"
+version = "0.1.0"
+description = "Detect degraded Buildkite agents in the tpu-commons cluster and recreate their VMs"
+requires-python = ">=3.12"
+dependencies = []
+
+[project.scripts]
+agent-health = "agent_health:main"
+
+[dependency-groups]
+dev = [
+  "pytest==9.0.2",
+  "ruff==0.15.8",
+]
+
+[tool.setuptools]
+py-modules = ["agent_health"]
+package-dir = {"" = "scripts"}
+
+[tool.pytest.ini_options]
+pythonpath = ["scripts"]
+testpaths = ["scripts"]

--- a/terraform/gcp_old/tpu-inference/skills/agent-health/references/detection.md
+++ b/terraform/gcp_old/tpu-inference/skills/agent-health/references/detection.md
@@ -1,0 +1,95 @@
+# Why the detector looks the way it does
+
+Notes from the investigation that produced this skill (2026-09-02), kept so the
+thresholds can be argued with rather than guessed at.
+
+## Agent state is useless on its own
+
+Every degraded agent found so far reported `connection_state: connected` and
+`paused: false`. Neither the queues page nor `bk agent list` distinguished them
+from healthy peers. Anything built on agent state alone will see a green fleet.
+
+`bk agent list --output json` also drops the fields that matter (`job`,
+`last_job_finished_at`, `connected_at`, `lost_at`), which is why this skill goes
+to the REST API directly.
+
+## Job history has to be reconstructed
+
+There is no per-agent job history endpoint. The only route is
+`/v2/organizations/tpu-commons/builds?created_from=...`, paged, grouping jobs by
+`job.agent.name`. A live 24h window is roughly 10k jobs across ~79 agents.
+
+Builds created before the window can hold jobs that finished inside it, so the
+fetch reaches back `2 * window_hours` and filters on `finished_at`.
+
+## disk-full: the counters cannot convict, only the log can
+
+The first version of this detector keyed on idleness and found nothing, because
+a disk-full agent is *busy*: it keeps winning jobs and failing them. Observed on
+`tpu7x-8-ci-17`: 35 failures out of 97 jobs.
+
+The second version keyed on "high failure rate + short median failure duration",
+on the theory that these die during a docker pull in ~47s. That is true for
+docker pulls and false for everything else — a model download can churn for many
+minutes before it runs out of room, and a slow-failing disk-full agent is
+exactly as damaging. Timing was dropped as a gate and kept only as reported
+evidence.
+
+What is left is: a loose statistical pre-filter picks who to investigate, then an
+ENOSPC marker in an actual job log convicts. Everything else is reported as
+`high-failure-rate` for a human, because flaky tests and a broken pipeline
+produce identical counters and a VM replacement fixes neither.
+
+`DISK_FULL_MARKERS` covers how different runtimes render ENOSPC: the kernel
+string (`no space left on device`), Python's `[Errno 28]` (huggingface_hub model
+downloads), hf_transfer's `not enough free disk space`, and docker's
+`failed to register layer`, which sometimes elides the errno entirely.
+
+Only the newest `MAX_LOGS_PER_AGENT` failures are read — the oldest failure in a
+window may predate the disk filling up.
+
+## silent-wedge: only meaningful relative to the queue
+
+`vllm-ci-cpu-64-core-6` ran 0 jobs in a 40.9h window while its 7 peers ran
+12-56. It was `connected`, unpaused, and the VM had been RUNNING for 8 days. A
+recreate fixed it.
+
+Two false positives shaped the rule:
+
+- Six `cpu` agents idle for 7.7h all had `exit_status: 0` in a synchronised
+  burst. The queue was simply quiet. Hence scoring per queue and skipping any
+  queue with no work at all.
+- `v6e-1-ci-1` had reconnected 1.25h earlier. Hence `WEDGE_MIN_HOURS`.
+
+## The attached disk is not disposable
+
+`ci_v6e`, `ci_v7x`, `ci_v5`, `ci_v6` and `benchmark` attach a separate
+`google_compute_disk`, mounted at `/mnt/disks/persist`, which CI jobs
+bind-mount. It is not `auto_delete`, and the startup script only formats it
+`if ! blkid`. Replacing just the instance therefore reattaches the same full
+disk and the agent comes straight back degraded.
+
+`ci_cpu` and `ci_cpu_64_core` differ: the boot disk is inline with
+`auto_delete = true`, so an instance replace already gives a fresh disk and `-d`
+is a no-op. Passing `-d` unconditionally for disk-full is safe across both.
+
+## SSH is not a diagnostic here
+
+SSH to these VMs fails with "Connection timed out during banner exchange" on
+*healthy* hosts too — an IAP/firewall gap, not a symptom. Always test a healthy
+peer before reading an SSH hang as evidence. Confirm from job logs instead.
+
+## Running on Linux
+
+The fleet `.terraform.lock.hcl` files originally recorded `h1:` hashes for one
+platform only, so `terraform state pull` failed on linux_amd64 with "Required
+plugins are not installed". Fixed by recording hashes for linux_amd64,
+darwin_arm64 and darwin_amd64:
+
+```bash
+terraform -chdir=<fleet-dir> providers lock \
+  -platform=linux_amd64 -platform=darwin_arm64 -platform=darwin_amd64
+```
+
+Re-run that when a provider version changes, or Linux users are locked out
+again.

--- a/terraform/gcp_old/tpu-inference/skills/agent-health/references/loop-prompt.md
+++ b/terraform/gcp_old/tpu-inference/skills/agent-health/references/loop-prompt.md
@@ -1,0 +1,83 @@
+# Driving this from `/loop`
+
+Run `/loop` from the repo root. Three prompts, in increasing order of autonomy —
+start at the top and move down once you trust it.
+
+## 1. Report only (start here)
+
+Nothing is ever changed. Good for a first day of watching it, and for confirming
+the thresholds match what you would have judged by eye.
+
+```
+/loop Use the agent-health skill to scan the tpu-commons Buildkite fleet.
+Run: uv run python scripts/agent_health.py scan --json
+from terraform/gcp_old/tpu-inference/skills/agent-health
+
+If degraded is empty and blocked_queues is empty, reply with exactly
+"clean: N agents, no action" and nothing else.
+
+Otherwise, for each entry in degraded print the agent name, queue, reason and
+evidence, and the exact recreate command you would run. Do not run it. Also
+list anything in needs_review in one line each.
+```
+
+## 2. Auto-fix disk-full, ask about the rest (recommended)
+
+Disk-full is the mode worth acting on unattended: it is log-confirmed, it is
+actively failing PRs, and the fix is deterministic. A silent wedge costs
+capacity but breaks nothing, so it can wait for a human.
+
+```
+/loop Use the agent-health skill to keep the tpu-commons Buildkite fleet healthy.
+Work from terraform/gcp_old/tpu-inference/skills/agent-health
+
+1. Run: uv run python scripts/agent_health.py scan --json
+2. If blocked_queues is non-empty, do not recreate anything. Report the
+   blocked queues and stop — that shape means a fleet-wide fault, not a
+   per-VM problem.
+3. For each degraded entry with reason "disk-full": run
+   uv run python scripts/agent_health.py recreate <agent>
+   one agent at a time, waiting for each to finish before starting the next.
+   Do not check whether it holds a job — a disk-full agent fails whatever it
+   is running anyway.
+4. For each degraded entry with reason "silent-wedge": report it with its
+   evidence and the recreate command, but do not run it.
+5. Ignore needs_review entries unless the same agent appears three ticks in a
+   row, in which case mention it once.
+
+Keep each tick's output short. If nothing was degraded, reply with exactly
+"clean: N agents, no action" and nothing else.
+```
+
+## 3. Fully autonomous
+
+Same as (2) but step 4 becomes:
+
+```
+4. For each degraded entry with reason "silent-wedge": run
+   uv run python scripts/agent_health.py recreate <agent>
+   The script already refuses if the agent holds a job; do not override it.
+```
+
+## Notes on pacing
+
+Let `/loop` pace itself rather than pinning an interval. A scan is ~15-30s and
+costs a few hundred API calls, so 20-30 minutes between ticks is plenty — a disk
+fills over hours, not seconds. Tighten to ~5 minutes only while actively
+watching a recreate land.
+
+A recreate takes several minutes for a CPU VM and longer for a TPU VM. The next
+tick will naturally see the new agent as healthy (freshly connected agents are
+exempt from the wedge rule for `WEDGE_MIN_HOURS`), so there is no risk of the
+loop recreating the same host twice in a row.
+
+## What the loop must not do
+
+- Do not bypass `blocked_queues`. It exists precisely for the case where the
+  loop would otherwise recreate half a fleet in response to a bad pipeline.
+- Do not pass `--force`. Every guard it skips is one the loop is not qualified
+  to judge.
+- Do not act on `needs_review` / `high-failure-rate`. No ENOSPC marker was found
+  in the logs, so a VM replacement is a guess.
+- Do not SSH into anything to confirm. SSH is blocked fleet-wide and fails on
+  healthy hosts too.

--- a/terraform/gcp_old/tpu-inference/skills/agent-health/scripts/agent_health.py
+++ b/terraform/gcp_old/tpu-inference/skills/agent-health/scripts/agent_health.py
@@ -1,0 +1,702 @@
+#!/usr/bin/env python3
+"""Detect degraded Buildkite agents and recreate their VMs.
+
+Degraded agents in this cluster keep reporting `connection_state: connected`
+and `paused: false`, so neither the queues page nor `bk agent list` shows the
+problem. Two distinct failure modes hide behind that healthy-looking state:
+
+disk-full
+    The agent keeps *accepting* jobs and fails them on ENOSPC. It never looks
+    idle, so an idleness check misses it entirely. This is the damaging mode:
+    it eats real jobs and fails PRs. The disk can fill anywhere - a docker
+    pull, a model download, a build cache - so detection is a high failure
+    rate confirmed by an ENOSPC marker in the job log, never a guess from
+    failure timing. Docker pulls die in seconds; a model download can churn
+    for minutes before it runs out of room.
+
+silent-wedge
+    The agent stops accepting work altogether while its queue peers cycle
+    normally. Capacity quietly drops with no failures to show for it.
+
+Detection is read-only against the Buildkite REST API. Remediation shells out
+to the existing rolling_restart.py so the destroy/create stays a reviewed
+`terraform apply -replace` rather than something reimplemented in here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+ORG = "tpu-commons"
+API_ROOT = "https://api.buildkite.com/v2"
+
+
+def _find_tf_root(start: Path) -> Path:
+    """Walk up to the directory holding scripts/rolling_restart.py.
+
+    Searching for the landmark rather than counting parents keeps this working
+    when the skill is reached through the .claude/skills symlink, or moved.
+    """
+    for parent in [start, *start.parents]:
+        if (parent / "scripts" / "rolling_restart.py").is_file():
+            return parent
+    return start
+
+
+# The per-fleet Terraform configs live alongside rolling_restart.py. Resolved
+# from this file's location so the skill works from any cwd.
+DEFAULT_TF_ROOT = _find_tf_root(Path(__file__).resolve().parent)
+# Fleets live in separate Terraform states and an agent name alone does not say
+# which one, so search them all.
+DEFAULT_TF_DIRS = (
+    "cloud-ullm-inference-ci-cd",
+    "cloud-tpu-inference-test",
+    "cloud-tpu-inference-test-v7x",
+)
+
+# These two only decide whose logs are worth fetching. They are deliberately
+# loose: the ENOSPC marker below is what actually convicts an agent, so a
+# generous pre-filter costs a few HTTP calls, while a tight one silently misses
+# real disk exhaustion.
+MIN_JOBS_FOR_RATE = 3
+MIN_FAILURES_FOR_LOG_CHECK = 2
+FAILURE_RATE_THRESHOLD = 0.25
+# Logs to read per suspect agent, newest first. Bounds the scan's cost.
+MAX_LOGS_PER_AGENT = 3
+# An agent must have been connected at least this long before "no jobs" means
+# anything; freshly booted agents legitimately have not won work yet.
+WEDGE_MIN_HOURS = 6.0
+# Refuse to act when more than this fraction of a queue looks degraded. That
+# pattern is a fleet-wide or pipeline-wide fault, and recreating VMs one by one
+# would churn the fleet without fixing anything.
+MAX_QUEUE_DEGRADED_FRACTION = 0.25
+
+# Whatever fills the disk - docker layers, model weights, pip wheels, build
+# caches - the write ultimately fails with ENOSPC, so match on how the various
+# runtimes render that rather than on any one workload.
+DISK_FULL_MARKERS = (
+    "no space left on device",  # kernel ENOSPC, surfaced by most tools
+    "errno 28",  # python OSError, e.g. huggingface_hub model downloads
+    "enospc",
+    "disk quota exceeded",
+    "not enough free disk space",  # hf_transfer / huggingface-cli
+    "insufficient disk space",
+    "write error: no space",
+    "failed to register layer",  # docker, which sometimes elides the errno
+    "no space left",  # last-resort catch-all for the above phrasings
+)
+
+TF_INSTANCE_TYPES = ("google_compute_instance", "google_tpu_v2_vm")
+TERMINAL_JOB_STATES = ("passed", "failed", "broken", "timed_out")
+
+REASON_DISK_FULL = "disk-full"
+REASON_SILENT_WEDGE = "silent-wedge"
+# Failing a lot, but the logs never mentioned ENOSPC. Reported, never acted on:
+# flaky tests and broken pipelines look exactly like this, and recreating the VM
+# would not fix either.
+REASON_HIGH_FAILURE = "high-failure-rate"
+# Pre-confirmation label. confirm_disk_full() promotes it to REASON_DISK_FULL or
+# demotes it to REASON_HIGH_FAILURE.
+REASON_DISK_FULL_SUSPECT = "disk-full-suspect"
+
+ACTIONABLE_REASONS = (REASON_DISK_FULL, REASON_SILENT_WEDGE)
+
+
+# --------------------------------------------------------------------------
+# Buildkite API
+# --------------------------------------------------------------------------
+
+
+def buildkite_token() -> str:
+    """Read the API token from the environment, else borrow the bk CLI's.
+
+    Deliberately does not reach into Secret Manager: this runs as whoever is
+    driving the loop, under their own Buildkite identity.
+    """
+    token = os.environ.get("BUILDKITE_API_TOKEN", "").strip()
+    if token:
+        return token
+    if shutil.which("bk"):
+        result = subprocess.run(
+            ["bk", "auth", "token"], capture_output=True, text=True, check=False
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    raise SystemExit(
+        "No Buildkite credentials. Set BUILDKITE_API_TOKEN or run `bk auth login`."
+    )
+
+
+def api_get(path: str, token: str, **params: Any) -> Any:
+    url = f"{API_ROOT}{path}"
+    if params:
+        url = f"{url}?{urllib.parse.urlencode(params)}"
+    request = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", "replace")[:200]
+        raise SystemExit(f"Buildkite API {error.code} for {path}: {detail}") from error
+
+
+def fetch_agents(token: str) -> list[dict[str, Any]]:
+    agents: list[dict[str, Any]] = []
+    for page in range(1, 11):
+        batch = api_get(f"/organizations/{ORG}/agents", token, per_page=100, page=page)
+        if not batch:
+            break
+        agents.extend(batch)
+        if len(batch) < 100:
+            break
+    return agents
+
+
+def fetch_jobs(
+    token: str, window_hours: float, now: dt.datetime
+) -> list[dict[str, Any]]:
+    """Return jobs from recent builds, each tagged with the agent that ran it.
+
+    Buildkite has no per-agent job history endpoint, so the only way to see what
+    an agent has been doing is to walk recent builds and group by
+    `job.agent.name`. Builds created before the window can still hold jobs that
+    finished inside it, so reach back further than the window itself.
+    """
+    created_from = now - dt.timedelta(hours=window_hours * 2)
+    jobs: list[dict[str, Any]] = []
+    for page in range(1, 21):
+        builds = api_get(
+            f"/organizations/{ORG}/builds",
+            token,
+            per_page=100,
+            page=page,
+            created_from=created_from.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        )
+        if not builds:
+            break
+        for build in builds:
+            for job in build.get("jobs") or []:
+                agent = job.get("agent") or {}
+                if agent.get("name"):
+                    job["_agent_name"] = agent["name"]
+                    jobs.append(job)
+        if len(builds) < 100:
+            break
+    return jobs
+
+
+def fetch_job_log(token: str, job: dict[str, Any]) -> str:
+    """Fetch a job's log, or "" when it is unavailable."""
+    url = job.get("log_url") or ""
+    if not url.startswith(API_ROOT):
+        return ""
+    try:
+        payload = api_get(url[len(API_ROOT) :], token)
+    except SystemExit:
+        return ""
+    return payload.get("content", "") if isinstance(payload, dict) else ""
+
+
+# --------------------------------------------------------------------------
+# Analysis
+# --------------------------------------------------------------------------
+
+
+def utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def parse_time(value: Any) -> dt.datetime | None:
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def hours_since(value: Any, now: dt.datetime) -> float | None:
+    moment = parse_time(value)
+    return None if moment is None else (now - moment).total_seconds() / 3600.0
+
+
+@dataclass
+class AgentStats:
+    name: str
+    queue: str
+    agent_id: str
+    hostname: str
+    connected_hours: float | None
+    has_running_job: bool
+    total_jobs: int = 0
+    failed_jobs: int = 0
+    median_fail_seconds: float | None = None
+    recent_failures: list[dict[str, Any]] = field(default_factory=list)
+    reason: str | None = None
+    evidence: str = ""
+    log_excerpt: str = ""
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def failure_rate(self) -> float:
+        return self.failed_jobs / self.total_jobs if self.total_jobs else 0.0
+
+
+def agent_queue(agent: dict[str, Any]) -> str:
+    for entry in agent.get("meta_data") or []:
+        if isinstance(entry, str) and entry.startswith("queue="):
+            return entry[len("queue=") :]
+    return agent.get("queue") or "(none)"
+
+
+def build_stats(
+    agents: list[dict[str, Any]],
+    jobs: list[dict[str, Any]],
+    window_hours: float,
+    now: dt.datetime,
+) -> list[AgentStats]:
+    by_agent: dict[str, list[dict[str, Any]]] = {}
+    for job in jobs:
+        finished = hours_since(job.get("finished_at"), now)
+        if finished is None or finished > window_hours:
+            continue
+        if job.get("state") not in TERMINAL_JOB_STATES:
+            continue
+        by_agent.setdefault(job["_agent_name"], []).append(job)
+
+    stats: list[AgentStats] = []
+    for agent in agents:
+        name = agent.get("name") or ""
+        entry = AgentStats(
+            name=name,
+            queue=agent_queue(agent),
+            agent_id=agent.get("id") or "",
+            hostname=agent.get("hostname") or "",
+            connected_hours=hours_since(agent.get("connected_at"), now),
+            has_running_job=bool(agent.get("job")),
+        )
+        agent_jobs = sorted(
+            by_agent.get(name, []), key=lambda job: job.get("finished_at") or ""
+        )
+        entry.total_jobs = len(agent_jobs)
+        failures = [job for job in agent_jobs if job.get("state") != "passed"]
+        entry.failed_jobs = len(failures)
+        durations = []
+        for job in failures:
+            started = parse_time(job.get("started_at"))
+            finished_at = parse_time(job.get("finished_at"))
+            if started and finished_at:
+                durations.append((finished_at - started).total_seconds())
+        if durations:
+            entry.median_fail_seconds = statistics.median(durations)
+        entry.recent_failures = list(reversed(failures))[:MAX_LOGS_PER_AGENT]
+        stats.append(entry)
+    return stats
+
+
+def classify(stats: list[AgentStats]) -> list[AgentStats]:
+    """Tag each agent with a failure mode. Returns only the flagged ones.
+
+    Disk-full comes back as REASON_DISK_FULL_SUSPECT; only confirm_disk_full()
+    can promote it, because a high failure rate on its own is equally well
+    explained by flaky tests or a broken pipeline.
+    """
+    # A quiet queue tells us nothing about its members, so compare every agent
+    # against its own queue rather than a global baseline. Without this an
+    # overnight lull flags an entire fleet.
+    active_queues = {entry.queue for entry in stats if entry.total_jobs > 0}
+
+    flagged: list[AgentStats] = []
+    for entry in stats:
+        if (
+            entry.total_jobs >= MIN_JOBS_FOR_RATE
+            and entry.failed_jobs >= MIN_FAILURES_FOR_LOG_CHECK
+            and entry.failure_rate >= FAILURE_RATE_THRESHOLD
+        ):
+            entry.reason = REASON_DISK_FULL_SUSPECT
+            entry.evidence = (
+                f"{entry.failed_jobs}/{entry.total_jobs} jobs failed "
+                f"({entry.failure_rate:.0%})"
+            )
+            if entry.median_fail_seconds is not None:
+                entry.evidence += f", median failure {entry.median_fail_seconds:.0f}s"
+            flagged.append(entry)
+            continue
+
+        if (
+            entry.total_jobs == 0
+            and entry.queue in active_queues
+            and entry.connected_hours is not None
+            and entry.connected_hours >= WEDGE_MIN_HOURS
+        ):
+            entry.reason = REASON_SILENT_WEDGE
+            entry.evidence = (
+                f"0 jobs in window while queue {entry.queue} was active; "
+                f"connected {entry.connected_hours:.1f}h"
+            )
+            flagged.append(entry)
+    return flagged
+
+
+def find_disk_full_marker(log: str) -> str:
+    """Return a one-line excerpt around the first ENOSPC marker, else ""."""
+    lowered = log.lower()
+    for marker in DISK_FULL_MARKERS:
+        index = lowered.find(marker)
+        if index >= 0:
+            return " ".join(log[max(0, index - 140) : index + 140].split())
+    return ""
+
+
+def confirm_disk_full(token: str, entry: AgentStats, fetch=fetch_job_log) -> None:
+    """Resolve a disk-full suspect by reading its recent failure logs.
+
+    Only a log marker convicts. Without one the agent is downgraded to
+    REASON_HIGH_FAILURE, which is reported but never auto-remediated.
+    """
+    if entry.reason != REASON_DISK_FULL_SUSPECT:
+        return
+    for job in entry.recent_failures:
+        excerpt = find_disk_full_marker(fetch(token, job))
+        if excerpt:
+            entry.reason = REASON_DISK_FULL
+            entry.extra["confirmed"] = True
+            entry.log_excerpt = excerpt
+            return
+    entry.reason = REASON_HIGH_FAILURE
+    entry.extra["confirmed"] = False
+    entry.evidence += "; no ENOSPC marker in recent logs"
+
+
+def queue_guard(degraded: list[AgentStats], stats: list[AgentStats]) -> list[str]:
+    """Flag queues where too much is broken for a per-VM recreate to be right."""
+    sizes: dict[str, int] = {}
+    for entry in stats:
+        sizes[entry.queue] = sizes.get(entry.queue, 0) + 1
+    bad: dict[str, int] = {}
+    for entry in degraded:
+        bad[entry.queue] = bad.get(entry.queue, 0) + 1
+    blocked = []
+    for queue, count in sorted(bad.items()):
+        total = sizes.get(queue, 0)
+        # A lone bad agent is always worth recreating - that is the whole point
+        # of the tool - even on a queue of two, where any single agent trips the
+        # fraction. Only a pattern of several is suspicious.
+        if count > 1 and total and count / total > MAX_QUEUE_DEGRADED_FRACTION:
+            blocked.append(
+                f"{queue}: {count}/{total} agents degraded "
+                f"(over {MAX_QUEUE_DEGRADED_FRACTION:.0%}) - looks like a "
+                "fleet-wide fault, not per-VM disk exhaustion"
+            )
+    return blocked
+
+
+# --------------------------------------------------------------------------
+# Terraform mapping
+# --------------------------------------------------------------------------
+
+
+def terraform_state(tf_root: Path, tf_dir: str) -> dict[str, Any]:
+    if not shutil.which("terraform"):
+        raise SystemExit("terraform is not on PATH; cannot resolve addresses")
+    result = subprocess.run(
+        ["terraform", f"-chdir={tf_dir}", "state", "pull"],
+        cwd=tf_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"terraform state pull failed in {tf_dir}:\n{result.stderr.strip()}"
+        )
+    return json.loads(result.stdout)
+
+
+def find_in_state(state: dict[str, Any], names: list[str]) -> tuple[str, int] | None:
+    """Return (module, index) for the first instance resource matching a name.
+
+    The fleets follow a name SSOT: the Buildkite agent, the VM, and its boot
+    disk all share one name. Reading state instead of hardcoding a regex per
+    fleet means new fleets work without editing this file.
+    """
+    wanted = {name for name in names if name}
+    for resource in state.get("resources", []):
+        if resource.get("mode") != "managed":
+            continue
+        if resource.get("type") not in TF_INSTANCE_TYPES:
+            continue
+        for instance in resource.get("instances", []):
+            attributes = instance.get("attributes") or {}
+            if attributes.get("name") not in wanted:
+                continue
+            index = instance.get("index_key")
+            if isinstance(index, int):
+                return resource.get("module", ""), index
+    return None
+
+
+def resolve_agent(
+    tf_root: Path, tf_dirs: list[str], names: list[str]
+) -> tuple[str, str, int]:
+    """Search each fleet's state for the VM. Returns (tf_dir, module, index)."""
+    for tf_dir in tf_dirs:
+        found = find_in_state(terraform_state(tf_root, tf_dir), names)
+        if found is None:
+            continue
+        module, index = found
+        if not module:
+            raise SystemExit(
+                f"{names[0]} is a root-level resource in {tf_dir}; "
+                "rolling_restart.py only targets modules."
+            )
+        return tf_dir, module, index
+    raise SystemExit(
+        f"No Terraform instance named any of {sorted(n for n in names if n)} "
+        f"in {', '.join(tf_dirs)}."
+    )
+
+
+# --------------------------------------------------------------------------
+# Commands
+# --------------------------------------------------------------------------
+
+
+def describe(entry: AgentStats) -> dict[str, Any]:
+    return {
+        "agent": entry.name,
+        "queue": entry.queue,
+        "agent_id": entry.agent_id,
+        "reason": entry.reason,
+        "evidence": entry.evidence,
+        "log_excerpt": entry.log_excerpt,
+        "has_running_job": entry.has_running_job,
+        "total_jobs": entry.total_jobs,
+        "failed_jobs": entry.failed_jobs,
+        "median_fail_seconds": entry.median_fail_seconds,
+    }
+
+
+def report(
+    flagged: list[AgentStats], stats: list[AgentStats], now: dt.datetime
+) -> dict[str, Any]:
+    degraded = [e for e in flagged if e.reason in ACTIONABLE_REASONS]
+    other = [e for e in flagged if e.reason not in ACTIONABLE_REASONS]
+    return {
+        "checked_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "agents_scanned": len(stats),
+        "degraded_count": len(degraded),
+        "blocked_queues": queue_guard(degraded, stats),
+        "degraded": [describe(entry) for entry in degraded],
+        # Reported for a human to eyeball, never auto-remediated.
+        "needs_review": [describe(entry) for entry in other],
+    }
+
+
+def print_human(payload: dict[str, Any]) -> None:
+    print(
+        f"Scanned {payload['agents_scanned']} agents at {payload['checked_at']}; "
+        f"{payload['degraded_count']} actionable, "
+        f"{len(payload['needs_review'])} needing review."
+    )
+    for warning in payload["blocked_queues"]:
+        print(f"  !! BLOCKED {warning}")
+    for heading, items in (
+        ("ACTIONABLE", payload["degraded"]),
+        ("NEEDS REVIEW (not auto-remediated)", payload["needs_review"]),
+    ):
+        if not items:
+            continue
+        print(f"\n{heading}")
+        for item in items:
+            print(f"\n  {item['agent']}  [{item['reason']}]")
+            print(f"    queue:    {item['queue']}")
+            print(f"    evidence: {item['evidence']}")
+            if item["log_excerpt"]:
+                print(f"    log:      ...{item['log_excerpt']}...")
+            if item["has_running_job"]:
+                print("    note:     currently holds a job")
+
+
+def analyze(
+    token: str, window_hours: float, now: dt.datetime
+) -> tuple[list[AgentStats], list[AgentStats], list[dict[str, Any]]]:
+    """Scan the cluster. Returns (flagged, all stats, raw agent records)."""
+    agents = fetch_agents(token)
+    jobs = fetch_jobs(token, window_hours, now)
+    stats = build_stats(agents, jobs, window_hours, now)
+    flagged = classify(stats)
+    for entry in flagged:
+        confirm_disk_full(token, entry)
+    return flagged, stats, agents
+
+
+def command_scan(args: argparse.Namespace) -> int:
+    now = utcnow()
+    flagged, stats, _ = analyze(buildkite_token(), args.window_hours, now)
+    payload = report(flagged, stats, now)
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print_human(payload)
+    return 0
+
+
+def replace_disks_for(reason: str, override: bool | None) -> bool:
+    """Decide whether the attached data disk goes with the instance.
+
+    The TPU fleets attach a separate google_compute_disk at /mnt/disks/persist
+    for models and caches. It is not auto_delete, and the startup script only
+    formats it `if ! blkid`, so an instance-only replace hands the new VM back
+    the same full disk and the agent comes straight back degraded. Disk-full
+    therefore has to take the disk with it.
+
+    A wedged agent's disk is fine, so keep it: reformatting costs every cached
+    model on the host and a slow first few jobs.
+    """
+    if override is not None:
+        return override
+    return reason == REASON_DISK_FULL
+
+
+def command_resolve(args: argparse.Namespace) -> int:
+    token = buildkite_token()
+    agent = next((a for a in fetch_agents(token) if a.get("name") == args.agent), None)
+    if agent is None:
+        raise SystemExit(f"No connected agent named {args.agent}")
+    # Legacy fleets predate the name SSOT, so the agent name and the VM name can
+    # differ; the agent's hostname is the VM name in that case.
+    names = [args.agent, agent.get("hostname", "")]
+    tf_dir, module, index = resolve_agent(args.tf_root, args.dir, names)
+    print(f"agent:    {args.agent}")
+    print(f"state:    {tf_dir}")
+    print(f"module:   {module}, index {index}")
+    print(f"cwd:      {args.tf_root}")
+    base = f"./scripts/rolling_restart.py -m {module} -i {index} --dir {tf_dir}"
+    print(f"wedged:   {base}")
+    print(f"disk-full: {base} -d")
+    return 0
+
+
+def command_recreate(args: argparse.Namespace) -> int:
+    token = buildkite_token()
+    now = utcnow()
+    flagged, stats, agents = analyze(token, args.window_hours, now)
+    agent = next((a for a in agents if a.get("name") == args.agent), None)
+    if agent is None:
+        raise SystemExit(f"No connected agent named {args.agent}")
+
+    degraded = [e for e in flagged if e.reason in ACTIONABLE_REASONS]
+    entry = next((e for e in degraded if e.name == args.agent), None)
+
+    if entry is None and not args.force:
+        current = next((e.reason for e in flagged if e.name == args.agent), "healthy")
+        raise SystemExit(
+            f"{args.agent} is not actionable (currently: {current}). "
+            "Re-run `scan`, or pass --force to override."
+        )
+    reason = entry.reason if entry else "forced"
+
+    blocked = queue_guard(degraded, stats)
+    if blocked and not args.force:
+        raise SystemExit("Refusing to act:\n  " + "\n  ".join(blocked))
+
+    # A disk-full agent fails whatever it is holding anyway, so waiting for its
+    # job to finish protects nothing and just prolongs the outage. A wedged
+    # agent is different: if it somehow holds a real job, killing the VM throws
+    # away work that would otherwise have completed.
+    if reason != REASON_DISK_FULL and agent.get("job") and not args.force:
+        raise SystemExit(
+            f"{args.agent} is running a job and the reason is {reason}. "
+            "Wait for it to finish, or pass --force."
+        )
+
+    names = [args.agent, agent.get("hostname", "")]
+    tf_dir, module, index = resolve_agent(args.tf_root, args.dir, names)
+    command = [args.rolling_restart, "-m", module, "-i", str(index), "--dir", tf_dir]
+    if replace_disks_for(reason, args.replace_disks):
+        command.append("--replace-disks")
+    command.append("--non-interactive")
+    command.append("--dry-run" if args.dry_run else "--auto-approve")
+
+    print(f"agent {args.agent} [{reason}] -> {module} index {index} in {tf_dir}")
+    print("running:", " ".join(command), f"(cwd={args.tf_root})")
+    return subprocess.run(command, cwd=args.tf_root, check=False).returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--window-hours",
+        type=float,
+        default=24.0,
+        help="How far back to look at job history (default: 24)",
+    )
+    parser.add_argument(
+        "--tf-root",
+        type=Path,
+        default=DEFAULT_TF_ROOT,
+        help="Directory holding scripts/rolling_restart.py "
+        f"(default: {DEFAULT_TF_ROOT})",
+    )
+    parser.add_argument(
+        "--dir",
+        action="append",
+        metavar="TF_DIR",
+        help="Terraform config dir to search; repeatable "
+        f"(default: {', '.join(DEFAULT_TF_DIRS)})",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    scan = subparsers.add_parser("scan", help="Report degraded agents (read-only)")
+    scan.add_argument("--json", action="store_true", help="Emit JSON")
+    scan.set_defaults(func=command_scan)
+
+    resolve = subparsers.add_parser(
+        "resolve", help="Map an agent onto its Terraform module and index"
+    )
+    resolve.add_argument("agent")
+    resolve.set_defaults(func=command_resolve)
+
+    recreate = subparsers.add_parser("recreate", help="Replace a degraded agent's VM")
+    recreate.add_argument("agent")
+    recreate.add_argument(
+        "--rolling-restart",
+        default="./scripts/rolling_restart.py",
+        help="Path to rolling_restart.py, relative to --tf-root",
+    )
+    recreate.add_argument("--dry-run", action="store_true")
+    recreate.add_argument(
+        "--replace-disks",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Also replace the attached data disk "
+        "(default: yes for disk-full, no otherwise)",
+    )
+    recreate.add_argument(
+        "--force",
+        action="store_true",
+        help="Skip the degraded, blast-radius, and running-job checks",
+    )
+    recreate.set_defaults(func=command_recreate)
+
+    args = parser.parse_args(argv)
+    args.dir = args.dir or list(DEFAULT_TF_DIRS)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/terraform/gcp_old/tpu-inference/skills/agent-health/scripts/test_agent_health.py
+++ b/terraform/gcp_old/tpu-inference/skills/agent-health/scripts/test_agent_health.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import datetime as dt
+
+import agent_health as ah
+
+NOW = dt.datetime(2026, 9, 2, 12, 0, tzinfo=dt.timezone.utc)
+
+
+def iso(hours_ago: float) -> str:
+    moment = NOW - dt.timedelta(hours=hours_ago)
+    return moment.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def make_agent(
+    name, queue="cpu_64_core", connected_hours=48.0, job=None, hostname=None
+):
+    return {
+        "id": f"id-{name}",
+        "name": name,
+        "hostname": hostname or name,
+        "connected_at": iso(connected_hours),
+        "connection_state": "connected",
+        "paused": False,
+        "job": job,
+        "meta_data": [f"queue={queue}"],
+    }
+
+
+def make_job(agent, state, finished_hours_ago=1.0, duration_seconds=600):
+    finished = NOW - dt.timedelta(hours=finished_hours_ago)
+    started = finished - dt.timedelta(seconds=duration_seconds)
+    return {
+        "_agent_name": agent,
+        "state": state,
+        "started_at": started.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+        "finished_at": finished.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+        "log_url": f"{ah.API_ROOT}/jobs/{agent}-{finished_hours_ago}/log",
+    }
+
+
+def classify_names(agents, jobs, window=24.0):
+    stats = ah.build_stats(agents, jobs, window, NOW)
+    return {entry.name: entry.reason for entry in ah.classify(stats)}
+
+
+def resolve_names(agents, jobs, logs, window=24.0):
+    """Classify, then run log confirmation against a canned log per agent."""
+    stats = ah.build_stats(agents, jobs, window, NOW)
+    flagged = ah.classify(stats)
+    for entry in flagged:
+        ah.confirm_disk_full(
+            "token",
+            entry,
+            fetch=lambda _token, job: logs.get(job["_agent_name"], ""),
+        )
+    return {entry.name: entry.reason for entry in flagged}, stats, flagged
+
+
+# -- disk-full ------------------------------------------------------------
+
+ENOSPC_DOCKER = (
+    "failed to copy: httpReadSeeker: failed open: "
+    "write /var/lib/docker/tmp/x: no space left on device\n"
+)
+ENOSPC_MODEL = (
+    "Traceback (most recent call last):\n"
+    "  File huggingface_hub/file_download.py, line 1, in http_get\n"
+    "OSError: [Errno 28] No space left on device\n"
+)
+ENOSPC_HF_TRANSFER = "Error: Not enough free disk space to download the model\n"
+FLAKY_LOG = "FAILED tests/test_attention.py::test_paged - AssertionError\n"
+
+
+def test_docker_pull_enospc_is_disk_full():
+    agents = [make_agent("bad"), make_agent("good")]
+    jobs = [make_job("bad", "failed", i, duration_seconds=45) for i in range(1, 9)]
+    jobs += [make_job("good", "passed", i) for i in range(1, 9)]
+    reasons, _, _ = resolve_names(agents, jobs, {"bad": ENOSPC_DOCKER})
+    assert reasons == {"bad": ah.REASON_DISK_FULL}
+
+
+def test_slow_model_download_enospc_is_still_disk_full():
+    """A model download churns for minutes before it runs out of room, so
+    failure timing must not gate detection."""
+    agents = [make_agent("bad"), make_agent("good")]
+    jobs = [make_job("bad", "failed", i, duration_seconds=1800) for i in range(1, 9)]
+    jobs += [make_job("good", "passed", i) for i in range(1, 9)]
+    reasons, _, _ = resolve_names(agents, jobs, {"bad": ENOSPC_MODEL})
+    assert reasons == {"bad": ah.REASON_DISK_FULL}
+
+
+def test_hf_transfer_wording_is_recognised():
+    agents = [make_agent("bad"), make_agent("good")]
+    jobs = [make_job("bad", "failed", i, duration_seconds=1200) for i in range(1, 9)]
+    jobs += [make_job("good", "passed", i) for i in range(1, 9)]
+    reasons, _, _ = resolve_names(agents, jobs, {"bad": ENOSPC_HF_TRANSFER})
+    assert reasons == {"bad": ah.REASON_DISK_FULL}
+
+
+def test_failures_without_enospc_are_not_actionable():
+    """Flaky tests look identical on the counters; only the log separates them."""
+    agents = [make_agent("flaky"), make_agent("good")]
+    jobs = [make_job("flaky", "failed", i, duration_seconds=900) for i in range(1, 9)]
+    jobs += [make_job("good", "passed", i) for i in range(1, 9)]
+    reasons, _, flagged = resolve_names(agents, jobs, {"flaky": FLAKY_LOG})
+    assert reasons == {"flaky": ah.REASON_HIGH_FAILURE}
+    assert not [e for e in flagged if e.reason in ah.ACTIONABLE_REASONS]
+
+
+def test_unreachable_logs_do_not_convict():
+    agents = [make_agent("bad"), make_agent("good")]
+    jobs = [make_job("bad", "failed", i, duration_seconds=45) for i in range(1, 9)]
+    jobs += [make_job("good", "passed", i) for i in range(1, 9)]
+    reasons, _, _ = resolve_names(agents, jobs, {})
+    assert reasons == {"bad": ah.REASON_HIGH_FAILURE}
+
+
+def test_a_single_failure_is_noise():
+    agents = [make_agent("bad"), make_agent("good")]
+    jobs = [make_job("bad", "failed", 1, duration_seconds=20)]
+    jobs += [make_job("bad", "passed", i) for i in range(2, 9)]
+    jobs += [make_job("good", "passed", i) for i in range(1, 9)]
+    assert classify_names(agents, jobs) == {}
+
+
+def test_log_check_reads_the_newest_failures_first():
+    """The oldest failure may predate the disk filling up."""
+    agents = [make_agent("bad"), make_agent("good")]
+    jobs = [make_job("bad", "failed", i, duration_seconds=45) for i in range(1, 9)]
+    jobs += [make_job("good", "passed", i) for i in range(1, 9)]
+    stats = ah.build_stats(agents, jobs, 24.0, NOW)
+    entry = next(e for e in stats if e.name == "bad")
+    assert len(entry.recent_failures) == ah.MAX_LOGS_PER_AGENT
+    assert (
+        entry.recent_failures[0]["finished_at"]
+        > entry.recent_failures[-1]["finished_at"]
+    )
+
+
+def test_find_disk_full_marker_returns_context():
+    excerpt = ah.find_disk_full_marker(ENOSPC_MODEL)
+    assert "Errno 28" in excerpt
+    assert "\n" not in excerpt
+
+
+def test_find_disk_full_marker_ignores_ordinary_logs():
+    assert ah.find_disk_full_marker(FLAKY_LOG) == ""
+
+
+# -- silent wedge ---------------------------------------------------------
+
+
+def test_idle_agent_in_busy_queue_is_wedged():
+    agents = [make_agent("wedged"), make_agent("busy")]
+    jobs = [make_job("busy", "passed", i) for i in range(1, 9)]
+    assert classify_names(agents, jobs) == {"wedged": ah.REASON_SILENT_WEDGE}
+
+
+def test_quiet_queue_flags_nobody():
+    """An overnight lull must not flag the whole fleet."""
+    agents = [make_agent("a"), make_agent("b"), make_agent("c")]
+    assert classify_names(agents, []) == {}
+
+
+def test_freshly_booted_agent_is_not_wedged():
+    agents = [make_agent("new", connected_hours=0.5), make_agent("busy")]
+    jobs = [make_job("busy", "passed", i) for i in range(1, 9)]
+    assert classify_names(agents, jobs) == {}
+
+
+def test_jobs_outside_the_window_do_not_count():
+    agents = [make_agent("stale"), make_agent("busy")]
+    jobs = [make_job("stale", "passed", 40)]
+    jobs += [make_job("busy", "passed", i) for i in range(1, 9)]
+    assert classify_names(agents, jobs) == {"stale": ah.REASON_SILENT_WEDGE}
+
+
+def test_queues_are_scored_independently():
+    """A busy cpu queue must not make a genuinely quiet tpu queue look wedged."""
+    agents = [make_agent("cpu-0", "cpu"), make_agent("tpu-0", "tpu_v6e_1")]
+    jobs = [make_job("cpu-0", "passed", i) for i in range(1, 9)]
+    assert classify_names(agents, jobs) == {}
+
+
+# -- guards ---------------------------------------------------------------
+
+
+def test_queue_guard_blocks_a_broadly_broken_queue():
+    agents = [make_agent(f"a{i}", "cpu") for i in range(4)]
+    jobs = []
+    for i in range(4):
+        jobs += [
+            make_job(f"a{i}", "failed", h, duration_seconds=30) for h in range(1, 9)
+        ]
+    logs = {f"a{i}": ENOSPC_DOCKER for i in range(4)}
+    _, stats, flagged = resolve_names(agents, jobs, logs)
+    degraded = [e for e in flagged if e.reason in ah.ACTIONABLE_REASONS]
+    assert len(degraded) == 4
+    assert ah.queue_guard(degraded, stats), "4/4 degraded should block"
+
+
+def test_queue_guard_never_blocks_on_one_agent_however_small_the_queue():
+    agents = [make_agent("a0", "cpu"), make_agent("a1", "cpu")]
+    jobs = [make_job("a0", "failed", h, duration_seconds=30) for h in range(1, 9)]
+    jobs += [make_job("a1", "passed", h) for h in range(1, 9)]
+    _, stats, flagged = resolve_names(agents, jobs, {"a0": ENOSPC_DOCKER})
+    degraded = [e for e in flagged if e.reason in ah.ACTIONABLE_REASONS]
+    assert [e.name for e in degraded] == ["a0"]
+    assert ah.queue_guard(degraded, stats) == []
+
+
+def test_queue_guard_allows_a_single_bad_agent():
+    agents = [make_agent(f"a{i}", "cpu") for i in range(8)]
+    jobs = [make_job("a0", "failed", h, duration_seconds=30) for h in range(1, 9)]
+    for i in range(1, 8):
+        jobs += [make_job(f"a{i}", "passed", h) for h in range(1, 9)]
+    _, stats, flagged = resolve_names(agents, jobs, {"a0": ENOSPC_DOCKER})
+    degraded = [e for e in flagged if e.reason in ah.ACTIONABLE_REASONS]
+    assert [e.name for e in degraded] == ["a0"]
+    assert ah.queue_guard(degraded, stats) == []
+
+
+# -- terraform mapping ----------------------------------------------------
+
+
+STATE = {
+    "resources": [
+        {
+            "mode": "managed",
+            "type": "google_compute_instance",
+            "name": "ci_cpu_64_core",
+            "module": "module.ci_cpu_64_core_zone_c",
+            "instances": [
+                {"index_key": 0, "attributes": {"name": "vllm-ci-cpu-64-core-0"}},
+                {"index_key": 6, "attributes": {"name": "vllm-ci-cpu-64-core-6"}},
+            ],
+        },
+        {
+            "mode": "data",
+            "type": "google_compute_instance",
+            "name": "decoy",
+            "module": "module.other",
+            "instances": [
+                {"index_key": 0, "attributes": {"name": "vllm-ci-cpu-64-core-6"}}
+            ],
+        },
+    ]
+}
+
+
+def test_find_in_state_maps_name_to_module_and_index():
+    assert ah.find_in_state(STATE, ["vllm-ci-cpu-64-core-6"]) == (
+        "module.ci_cpu_64_core_zone_c",
+        6,
+    )
+
+
+def test_find_in_state_falls_back_to_hostname():
+    assert ah.find_in_state(STATE, ["legacy-agent-name", "vllm-ci-cpu-64-core-0"]) == (
+        "module.ci_cpu_64_core_zone_c",
+        0,
+    )
+
+
+def test_find_in_state_returns_none_for_unknown_name():
+    assert ah.find_in_state(STATE, ["nope"]) is None
+
+
+# -- helpers and reporting ------------------------------------------------
+
+
+def test_agent_queue_reads_meta_data():
+    assert ah.agent_queue(make_agent("x", "tpu_v7x_8")) == "tpu_v7x_8"
+
+
+def test_agent_queue_falls_back():
+    assert ah.agent_queue({"queue": "cpu"}) == "cpu"
+    assert ah.agent_queue({}) == "(none)"
+
+
+def test_hours_since_handles_missing_and_bad_values():
+    assert ah.hours_since(None, NOW) is None
+    assert ah.hours_since("not a date", NOW) is None
+    assert ah.hours_since(iso(3), NOW) == 3.0
+
+
+def test_report_separates_actionable_from_review():
+    agents = [make_agent("full"), make_agent("flaky"), make_agent("good")]
+    jobs = [make_job("full", "failed", i, duration_seconds=45) for i in range(1, 9)]
+    jobs += [make_job("flaky", "failed", i, duration_seconds=900) for i in range(1, 9)]
+    jobs += [make_job("good", "passed", i) for i in range(1, 9)]
+    _, stats, flagged = resolve_names(
+        agents, jobs, {"full": ENOSPC_DOCKER, "flaky": FLAKY_LOG}
+    )
+    payload = ah.report(flagged, stats, NOW)
+    assert payload["agents_scanned"] == 3
+    assert [item["agent"] for item in payload["degraded"]] == ["full"]
+    assert [item["agent"] for item in payload["needs_review"]] == ["flaky"]
+    assert "8/8 jobs failed" in payload["degraded"][0]["evidence"]
+    assert payload["blocked_queues"] == []
+
+
+# -- disk replacement policy ----------------------------------------------
+
+
+def test_disk_full_takes_the_data_disk_with_it():
+    """The persist disk survives an instance-only replace, so it must go too."""
+    assert ah.replace_disks_for(ah.REASON_DISK_FULL, None) is True
+
+
+def test_wedge_keeps_the_data_disk():
+    assert ah.replace_disks_for(ah.REASON_SILENT_WEDGE, None) is False
+
+
+def test_explicit_override_wins_either_way():
+    assert ah.replace_disks_for(ah.REASON_DISK_FULL, False) is False
+    assert ah.replace_disks_for(ah.REASON_SILENT_WEDGE, True) is True


### PR DESCRIPTION
## Why

Degraded agents in the `tpu-commons` cluster keep reporting `connection_state: connected` and `paused: false`. The Buildkite queues page and `bk agent list` both show a green fleet while jobs are actively failing on those hosts. We find them by hand, after someone notices red PRs.

This adds a skill that judges agents from **job history** rather than agent state, and delegates the actual fix to the existing `rolling_restart.py`.

## Two failure modes, handled differently

**`disk-full`** — the agent keeps *winning* jobs and failing them on ENOSPC, so it never looks idle and no idleness check finds it. Observed on `tpu7x-8-ci-17`: 35 failures out of 97 jobs.

The disk can fill on a docker pull, a model download, a pip install or a build cache, and those fail anywhere from ~45s to many minutes apart — so failure *timing* is not a usable signal. Instead: a loose failure-rate pre-filter decides whose logs to read, and an **ENOSPC marker in an actual job log** is what convicts. `DISK_FULL_MARKERS` covers the kernel string, Python `[Errno 28]` (huggingface_hub), hf_transfer's `not enough free disk space`, and docker's `failed to register layer`.

A high failure rate with **no** marker is reported as `high-failure-rate` and never auto-remediated — flaky tests and a broken pipeline produce identical counters, and a VM replace fixes neither.

**`silent-wedge`** — the agent stops accepting work while its queue peers cycle normally. `vllm-ci-cpu-64-core-6` ran 0 jobs in a 40.9h window while its 7 peers ran 12–56; a recreate fixed it. Scored per queue, so an overnight lull cannot flag a whole fleet.

## Remediation choices worth reviewing

- **`disk-full` passes `-d/--replace-disks`.** `ci_v6e`/`ci_v7x`/`ci_v5`/`ci_v6`/`benchmark` attach a separate `google_compute_disk` at `/mnt/disks/persist` that is **not** `auto_delete`, and the startup script only formats it `if ! blkid`. An instance-only replace hands the new VM back the same full disk. `silent-wedge` withholds `-d` to keep the model cache.
- **`disk-full` does not wait for an in-flight job** — it would fail anyway, so waiting only prolongs the outage. `silent-wedge` does wait.
- **Blast-radius guard**: stops if >25% of a queue is degraded *and* more than one agent. That shape is a fleet-wide fault, not a per-VM one. A lone bad agent never trips it, whatever the queue size.
- **`recreate` re-runs the scan itself**, so a stale scan can't fire a replacement.

All guards are `--force`-bypassable for interactive use; the loop prompts explicitly tell the loop not to.

## Terraform mapping

Matches `attributes.name` from `terraform state pull` across the fleet directories, relying on the fleets' name SSOT, with the agent hostname as a fallback for legacy fleets. Reading state rather than hardcoding a name regex means new fleets need no change here.

## Two things to flag

1. **The lock-file commit is a prerequisite, not incidental.** The fleet `.terraform.lock.hcl` files only carried `h1:` hashes for one platform, so *any* Terraform command on Linux failed with "Required plugins are not installed". Fixed by recording linux_amd64 + both darwin arches. Hash additions only — no version changes, no removals.
2. **Source lives under `skills/`, not `.claude/`**, because the repo gitignores `.claude/`. `SKILL.md` documents a one-line local symlink for Claude Code discovery; nothing depends on it, since every command and prompt invokes the script by path.

## Usage

Driven by `/loop` rather than a timer — `references/loop-prompt.md` has three prompts at increasing autonomy (report-only → auto-fix disk-full only → fully autonomous). `references/detection.md` records the evidence behind each threshold, including the false positives that shaped them.

Auth is `BUILDKITE_API_TOKEN` or `bk auth token`, deliberately not Secret Manager, so it runs under whoever drives it.

## Validation

```
uv run ruff check scripts && uv run ruff format --check scripts && uv run pytest
27 passed
```

Live against the cluster:
- `scan` reads 10,464 jobs across 79 agents in ~16s; fleet currently healthy, 0 flagged (top failure rate 12%)
- `resolve tpu7x-8-ci-11-cicd-us-central1-c` → `module.ci_v7x_8` index 11 in `cloud-ullm-inference-ci-cd`
- forced `--dry-run` emits the correct `terraform apply -replace -target`
- verified identical behaviour through the real path and the `.claude` symlink

Nothing in this PR has been run against the fleet in write mode beyond the previously-agreed recreate of `vllm-ci-cpu-64-core-6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)