### PR TITLE
Make Buildkite GPU CDI startup timeout safe

### DIFF
--- a/scripts/AGENT.md
+++ b/scripts/AGENT.md
@@ -128,6 +128,12 @@ nvidia-smi
 docker run --rm --gpus all nvidia/cuda:12.8.0-base-ubuntu22.04 nvidia-smi
 ```
 
+Dedicated GPU Buildkite hosts should use the native CDI selector and agent
+pre-start refresh in [`buildkite-gpu-cdi/`](buildkite-gpu-cdi/README.md). Its
+guarded installer requires the agents to be paused and the Buildkite API,
+Docker, and GPU-process gates to be empty before it reloads systemd. Do not run
+that deployment while the host is accepting or executing jobs.
+
 For H200 MIG setup, see [`setup_mig_h200.sh`](setup_mig_h200.sh) and [`teardown_mig_h200.sh`](teardown_mig_h200.sh).
 
 ## 6. Configure and Start the Buildkite Agent

--- a/scripts/buildkite-gpu-cdi/README.md
+++ b/scripts/buildkite-gpu-cdi/README.md
@@ -1,0 +1,94 @@
+# Buildkite GPU CDI host rollout
+
+These files move Buildkite Docker-plugin jobs from the legacy NVIDIA `--gpus`
+hook to native CDI device requests. The agent pre-start regenerates the CDI spec
+so a current MIG topology is available before the agent accepts work.
+
+The drop-in sets `TimeoutStartSec=120`. On the 56-slice H200 layout,
+`nvidia-ctk cdi generate` has taken about 20 seconds; the base unit's 10-second
+timeout can otherwise trap the service in a restart loop.
+
+## Read-only audit
+
+`audit.sh` checks the effective timeout, pre-start command, hook, service state,
+and CDI inventory. It does not modify the host and can be run while jobs are
+active:
+
+```bash
+sudo scripts/buildkite-gpu-cdi/audit.sh
+```
+
+Do not regenerate CDI, reload systemd, or restart Docker or the agent merely to
+make an audit pass. Those operations require the drain below.
+
+## Drain and deploy
+
+Treat `systemctl daemon-reload`, `systemctl daemon-reexec`, Docker or agent
+restarts, NVIDIA toolkit/driver changes, and MIG topology changes as
+workload-disruptive.
+
+For one host at a time:
+
+1. Pause every Buildkite agent record on the host with a maintenance note and a
+   long enough `timeout_in_minutes` value.
+2. Wait for the Buildkite API to report zero assigned jobs.
+3. Verify both local gates are empty:
+
+   ```bash
+   docker ps -q
+   nvidia-smi --query-compute-apps=pid --format=csv,noheader
+   ```
+
+4. Run the guarded installer from this directory:
+
+   ```bash
+   sudo env \
+     CONFIRM_BUILDKITE_AGENTS_PAUSED=1 \
+     CONFIRM_BUILDKITE_API_JOBS_ZERO=1 \
+     ./deploy.sh
+   ```
+
+The installer checks the two explicit confirmations and both local zero-state
+gates before it writes the hook/drop-in, regenerates CDI, or calls
+`systemctl daemon-reload`. It fails before the reload if the checked-in timeout
+is below 120 seconds. It does not restart the agent.
+
+5. Keep the agents paused. Run `audit.sh`, then run the reload canary below.
+6. Remove the canary, prove the local gates are empty again, and only then
+   resume the agents. Preserve any pause that predates this maintenance.
+
+## Reload canary
+
+Use a cached CI image and the exact CDI selector assigned to the agent. On a
+MIG host, use a current MIG UUID present in both `nvidia-smi -L` and
+`nvidia-ctk cdi list`.
+
+```bash
+docker run -d --rm \
+  --name gpu-cdi-reload-canary \
+  --device "nvidia.com/gpu=${GPU_OR_MIG_SELECTOR}" \
+  --entrypoint bash "${CACHED_IMAGE}" -lc 'sleep infinity'
+
+docker exec gpu-cdi-reload-canary nvidia-smi -L >before.txt
+agent_pid_before="$(systemctl show buildkite-agent.service -p MainPID --value)"
+sudo systemctl daemon-reload
+docker exec gpu-cdi-reload-canary nvidia-smi -L >after.txt
+agent_pid_after="$(systemctl show buildkite-agent.service -p MainPID --value)"
+
+cmp before.txt after.txt
+test "${agent_pid_before}" = "${agent_pid_after}"
+docker rm -f gpu-cdi-reload-canary
+```
+
+Pass only when both `nvidia-smi` calls succeed, the visible GPU/MIG UUIDs are
+byte-identical, the agent PID is unchanged, and the host returns to zero test
+containers and GPU processes. Do not resume a failed canary host.
+
+## Rollback
+
+Rollback has the same pause, API-zero, container-zero, and GPU-process-zero
+requirements. Restore `/etc/buildkite-agent/hooks/environment.pre-cdi` (or
+remove only the exact CDI source line), remove the `gpu-cdi.conf` drop-in and
+selector helper, then run `systemctl daemon-reload` while the host remains
+drained. Resume only after documenting that legacy GPU jobs are again exposed
+to the daemon-reload device-loss behavior.

--- a/scripts/buildkite-gpu-cdi/audit.sh
+++ b/scripts/buildkite-gpu-cdi/audit.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly MIN_START_TIMEOUT_USEC=120000000
+readonly HOOK=/etc/buildkite-agent/hooks/environment
+readonly SOURCE_LINE='source /usr/local/libexec/buildkite-gpu-cdi-env.sh'
+
+failures=0
+
+check() {
+  local description=$1
+  shift
+  if "$@"; then
+    printf 'PASS: %s\n' "${description}"
+  else
+    printf 'FAIL: %s\n' "${description}" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+timeout_at_least_minimum() {
+  local timeout_usec=$1
+  local minimum_usec=$2
+  [[ "${timeout_usec}" =~ ^[0-9]+$ ]] &&
+    ((timeout_usec >= minimum_usec))
+}
+
+effective_timeout="$(
+  systemctl show buildkite-agent.service -p TimeoutStartUSec --value
+)"
+effective_timeout_usec="$({
+  LC_ALL=C systemd-analyze timespan "${effective_timeout}"
+} | awk '$1 == "us:" {print $2}')"
+
+check "Buildkite agent service is active" systemctl is-active --quiet buildkite-agent.service
+check "environment hook sources the CDI selector" grep -Fqx "${SOURCE_LINE}" "${HOOK}"
+check "CDI selector helper is executable" test -x /usr/local/libexec/buildkite-gpu-cdi-env.sh
+check "agent startup regenerates the NVIDIA CDI spec" \
+  bash -c "systemctl show buildkite-agent.service -p ExecStartPre --value | grep -Fq nvidia-ctk"
+check "effective startup timeout is at least 120 seconds (${effective_timeout})" \
+  timeout_at_least_minimum "${effective_timeout_usec}" "${MIN_START_TIMEOUT_USEC}"
+check "NVIDIA CDI inventory contains the all selector" \
+  bash -c "nvidia-ctk cdi list 2>/dev/null | grep -Fqx nvidia.com/gpu=all"
+
+((failures == 0)) || exit 1

--- a/scripts/buildkite-gpu-cdi/buildkite-gpu-cdi-env.sh
+++ b/scripts/buildkite-gpu-cdi/buildkite-gpu-cdi-env.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Use Docker's native CDI device injection instead of the legacy --gpus hook.
+# The legacy hook can lose GPU cgroup access after `systemctl daemon-reload`.
+cdi_selector="${BUILDKITE_PLUGIN_DOCKER_GPUS:-all}"
+cdi_selector="${cdi_selector#device=}"
+
+if [[ -n "${UUID:-}" ]]; then
+  cdi_selector="${UUID}"
+fi
+
+cdi_device="nvidia.com/gpu=${cdi_selector}"
+if ! nvidia-ctk cdi list 2>/dev/null | grep -Fqx "${cdi_device}"; then
+  echo "ERROR: CDI device ${cdi_device} is absent from the NVIDIA CDI spec" >&2
+  exit 1
+fi
+
+unset BUILDKITE_PLUGIN_DOCKER_GPUS
+export BUILDKITE_PLUGIN_DOCKER_DEVICES_0="${cdi_device}"

--- a/scripts/buildkite-gpu-cdi/buildkite-gpu-cdi.conf
+++ b/scripts/buildkite-gpu-cdi/buildkite-gpu-cdi.conf
@@ -1,0 +1,4 @@
+[Service]
+# MIG-heavy hosts can take about 20 seconds to regenerate the CDI inventory.
+TimeoutStartSec=120
+ExecStartPre=+/usr/bin/nvidia-ctk --quiet cdi generate --output=/var/run/cdi/nvidia.yaml

--- a/scripts/buildkite-gpu-cdi/deploy.sh
+++ b/scripts/buildkite-gpu-cdi/deploy.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly MIN_START_TIMEOUT_SECONDS=120
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+[[ "$(id -u)" -eq 0 ]] || die "run as root"
+[[ "${CONFIRM_BUILDKITE_AGENTS_PAUSED:-}" == 1 ]] ||
+  die "pause every host agent, then set CONFIRM_BUILDKITE_AGENTS_PAUSED=1"
+[[ "${CONFIRM_BUILDKITE_API_JOBS_ZERO:-}" == 1 ]] ||
+  die "verify zero assigned jobs in the Buildkite API, then set CONFIRM_BUILDKITE_API_JOBS_ZERO=1"
+
+if [[ -n "$(docker ps -q)" ]]; then
+  die "running containers remain; drain the host first"
+fi
+
+if nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null |
+  grep -q '[0-9]'; then
+  die "GPU compute processes remain; drain the host first"
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+hook=/etc/buildkite-agent/hooks/environment
+drop_in_dir=/etc/systemd/system/buildkite-agent.service.d
+drop_in="${drop_in_dir}/gpu-cdi.conf"
+source_line='source /usr/local/libexec/buildkite-gpu-cdi-env.sh'
+
+test -f "${script_dir}/buildkite-gpu-cdi-env.sh"
+test -f "${script_dir}/buildkite-gpu-cdi.conf"
+test -f "${hook}"
+
+configured_timeout_seconds="$({
+  sed -n 's/^TimeoutStartSec=\([0-9][0-9]*\)$/\1/p' \
+    "${script_dir}/buildkite-gpu-cdi.conf"
+} | tail -1)"
+[[ "${configured_timeout_seconds}" =~ ^[0-9]+$ ]] ||
+  die "buildkite-gpu-cdi.conf must set TimeoutStartSec in whole seconds"
+((configured_timeout_seconds >= MIN_START_TIMEOUT_SECONDS)) ||
+  die "TimeoutStartSec must be at least ${MIN_START_TIMEOUT_SECONDS} seconds"
+
+install -d -o root -g root -m 0755 /usr/local/libexec "${drop_in_dir}"
+install -o root -g root -m 0755 \
+  "${script_dir}/buildkite-gpu-cdi-env.sh" \
+  /usr/local/libexec/buildkite-gpu-cdi-env.sh
+install -o root -g root -m 0644 \
+  "${script_dir}/buildkite-gpu-cdi.conf" \
+  "${drop_in}"
+
+if ! grep -Fqx "${source_line}" "${hook}"; then
+  if [[ ! -e "${hook}.pre-cdi" ]]; then
+    cp -a "${hook}" "${hook}.pre-cdi"
+  fi
+  printf '\n%s\n' "${source_line}" >>"${hook}"
+fi
+
+nvidia-ctk --quiet cdi generate --output=/var/run/cdi/nvidia.yaml
+systemctl daemon-reload
+
+grep -Fqx "${source_line}" "${hook}"
+systemctl show buildkite-agent.service -p ExecStartPre --value |
+  grep -Fq 'nvidia-ctk'
+
+effective_timeout="$(
+  systemctl show buildkite-agent.service -p TimeoutStartUSec --value
+)"
+effective_timeout_usec="$({
+  LC_ALL=C systemd-analyze timespan "${effective_timeout}"
+} | awk '$1 == "us:" {print $2}')"
+[[ "${effective_timeout_usec}" =~ ^[0-9]+$ ]] ||
+  die "could not parse effective TimeoutStartSec: ${effective_timeout}"
+((effective_timeout_usec >= MIN_START_TIMEOUT_SECONDS * 1000000)) ||
+  die "effective TimeoutStartSec is below ${MIN_START_TIMEOUT_SECONDS} seconds"
+
+echo "CDI hook and ${effective_timeout} agent startup timeout installed; agent was not restarted"


### PR DESCRIPTION
## Why

On `h200-ci-5`, the Buildkite agent's CDI pre-start generation takes about
0:20, but the base unit allowed only 0:10 for startup. Systemd killed
`nvidia-ctk` repeatedly, reaching 1,026 restarts and leaving the `h200_18gb`
queue with no connected agents.

A drained hotfix setting `TimeoutStartSec=120` restored all 56 agents. The
remaining CDI hosts inherited the unsafe 0:10 timeout.

## What changed

- Check in the previously attachment-only CDI selector, systemd drop-in, and
  guarded installer as durable source.
- Set the effective Buildkite agent startup timeout to 2:00 alongside the CDI
  `ExecStartPre`.
- Require explicit confirmation that agents are paused and the Buildkite API
  reports zero assigned jobs, plus local zero-container and zero-GPU-process
  gates, before installing files or reloading systemd.
- Add a read-only audit that verifies the effective timeout, pre-start, hook,
  service, and CDI inventory.
- Document the one-host-at-a-time drain, deploy, reload canary, and rollback
  procedure.

## Validation

- `bash -n scripts/buildkite-gpu-cdi/*.sh`
- ShellCheck on all three shell scripts
- Pre-commit on all changed files
- `git diff --check`
- Read-only audit passes all checks on the repaired `h200-ci-5`
- The same audit fails specifically on the effective 0:10 timeout on an
  otherwise healthy CDI host

### Drained fleet rollout

The guarded source was hash-verified before installation on each host. Agents
were paused, the Buildkite API showed zero assigned jobs, and local container
and GPU-process counts were zero before each `daemon-reload`.

| Host | Effective timeout | CDI reload canary | Agent continuity | Final state |
| --- | --- | --- | --- | --- |
| `h200-ci-5` | 0:10 → 2:00 | Recovery host; audit 6/6 | 56 agents recovered | Active |
| `h200-ci-1` | 0:10 → 2:00 | Exact GPU UUID, `Driver=cdi`; `nvidia-smi -L` byte-identical | PID unchanged | Audit 6/6; 0 containers / 0 GPU processes before resume |
| `h200-ci-3` | 0:10 → 2:00 | Exact MIG UUID, `Driver=cdi`; `nvidia-smi -L` byte-identical | PID unchanged | Audit 6/6; 0 containers / 0 GPU processes before resume |
| `h200-ci-6` | 0:10 → 2:00 | Exact MIG UUID, `Driver=cdi`; `nvidia-smi -L` byte-identical | PID unchanged | Audit 6/6; 0 containers / 0 GPU processes before resume |
| `h200-ci-4` | 0:10 → 2:00 | Exact MIG UUID, `Driver=cdi`; `nvidia-smi -L` byte-identical | PID unchanged | Audit 6/6; 0 containers / 0 GPU processes before resume |
| `h200-ci-2` | 0:10 → 2:00 | Exact MIG UUID, `Driver=cdi`; `nvidia-smi -L` byte-identical | PID unchanged | Audit 6/6; 0 containers / 0 GPU processes before resume |

The six schedulable CI/MIG hosts are complete and back in service. `h200-0`
and `h200-1` still have long-lived owner-managed, all-GPU containers, so the
guarded installer correctly refuses to reload them. They are explicitly
deferred until their owners approve a drain; no active job or manually managed
workload is canceled by this rollout.

AI assistance was used. A human submitter must review every changed line and
validate the drained fleet rollout before merge.
