### PR TITLE
[CI] Retry valid steps when requested keys are missing

### DIFF
--- a/buildkite/pipeline_generator/README.md
+++ b/buildkite/pipeline_generator/README.md
@@ -80,7 +80,14 @@ The generator relies on several environment variables, typically provided by Bui
 *   `VLLM_USE_PRECOMPILED`: Set to "1" to force use of precompiled wheels.
 *   `VLLM_CI_ONLY_STEP_KEYS`: A non-empty JSON array of stable step keys. When
     set, the generator emits those steps and their transitive dependencies,
-    ignoring normal source-file selection. Unknown keys fail generation.
+    ignoring normal source-file selection. Derived AMD mirror keys such as
+    `amd-multi-modal-processor` are supported and select only the mirror plus
+    its AMD dependencies. Unknown keys fail generation.
+
+When generation fails for any reason on a Buildkite agent, the error is
+recorded as an `error` annotation under the `pipeline-generator-error` context.
+The vLLM CI command bot reads that annotation so `/ci retry` can report the
+cause on the pull request.
 
 Kubernetes-backed test jobs read `BUILDKITE_ANALYTICS_TOKEN` from the
 `buildkite-analytics-token-secret` Secret's `token` key when it is available.

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -594,7 +594,11 @@ def convert_group_step_to_buildkite_step(
         group_steps_list = []
         for step in steps:
             step_key = step.key or _generate_step_key(step.label)
+            only_step_keys = global_config["only_step_keys"]
+            include_step = only_step_keys is None or step_key in only_step_keys
             if is_amd_gpu_device(step.device):
+                if not include_step:
+                    continue
                 amd_commands = [f"export VLLM_TEST_GROUP_NAME={step_key}"]
                 amd_commands.extend(
                     _prepare_commands(
@@ -683,7 +687,7 @@ def convert_group_step_to_buildkite_step(
                     step.timeout_in_minutes
                 )
 
-            if not _step_should_run(step, list_file_diff):
+            if include_step and not _step_should_run(step, list_file_diff):
                 block_step = _create_block_step(
                     block=f"Run {step.label}",
                     key=f"block-{step_key}",
@@ -704,13 +708,15 @@ def convert_group_step_to_buildkite_step(
                 if step.device == DeviceType.L4 and not step.retry:
                     buildkite_step.retry = K8S_RETRY
 
-            group_steps_list.append(buildkite_step)
+            if include_step:
+                group_steps_list.append(buildkite_step)
 
             # Create AMD mirror step and its block step if specified/applicable
+            amd_mirror_key = f"amd-{step_key}"
             if (
                 step.mirror
                 and step.mirror.get("amd")
-                and global_config["only_step_keys"] is None
+                and (only_step_keys is None or amd_mirror_key in only_step_keys)
             ):
                 amd = step.mirror["amd"]
                 amd_no_plugin = amd.get("no_plugin", False)
@@ -752,7 +758,7 @@ def convert_group_step_to_buildkite_step(
                 extra_env.update(amd.get("env", {}))
                 amd_step = _create_amd_step(
                     label=step.label,
-                    key=f"amd-{step_key}",
+                    key=amd_mirror_key,
                     device=amd["device"],
                     num_devices=amd_num_devices,
                     commands_str=amd_commands_str,
@@ -772,7 +778,10 @@ def convert_group_step_to_buildkite_step(
                     agent_tags=amd.get("agent_tags"),
                     display_label=amd.get("label"),
                 )
-                if not _amd_mirror_should_run(
+                mirror_is_selected = (
+                    only_step_keys is not None and amd_mirror_key in only_step_keys
+                )
+                if not mirror_is_selected and not _amd_mirror_should_run(
                     _step_should_run(
                         _get_amd_mirror_effective_step(step, amd),
                         list_file_diff,

--- a/buildkite/pipeline_generator/main.py
+++ b/buildkite/pipeline_generator/main.py
@@ -1,5 +1,28 @@
+import os
+import subprocess
+
 import click
 from pipeline_generator import PipelineGenerator
+
+GENERATOR_ERROR_ANNOTATION_CONTEXT = "pipeline-generator-error"
+
+
+def annotate_generation_failure(message: str) -> None:
+    """Record a generation failure as a build annotation for CI tooling to read."""
+    if os.getenv("BUILDKITE") != "true":
+        return
+    subprocess.run(
+        [
+            "buildkite-agent",
+            "annotate",
+            message,
+            "--style",
+            "error",
+            "--context",
+            GENERATOR_ERROR_ANNOTATION_CONTEXT,
+        ],
+        check=False,
+    )
 
 
 @click.command()
@@ -11,7 +34,11 @@ from pipeline_generator import PipelineGenerator
 @click.option("--output_file_path", type=click.Path(), help="Path to the output file")
 def main(pipeline_config_path, output_file_path):
     pipeline_generator = PipelineGenerator(pipeline_config_path, output_file_path)
-    pipeline_generator.generate()
+    try:
+        pipeline_generator.generate()
+    except Exception as error:
+        annotate_generation_failure(f"Pipeline generation failed: {error}")
+        raise
 
 
 if __name__ == "__main__":

--- a/buildkite/pipeline_generator/pipeline_generator.py
+++ b/buildkite/pipeline_generator/pipeline_generator.py
@@ -4,6 +4,7 @@ from typing import FrozenSet, List, Optional, Tuple
 
 import yaml
 
+from amd import normalize_amd_depends_on
 from buildkite_step import (
     _generate_step_key,
     add_precommit_dependency,
@@ -93,6 +94,7 @@ def select_steps_and_dependencies(
         return steps, None
 
     steps_by_key = {}
+    dependencies_by_key = {}
     for step in steps:
         # Steps without an explicit key are uploaded with a label-derived key
         # (see convert_group_step_to_buildkite_step), so retry builds reference
@@ -102,6 +104,21 @@ def select_steps_and_dependencies(
         if step.key in steps_by_key:
             raise ValueError(f"Duplicate CI step key: {step.key}")
         steps_by_key[step.key] = step
+        dependencies_by_key[step.key] = step.depends_on or []
+
+        # AMD mirrors are minted later, in convert_group_step_to_buildkite_step,
+        # so their derived keys are registered here. Without this a retry that
+        # references a mirror cannot resolve it, because steps_by_key would only
+        # ever hold top-level YAML steps.
+        amd_mirror = (step.mirror or {}).get("amd")
+        if amd_mirror:
+            mirror_key = f"amd-{step.key}"
+            if mirror_key in steps_by_key:
+                raise ValueError(f"Duplicate CI step key: {mirror_key}")
+            steps_by_key[mirror_key] = step
+            dependencies_by_key[mirror_key] = normalize_amd_depends_on(
+                amd_mirror.get("depends_on")
+            )
 
     missing = requested_step_keys - steps_by_key.keys()
     if missing:
@@ -111,7 +128,7 @@ def select_steps_and_dependencies(
     pending = list(requested_step_keys)
     while pending:
         step_key = pending.pop()
-        for dependency in steps_by_key[step_key].depends_on or []:
+        for dependency in dependencies_by_key[step_key]:
             if dependency not in steps_by_key:
                 raise ValueError(
                     f"CI step {step_key} depends on unknown step {dependency}."
@@ -120,7 +137,10 @@ def select_steps_and_dependencies(
                 selected_step_keys.add(dependency)
                 pending.append(dependency)
 
-    selected = [step for step in steps if step.key in selected_step_keys]
+    # A mirror key and its parent key resolve to the same Step, so select by
+    # object identity rather than by key.
+    selected_step_ids = {id(steps_by_key[key]) for key in selected_step_keys}
+    selected = [step for step in steps if id(step) in selected_step_ids]
     return selected, frozenset(selected_step_keys)
 
 

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 import buildkite_step
+from main import GENERATOR_ERROR_ANNOTATION_CONTEXT, annotate_generation_failure
 from pipeline_generator import select_steps_and_dependencies
 from step import Step, group_steps, read_steps_from_job_dir
 
@@ -86,11 +87,11 @@ def test_selected_steps_include_transitive_dependencies():
     assert selected_keys == frozenset({"image-build", "prepare", "test"})
 
 
-def test_selected_steps_reject_unknown_key():
-    with pytest.raises(ValueError, match="Unknown CI step key.*missing"):
+def test_selected_steps_reject_unknown_keys():
+    with pytest.raises(ValueError, match="Unknown CI step key\\(s\\): missing"):
         select_steps_and_dependencies(
             [Step(label="Test", key="test", commands=["test"])],
-            frozenset({"missing"}),
+            frozenset({"test", "missing"}),
         )
 
 
@@ -117,6 +118,78 @@ def test_selected_steps_support_label_generated_keys():
     assert selected_keys == frozenset(
         {"image-build", "-nvidia--h200-rust-frontend-openai-coverage"}
     )
+
+
+def test_selected_steps_support_amd_mirror_keys(fake_global_config):
+    steps = [
+        Step(label="AMD image", key="image-build-amd", commands=["build"]),
+        Step(
+            label="Multimodal Processor",
+            group="Models - Multimodal",
+            key="multi-modal-processor",
+            commands=["test"],
+            mirror={
+                "amd": {
+                    "device": "mi355_1",
+                    "dind": False,
+                    "depends_on": ["image-build-amd"],
+                }
+            },
+        ),
+        Step(label="Other", key="other", commands=["other"]),
+    ]
+
+    selected, selected_keys = select_steps_and_dependencies(
+        steps, frozenset({"amd-multi-modal-processor"})
+    )
+    fake_global_config["only_step_keys"] = selected_keys
+    groups = buildkite_step.convert_group_step_to_buildkite_step(group_steps(selected))
+    generated_keys = [job.key for group in groups for job in group.steps]
+
+    assert [step.key for step in selected] == [
+        "image-build-amd",
+        "multi-modal-processor",
+    ]
+    assert selected_keys == frozenset({"image-build-amd", "amd-multi-modal-processor"})
+    assert generated_keys == ["image-build-amd", "amd-multi-modal-processor"]
+
+
+def test_generator_failure_is_annotated(monkeypatch):
+    calls = []
+    monkeypatch.setenv("BUILDKITE", "true")
+    monkeypatch.setattr(
+        "main.subprocess.run",
+        lambda command, check: calls.append((command, check)),
+    )
+
+    annotate_generation_failure(
+        "Pipeline generation failed: Unknown CI step key(s): removed-test"
+    )
+
+    assert calls[0] == (
+        [
+            "buildkite-agent",
+            "annotate",
+            "Pipeline generation failed: Unknown CI step key(s): removed-test",
+            "--style",
+            "error",
+            "--context",
+            GENERATOR_ERROR_ANNOTATION_CONTEXT,
+        ],
+        False,
+    )
+
+
+def test_generator_failure_is_not_annotated_outside_buildkite(monkeypatch):
+    calls = []
+    monkeypatch.delenv("BUILDKITE", raising=False)
+    monkeypatch.setattr(
+        "main.subprocess.run", lambda *args, **kwargs: calls.append(args)
+    )
+
+    annotate_generation_failure("Pipeline generation failed: boom")
+
+    assert calls == []
 
 
 def test_selected_steps_reject_duplicate_generated_key():


### PR DESCRIPTION
## Summary

- Register every declared AMD mirror as a selectable `amd-<source-key>` before filtered-key validation.
- Partition requested retry keys into valid and missing sets instead of rejecting the entire request when one key is missing.
- Generate valid jobs with their dependency closure.
- Publish one atomic `vllm-ci-retry-validation` metadata document containing valid and missing keys.
- Add a Buildkite warning annotation and a final failing validation step after valid jobs finish, so a partial retry cannot appear complete.

## Why

A cross-commit `/ci retry` on vllm-project/vllm#54557 forwarded `amd-multi-modal-processor`. The generator did not register generated AMD mirror keys during selection, so bootstrap rejected the entire retry and no otherwise-valid jobs ran.

This change supports every declared AMD mirror dynamically. If a future retry contains a genuinely removed key alongside valid keys, valid jobs still run while the build remains visibly incomplete.

Companion GitHub reporting change: vllm-project/vllm#55248.

## Tests

- Full pipeline-generator suite: 107 passed.
- Ruff lint passed on changed Python files.
- Current vLLM configuration validated and rendered all 89 declared AMD mirrors.
- Mixed-key test against current vLLM job YAML kept `multi-modal-processor`, skipped a synthetic removed key, and appended the final validation failure.