### PR TITLE
[CI] Point the v7x fleet at the vllm org token

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -112,8 +112,8 @@ module "ci_v7x_2" {
   disk_size                       = 2048
   project_id                      = var.project_id
   project_short_name              = var.project_short_name
-  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
-  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
+  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_vllm.secret_data
+  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_vllm.secret_data
   huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
 }
 
@@ -130,8 +130,8 @@ module "ci_v7x_8" {
   disk_size                       = 4096
   project_id                      = var.project_id
   project_short_name              = var.project_short_name
-  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
-  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
+  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_vllm.secret_data
+  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_vllm.secret_data
   huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
 }
 
@@ -147,8 +147,8 @@ module "ci_v7x_16" {
   buildkite_queue_name            = "tpu_v7x_16_queue"
   project_id                      = var.project_id
   project_short_name              = var.project_short_name
-  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
-  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
+  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_vllm.secret_data
+  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_vllm.secret_data
   huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
   # disk_size defaults to 0, disable attached disk
 }

--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -8,11 +8,6 @@ data "google_secret_manager_secret_version" "buildkite_agent_token_vllm" {
   version = "latest"
 }
 
-data "google_secret_manager_secret_version" "buildkite_analytics_token_ci_cluster" {
-  secret  = "projects/${var.secret_project_id}/secrets/tpu_commons_buildkite_analytics_token"
-  version = "latest"
-}
-
 data "google_secret_manager_secret_version" "buildkite_analytics_token_vllm" {
   secret  = "projects/${var.secret_project_id}/secrets/vllm_buildkite_analytics_token"
   version = "latest"
@@ -24,42 +19,6 @@ data "google_secret_manager_secret_version" "huggingface_token" {
 }
 
 
-module "ci_v6e_1" {
-  source = "../modules/ci_v6e"
-  providers = {
-    google-beta = google-beta.us-east5-a
-  }
-
-  accelerator_type                = "v6e-1"
-  reserved                        = true
-  instance_count                  = 20
-  disk_size                       = 1024
-  buildkite_queue_name            = "tpu_v6e_queue"
-  project_id                      = var.project_id
-  project_short_name              = var.project_short_name
-  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
-  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
-  huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
-}
-
-module "ci_v6e_8" {
-  source = "../modules/ci_v6e"
-  providers = {
-    google-beta = google-beta.us-east5-a
-  }
-
-  accelerator_type                = "v6e-8"
-  reserved                        = true
-  instance_count                  = 7
-  disk_size                       = 4096
-  buildkite_queue_name            = "tpu_v6e_8_queue"
-  project_id                      = var.project_id
-  project_short_name              = var.project_short_name
-  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
-  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
-  huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
-}
-
 module "ci_v6e_1_vllm" {
   source = "../modules/ci_v6e"
   providers = {
@@ -69,7 +28,7 @@ module "ci_v6e_1_vllm" {
   accelerator_type                = "v6e-1"
   reserved                        = true
   purpose                         = "vllm"
-  instance_count                  = 10
+  instance_count                  = 30
   disk_size                       = 1024
   buildkite_queue_name            = "tpu_v6e_queue"
   project_id                      = var.project_id
@@ -88,7 +47,7 @@ module "ci_v6e_8_vllm" {
   accelerator_type                = "v6e-8"
   reserved                        = true
   purpose                         = "vllm"
-  instance_count                  = 2
+  instance_count                  = 9
   disk_size                       = 4096
   buildkite_queue_name            = "tpu_v6e_8_queue"
   project_id                      = var.project_id


### PR DESCRIPTION
Part of the `tpu-commons` → `vllm` Buildkite org cutover (migration step 30). **1 of 2**; `buildkite/v6e-vllm-org-collapse` stacks on this.

All 36 v7x CI nodes live in `cloud-ullm-inference-ci-cd`. `modules/ci_v7x` has no `purpose` variable, so unlike v6e there is no parallel-fleet option and no rename — the agent and analytics tokens flip in place on `ci_v7x_2`, `ci_v7x_8` and `ci_v7x_16`.

## Applying this

**Do not `terraform apply` this on its own and expect agents to move.** Both tokens reach a host only through `metadata.startup-script`, which writes `token=` into `/etc/buildkite-agent/buildkite-agent.cfg`. A plain apply changes metadata and nothing else; a `systemctl restart buildkite-agent` re-reads the *existing* cfg and reconnects to tpu-commons. The org only moves when the startup script runs again.

Use the roller, which targets the resources it replaces and so applies the new token as each node is created:

```
./scripts/rolling_restart.py -m module.ci_v7x_2 -b 4 --delay 120 --dir <root>
```

Two defaults matter: `-replace` is destroy-before-create (this module declares no `create_before_destroy`), which is what the 128/128 `tpu7x` reservation in `us-central1-c` requires; and `--replace-disks` is off, so `/mnt/disks/persist` survives — that disk is Docker's `data-root`, so the image cache is kept.

## Notes

- No capacity moves, so this is safe against the reservation.
- Budget time, not risk: every create re-runs the full startup script including a `cargo install minijinja-cli` that compiles from source. Time one batch before settling on a batch size.
- Watch `tpu7x-8-ci-4` afterwards — it is already running Docker off the boot disk, and the script exits with the agent masked if `/mnt/disks/persist` fails to mount.
- `ci_v7x_16` is multi-host, so it is one Terraform resource spanning both workers; only worker 0 runs an agent.