### PR TITLE
[CI] Collapse the v6e fleet onto the vllm org modules

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -8,11 +8,6 @@ data "google_secret_manager_secret_version" "buildkite_agent_token_vllm" {
   version = "latest"
 }
 
-data "google_secret_manager_secret_version" "buildkite_analytics_token_ci_cluster" {
-  secret  = "projects/${var.secret_project_id}/secrets/tpu_commons_buildkite_analytics_token"
-  version = "latest"
-}
-
 data "google_secret_manager_secret_version" "buildkite_analytics_token_vllm" {
   secret  = "projects/${var.secret_project_id}/secrets/vllm_buildkite_analytics_token"
   version = "latest"
@@ -24,42 +19,6 @@ data "google_secret_manager_secret_version" "huggingface_token" {
 }
 
 
-module "ci_v6e_1" {
-  source = "../modules/ci_v6e"
-  providers = {
-    google-beta = google-beta.us-east5-a
-  }
-
-  accelerator_type                = "v6e-1"
-  reserved                        = true
-  instance_count                  = 20
-  disk_size                       = 1024
-  buildkite_queue_name            = "tpu_v6e_queue"
-  project_id                      = var.project_id
-  project_short_name              = var.project_short_name
-  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
-  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
-  huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
-}
-
-module "ci_v6e_8" {
-  source = "../modules/ci_v6e"
-  providers = {
-    google-beta = google-beta.us-east5-a
-  }
-
-  accelerator_type                = "v6e-8"
-  reserved                        = true
-  instance_count                  = 7
-  disk_size                       = 4096
-  buildkite_queue_name            = "tpu_v6e_8_queue"
-  project_id                      = var.project_id
-  project_short_name              = var.project_short_name
-  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
-  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_ci_cluster.secret_data
-  huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
-}
-
 module "ci_v6e_1_vllm" {
   source = "../modules/ci_v6e"
   providers = {
@@ -69,7 +28,7 @@ module "ci_v6e_1_vllm" {
   accelerator_type                = "v6e-1"
   reserved                        = true
   purpose                         = "vllm"
-  instance_count                  = 10
+  instance_count                  = 30
   disk_size                       = 1024
   buildkite_queue_name            = "tpu_v6e_queue"
   project_id                      = var.project_id
@@ -88,7 +47,7 @@ module "ci_v6e_8_vllm" {
   accelerator_type                = "v6e-8"
   reserved                        = true
   purpose                         = "vllm"
-  instance_count                  = 2
+  instance_count                  = 9
   disk_size                       = 4096
   buildkite_queue_name            = "tpu_v6e_8_queue"
   project_id                      = var.project_id


### PR DESCRIPTION
Part of the `tpu-commons` → `vllm` Buildkite org cutover (migration steps 31a/31b). **2 of 2**, stacked on #513 — review that one first.

Four v6e modules become two. `ci_v6e_1` and `ci_v6e_8` exist only to keep the tpu-commons org alive during the overlap; once traffic is on vllm they are pure duplication. Retire them and give the vllm modules the full capacity:

| Queue | Keep | Retire | `instance_count` |
|---|---|---|---|
| `tpu_v6e_queue` | `ci_v6e_1_vllm` | `ci_v6e_1` | 10 → **30** |
| `tpu_v6e_8_queue` | `ci_v6e_8_vllm` | `ci_v6e_8` | 2 → **9** |

Per-queue totals are unchanged — this is a consolidation, not a capacity change. `buildkite_analytics_token_ci_cluster` loses its last consumer here and goes with them; `buildkite_agent_token_ci_cluster` stays, because `ci_cpu_64_core_zone_c` still uses it.

## Apply in two passes

`us-east5-a` is exactly 128/128 and this touches 102 of those chips. A single untargeted apply contains both the destroys and their replacement creates, and Terraform gives no ordering guarantee across separate modules — worst case it asks for 94 existing + 76 new against a hard ceiling of 128 and fails halfway.

```
terraform apply -target=module.ci_v6e_1 -target=module.ci_v6e_8   # frees 68 chips
terraform apply                                                   # creates 76
```

Run `terraform state list | grep ci_v6e_8` first — that module has carried a phantom index past its declared count before, which stops `-target` resolving. Finish with an untargeted `plan` to confirm convergence.

## Why not just free up the benchmark fleet

`us-east5-a` holds 94 chips of CI and 34 of benchmark (`vllm-tpu-v6e-1-bm-600..609`, `-v6e-4-bm-600,601`, `-v6e-8-bm-600,601`). Freeing all 34 still leaves the 128 ceiling below the 170-chip worst-case overlap, so it turns "will fail" into "will probably succeed" — the worse failure mode inside a timed window. It also would not simplify the change: that fleet is not in this repo's Terraform. Still worth destroying separately as headroom if its owners agree (end state would be 102/128), but it is not load-bearing.

## Note on #494

`ci_v6e_8` is declared 7 as of #494 but only 6 nodes exist — #494 is merged and unapplied. Apply it before the window or the collapsed fleet lands at 8, not 9.