### PR TITLE
[CI] Describe the CPU fleets rather than how they got here

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -153,7 +153,6 @@ module "ci_v7x_16" {
   # disk_size defaults to 0, disable attached disk
 }
 
-# The whole tpu-commons 64-core fleet.
 module "ci_cpu_64_core_zone_c" {
   source = "../modules/ci_cpu_64_core"
   providers = {
@@ -171,11 +170,9 @@ module "ci_cpu_64_core_zone_c" {
   huggingface_token_value = data.google_secret_manager_secret_version.huggingface_token.secret_data
 }
 
-# CPU fleets registered against the vllm org's TPU cluster. Additive: the
-# tpu-commons fleet above (and module.ci_cpu in cloud-tpu-inference-test) keeps
-# running until traffic is cut over. purpose = "vllm" switches these onto the
-# self-describing naming scheme: vllm-ci-<kind>-vllm-<zone>-<index>, shared by
-# the VM, its disk, its address, and the Buildkite agent.
+# purpose puts these on the self-describing naming scheme,
+# vllm-ci-<kind>-<purpose>-<zone>-<index>, shared by the VM, its disk, its
+# address, and the Buildkite agent.
 module "ci_cpu_vllm_zone_b" {
   source = "../modules/ci_cpu"
   providers = {

--- a/terraform/gcp_old/tpu-inference/modules/ci_cpu/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cpu/main.tf
@@ -13,9 +13,8 @@ locals {
   zone = data.google_client_config.gcp_client.zone
 
   # One name for the VM, its disk, its address, and the Buildkite agent, so a
-  # queue entry in the Buildkite UI maps straight onto a GCE instance.
-  # An empty purpose keeps the original names, so the tpu-commons fleet is not
-  # renamed and therefore not recreated.
+  # queue entry in the Buildkite UI maps straight onto a GCE instance. An empty
+  # purpose keeps the legacy flat name; renaming a live fleet recreates it.
   node_names = [for i in range(var.instance_count) :
     var.purpose == "" ? "vllm-ci-cpu-${i}" : "vllm-ci-cpu-${var.purpose}-${local.zone}-${i}"
   ]

--- a/terraform/gcp_old/tpu-inference/modules/ci_cpu/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cpu/variables.tf
@@ -20,9 +20,8 @@ variable "huggingface_token_value" {
 variable "purpose" {
   type        = string
   description = <<-DESC
-    What this fleet is for, e.g. "vllm" for the fleet registered against the
-    vllm Buildkite org. When set, every name this module creates -- the VM, its
-    boot disk, the static address, and the Buildkite agent -- becomes
+    What this fleet is for. When set, every name this module creates -- the VM,
+    its boot disk, the static address, and the Buildkite agent -- becomes
     vllm-ci-cpu-<purpose>-<zone>-<index>. The zone is read from the provider, so
     it is never passed in. Empty keeps the original unsuffixed names.
   DESC

--- a/terraform/gcp_old/tpu-inference/modules/ci_cpu_64_core/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cpu_64_core/main.tf
@@ -8,9 +8,8 @@ locals {
   zone = data.google_client_config.gcp_client.zone
 
   # One name for the VM, its disk, its address, and the Buildkite agent, so a
-  # queue entry in the Buildkite UI maps straight onto a GCE instance.
-  # An empty purpose keeps the original names, so the tpu-commons fleet is not
-  # renamed and therefore not recreated.
+  # queue entry in the Buildkite UI maps straight onto a GCE instance. An empty
+  # purpose keeps the legacy flat name; renaming a live fleet recreates it.
   node_names = [for i in range(var.instance_count) :
     var.purpose == "" ? "vllm-ci-cpu-64-core-${i}" : "vllm-ci-cpu-64-core-${var.purpose}-${local.zone}-${i}"
   ]

--- a/terraform/gcp_old/tpu-inference/modules/ci_cpu_64_core/variables.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_cpu_64_core/variables.tf
@@ -55,9 +55,8 @@ variable "resource_suffix" {
 
 variable "purpose" {
   description = <<-DESC
-    What this fleet is for, e.g. "vllm" for the fleet registered against the
-    vllm Buildkite org. When set, every name this module creates -- the VM, its
-    boot disk, the static address, and the Buildkite agent -- becomes
+    What this fleet is for. When set, every name this module creates -- the VM,
+    its boot disk, the static address, and the Buildkite agent -- becomes
     vllm-ci-cpu-64-core-<purpose>-<zone>-<index>, and resource_suffix is
     ignored. The zone is read from the provider, so it is never passed in.
     Empty keeps the original unsuffixed names.


### PR DESCRIPTION
The comments around the CPU modules narrated a transition — which fleet was "additive", which one kept running until traffic moved, which org a fleet was registered against. None of that tells a reader what the code does, and all of it stops being true once there is one fleet per queue.

Kept the durable half: what `purpose` does to the generated names, and why an empty `purpose` exists. Dropped the rest.

| file | was | now |
|---|---|---|
| `cloud-ullm-inference-ci-cd/main.tf` | `# The whole tpu-commons 64-core fleet.` | removed — the module name and `buildkite_queue_name` already say it |
| `cloud-ullm-inference-ci-cd/main.tf` | 5 lines on which fleet is additive and what keeps running until cutover | 3 lines on the naming scheme |
| `modules/ci_cpu{,_64_core}/main.tf` | "so the tpu-commons fleet is not renamed" | "renaming a live fleet recreates it" |
| `modules/ci_cpu{,_64_core}/variables.tf` | `e.g. "vllm" for the fleet registered against the vllm Buildkite org` | dropped, matching `ci_v6e`'s neutral wording |

Comments and variable descriptions only — no resource, value, or naming changes. `terraform validate` and `terraform fmt -check` pass, and the diff contains no non-comment lines.

Not gated on the cutover window; safe to merge whenever.