### PR TITLE
[CI] Add a tpu7x-32 multi-host Buildkite agent in cloud-ullm-inference-ci-cd

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -107,6 +107,31 @@ module "ci_v7x_16" {
   # disk_size defaults to 0, disable attached disk
 }
 
+# 4 hosts x 4 chips (2x2x4). Same multi-host shape as tpu7x-16: the agent runs
+# on worker 0 and fans out to the other hosts over ssh. No data disk: a
+# READ_WRITE disk cannot be shared by four hosts, and the multi-host jobs
+# stream weights from GCS instead. Replaces the hand-built ranlihao-v7x-32 slice.
+#
+# instance_count is 0 because the project's tpu7x reservation is fully used
+# and a tpu7x-32 needs 16 chips. The hand-built slice still holds them. Raise
+# to 1 after that slice is deleted (or 4 tpu7x-8 nodes are released).
+module "ci_v7x_32" {
+  source = "../modules/ci_v7x"
+  providers = {
+    google-beta = google-beta.us-central1-c
+  }
+
+  accelerator_type                = "tpu7x-32"
+  reserved                        = true
+  instance_count                  = 0
+  buildkite_queue_name            = "tpu_v7x_32_queue"
+  project_id                      = var.project_id
+  project_short_name              = var.project_short_name
+  buildkite_token_value           = data.google_secret_manager_secret_version.buildkite_agent_token_vllm.secret_data
+  buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_vllm.secret_data
+  huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
+}
+
 # purpose puts these on the self-describing naming scheme,
 # vllm-ci-<kind>-<purpose>-<zone>-<index>, shared by the VM, its disk, its
 # address, and the Buildkite agent.

--- a/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_v7x/main.tf
@@ -10,6 +10,8 @@ locals {
   # Detect multi-host based on accelerator_type suffix
   # Expected format: tpu7x-N where N is the number of cores.
   # For v7x, usually 8 cores/ 4 chips per host. (there're 2 core per chip for v7x)
+  # So tpu7x-16 is 2 hosts and tpu7x-32 is 4 hosts; the startup script starts
+  # the Buildkite agent on worker 0 only and the other hosts are reached over ssh.
   tpu_size_parts = split("-", var.accelerator_type)
   tpu_core_size  = length(local.tpu_size_parts) > 1 ? tonumber(local.tpu_size_parts[1]) : 0
   is_multi_host  = local.tpu_core_size > 8


### PR DESCRIPTION
## Why

`tpu_v7x_32_queue` (used by the vllm-torchtpu nightly `kimi-k3-tp32-ep` perf step) is served by a single hand-built slice, `ranlihao-v7x-32`, that predates the terraform fleet. It has already drifted once: it lacked the GitHub App credential helper that `modules/ci_v7x` installs, so every private-repo checkout on that queue failed until it was patched by hand. Bringing it under terraform, next to `ci_v7x_16`, keeps it in step with the rest of the v7x fleet.

## What

- `cloud-ullm-inference-ci-cd/main.tf`: new `module "ci_v7x_32"` — `tpu7x-32`, `us-central1-c`, reserved, `tpu_v7x_32_queue`, no data disk (same as `ci_v7x_16`; a `READ_WRITE` disk cannot be attached to four hosts, and the multi-host jobs stream weights from GCS). Node and agent name follow the fleet scheme: `tpu7x-32-ci-<i>-cicd-us-central1-c`.
- **`instance_count = 0`** — see "Capacity" below.
- `modules/ci_v7x/main.tf`: comment only. The module was already multi-host generic (agent only on worker 0, internal ssh key pair pushed to every host, GitHub App auth); tpu7x-32 is the same shape with four hosts (`2x2x4`, the topology the API picks for `accelerator_type = "tpu7x-32"`).

## Tested

This module was applied for real on 2026-09-07 with `instance_count = 2` (after temporarily releasing 8 tpu7x-8 nodes) and both slices were exercised, then torn down and the tpu7x-8 nodes restored.

- Both `tpu7x-32-ci-0` and `tpu7x-32-ci-1` came up in ~4 min and registered on `tpu_v7x_32_queue` with the fleet name and `queue=`/`hostname=` tags.
- Everything the startup script owns worked on the first job: private-repo clone via the GitHub App helper, worker 0 → workers 1-3 ssh as `buildkite-agent`, docker pull on all 4 hosts, Ray head + 3 workers via `run_multihost.sh`.
- Real workloads passed end to end: vllm-torchtpu-dev builds 12 (K3 W4A8, TP=32) and 14 (nightly `kimi-k3-tp32-ep` config + MMLU evals) — the 1.5 TB Kimi-K3 checkpoint streamed from GCS to all 32 ranks in ~5 min.
- A per-host device smoke (Ray task on each of the 4 hosts printing `jax.devices()`) passed on both slices: 4/4 hosts, 8 devices each (4 chips × 2 TensorCores), vllm-torchtpu-dev build 29.
- Teardown: reducing `instance_count` destroys only the highest index, so a slice can be retired while the other keeps serving.

## Capacity

The tpu7x reservation in `cloud-ullm-inference-ci-cd` is 128/128 chips and a tpu7x-32 needs 16, currently held by the hand-built slice. So this lands with `instance_count = 0`: the module and its wiring are in, nothing is created on apply. To cut over:

```
# delete the hand-built ranlihao-v7x-32 slice (frees 16 chips), then
# set instance_count = 1 and:
cd terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd
terraform init
terraform apply -target=module.ci_v7x_32
```

## Validation

- `terraform fmt -check`, `terraform validate`: clean.
- `terraform plan -target=module.ci_v7x_32` at `instance_count = 0`: no changes.
- The untargeted plan carries unrelated pre-existing drift (`ssh-keys` metadata on TPU nodes touched by `gcloud ... ssh`); this branch contributes nothing to it.
