### PR TITLE
[CI] Retire the CPU fleets that served the tpu-commons org

### DIFF
--- a/terraform/gcp_old/tpu-inference/cloud-tpu-inference-test/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-tpu-inference-test/main.tf
@@ -8,27 +8,6 @@
 #   huggingface_token     = var.huggingface_token
 # }
 
-data "google_secret_manager_secret_version" "buildkite_agent_token_ci_cluster" {
-  secret  = "projects/${var.project_id}/secrets/tpu_commons_buildkite_agent_token"
-  version = "latest"
-}
-
-data "google_secret_manager_secret_version" "huggingface_token" {
-  secret  = "projects/${var.project_id}/secrets/tpu_commons_buildkite_hf_token"
-  version = "latest"
-}
-
-module "ci_cpu" {
-  source = "../modules/ci_cpu"
-  providers = {
-    google-beta = google-beta.us-east5-b
-  }
-  project_id              = var.project_id
-  instance_count          = 8
-  buildkite_token_value   = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
-  huggingface_token_value = data.google_secret_manager_secret_version.huggingface_token.secret_data
-}
-
 # module "ci_v5" {
 #   source = "./modules/ci_v5"
 #   providers = {

--- a/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
+++ b/terraform/gcp_old/tpu-inference/cloud-ullm-inference-ci-cd/main.tf
@@ -1,8 +1,3 @@
-data "google_secret_manager_secret_version" "buildkite_agent_token_ci_cluster" {
-  secret  = "projects/${var.secret_project_id}/secrets/tpu_commons_buildkite_agent_token"
-  version = "latest"
-}
-
 data "google_secret_manager_secret_version" "buildkite_agent_token_vllm" {
   secret  = "projects/${var.secret_project_id}/secrets/vllm_buildkite_agent_token"
   version = "latest"
@@ -110,23 +105,6 @@ module "ci_v7x_16" {
   buildkite_analytics_token_value = data.google_secret_manager_secret_version.buildkite_analytics_token_vllm.secret_data
   huggingface_token_value         = data.google_secret_manager_secret_version.huggingface_token.secret_data
   # disk_size defaults to 0, disable attached disk
-}
-
-module "ci_cpu_64_core_zone_c" {
-  source = "../modules/ci_cpu_64_core"
-  providers = {
-    google-beta = google-beta.us-central1-c
-  }
-  resource_suffix      = "-zone-c"
-  project_id           = var.project_id
-  instance_count       = 8
-  machine_type         = "n2d-standard-64"
-  disk_size            = 250
-  disk_type            = "pd-balanced"
-  buildkite_queue_name = "cpu_64_core"
-
-  buildkite_token_value   = data.google_secret_manager_secret_version.buildkite_agent_token_ci_cluster.secret_data
-  huggingface_token_value = data.google_secret_manager_secret_version.huggingface_token.secret_data
 }
 
 # purpose puts these on the self-describing naming scheme,


### PR DESCRIPTION
Both CPU queues are now served entirely out of `cloud-ullm-inference-ci-cd` on the vllm agent token:

| queue | hosts | zone | module |
|---|---|---|---|
| `cpu` | 8 × e2-standard-2 | us-central1-b | `ci_cpu_vllm_zone_b` |
| `cpu_64_core` | 4 × n2d-standard-64 | us-central1-b | `ci_cpu_64_core_vllm_zone_b` |
| `cpu_64_core` | 4 × n2d-standard-64 | us-central1-f | `ci_cpu_64_core_vllm_zone_f` |

That makes two older fleets redundant, so this drops them:

- **`cloud-ullm-inference-ci-cd`** — `ci_cpu_64_core_zone_c`, 8 hosts in us-central1-c on the tpu-commons token. us-central1-c has no n2d-standard-64 capacity left, which is why the replacements live in zones b and f.
- **`cloud-tpu-inference-test`** — `ci_cpu`, 8 hosts in us-east5-b, also on the tpu-commons token.

With both gone the tpu-commons org has **no agents at all**.

Each root's tpu-commons agent-token data source went unused once its module was removed, so both are dropped too. The secrets themselves stay — the `cloud-ullm-inference-ci-cd` root still reads `tpu_commons_buildkite_hf_token`.

## Applied

Both roots are already applied and converged; re-plan reports `No changes` on each.

- `cloud-ullm-inference-ci-cd`: `0 added, 16 changed, 16 destroyed`. The 16 destroys are the zone-c VMs and their static IPs. The 16 in-place changes are the startup-script fix from #506, which was merged but never applied — metadata only, no reboot, confined to the vllm CPU fleet.
- `cloud-tpu-inference-test`: `0 added, 0 changed, 16 destroyed` — the 8 us-east5-b VMs and their static IPs, nothing else.

Verified before destroying: 0 running and 0 scheduled builds in tpu-commons, and all 16 replacement agents connected in vllm.