### PR TITLE
[CI] Dedup the BigQuery step logs and retire stale metric exporters

### DIFF
--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/main.tf
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/main.tf
@@ -103,7 +103,8 @@ resource "google_bigquery_table" "step_logs" {
   {"name": "wait_duration_sec", "type": "FLOAT", "mode": "NULLABLE"},
   {"name": "run_duration_sec", "type": "FLOAT", "mode": "NULLABLE"},
   {"name": "created_at", "type": "TIMESTAMP", "mode": "NULLABLE"},
-  {"name": "org_slug", "type": "STRING", "mode": "NULLABLE"}
+  {"name": "org_slug", "type": "STRING", "mode": "NULLABLE"},
+  {"name": "row_key", "type": "STRING", "mode": "NULLABLE"}
 ]
 EOF
 }
@@ -145,6 +146,13 @@ resource "google_service_account" "function_sa" {
 resource "google_project_iam_member" "bq_editor" {
   project = var.project_id
   role    = "roles/bigquery.dataEditor"
+  member  = "serviceAccount:${google_service_account.function_sa.email}"
+}
+
+# The puller's MERGE needs job-creation rights; streaming inserts did not.
+resource "google_project_iam_member" "bq_job_user" {
+  project = var.project_id
+  role    = "roles/bigquery.jobUser"
   member  = "serviceAccount:${google_service_account.function_sa.email}"
 }
 

--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/src/main.py
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/src/main.py
@@ -11,6 +11,37 @@ from google.cloud import bigquery
 client = bigquery.Client()
 TABLE_ID = os.environ.get("BQ_TABLE_ID")
 
+# The batch arrives as one array of JSON strings, so the MERGE needs no table of
+# its own to read from. Keying on row_key means a build that two runs both pick
+# up is written once; the lookback deliberately overruns the cron interval to
+# survive a failed run, so re-sends are routine.
+MERGE_SQL = """
+MERGE `{target}` T
+USING (
+  SELECT
+    JSON_VALUE(r, '$.row_key') AS row_key,
+    JSON_VALUE(r, '$.build_id') AS build_id,
+    JSON_VALUE(r, '$.org_slug') AS org_slug,
+    JSON_VALUE(r, '$.commit_hash') AS commit_hash,
+    JSON_VALUE(r, '$.step_name') AS step_name,
+    JSON_VALUE(r, '$.pipeline_slug') AS pipeline_slug,
+    JSON_VALUE(r, '$.branch') AS branch,
+    JSON_VALUE(r, '$.state') AS state,
+    CAST(JSON_VALUE(r, '$.wait_duration_sec') AS FLOAT64) AS wait_duration_sec,
+    CAST(JSON_VALUE(r, '$.run_duration_sec') AS FLOAT64) AS run_duration_sec,
+    TIMESTAMP(JSON_VALUE(r, '$.created_at')) AS created_at
+  FROM UNNEST(@rows) AS r
+) S
+ON T.row_key = S.row_key
+WHEN NOT MATCHED THEN INSERT (
+  row_key, build_id, org_slug, commit_hash, step_name, pipeline_slug,
+  branch, state, wait_duration_sec, run_duration_sec, created_at
+) VALUES (
+  row_key, build_id, org_slug, commit_hash, step_name, pipeline_slug,
+  branch, state, wait_duration_sec, run_duration_sec, created_at
+)
+"""
+
 # Every pipeline is polled in every org; a pipeline absent from an org 404s.
 PIPELINE_SLUGS = json.loads(os.environ.get("PIPELINE_SLUGS", "[]"))
 
@@ -28,7 +59,7 @@ def handle_webhook(request):
     now = datetime.datetime.now(datetime.timezone.utc)
     finished_from = (now - datetime.timedelta(minutes=15)).isoformat()
 
-    # (row_id, row) pairs; the id is what BigQuery dedups on.
+    # (row_key, row) pairs; the key is what the MERGE dedups on.
     pairs = []
     failures = []
 
@@ -47,15 +78,17 @@ def handle_webhook(request):
                 # lookback re-covers this window next run.
                 failures.append(f"{org}/{pipeline}: {e}")
 
-    rows_to_insert = [row for _, row in pairs]
+    # A MERGE cannot match one target row from two source rows, so collapse any
+    # key the poll returned twice before handing the batch over.
+    unique = {row_key: row for row_key, row in pairs}
+    rows_to_insert = [dict(row, row_key=row_key) for row_key, row in unique.items()]
 
     if rows_to_insert:
-        # Stream to BigQuery with deduplication
-        row_ids = [row_id for row_id, _ in pairs]
-        errors = client.insert_rows_json(TABLE_ID, rows_to_insert, row_ids=row_ids)
-        if errors:
-            print(f"BigQuery Errors: {errors}")
-            return "Partial Success", 500
+        try:
+            merge_rows(rows_to_insert)
+        except Exception as e:
+            print(f"BigQuery merge failed: {e}")
+            return "Merge failed", 500
 
     if failures:
         print(f"Failed: {'; '.join(failures)}")
@@ -63,6 +96,17 @@ def handle_webhook(request):
 
     targets = len(ORGS) * len(PIPELINE_SLUGS)
     return f"Processed {len(rows_to_insert)} items across {targets} org/pipeline pair(s)", 200
+
+def merge_rows(rows):
+    """MERGE the batch into the target; a row_key already present is skipped."""
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ArrayQueryParameter(
+                "rows", "STRING", [json.dumps(row) for row in rows]
+            )
+        ]
+    )
+    client.query(MERGE_SQL.format(target=TABLE_ID), job_config=job_config).result()
 
 def fetch_rows(org, token, pipeline, finished_from):
     headers = {"Authorization": f"Bearer {token}"}
@@ -76,7 +120,7 @@ def fetch_rows(org, token, pipeline, finished_from):
     response = requests.get(url, headers=headers, params=params, timeout=30)
     response.raise_for_status()
 
-    # Row IDs dedup the builds the lookback re-sends. Key on the job UUID, not
+    # Row keys dedup the builds the lookback re-sends. Key on the job UUID, not
     # the step name: parallel jobs share a name and would collapse into one.
     rows = []
     for build in response.json():

--- a/terraform/gcp_old/tpu-inference/modules/ci_monitoring/startup.sh.tftpl
+++ b/terraform/gcp_old/tpu-inference/modules/ci_monitoring/startup.sh.tftpl
@@ -7,16 +7,20 @@ for unit in /etc/systemd/system/bk-metrics*.service; do
   systemctl stop "$(basename "$unit")" || true
 done
 
-# Retire the single-org unit that predates the per-org exporters.
-if [ -f /etc/systemd/system/bk-metrics.service ]; then
-  systemctl disable bk-metrics.service || true
-  rm -f /etc/systemd/system/bk-metrics.service
-fi
-
 # Stage and rename; writing the destination directly fails with ETXTBSY.
 wget -q https://github.com/buildkite/buildkite-agent-metrics/releases/download/v5.5.0/buildkite-agent-metrics-linux-amd64 -O /tmp/buildkite-agent-metrics
 chmod +x /tmp/buildkite-agent-metrics
 mv -f /tmp/buildkite-agent-metrics /usr/local/bin/buildkite-agent-metrics
+
+# Discard every unit and token, then rebuild only what is configured below.
+# Stopping a unit leaves it enabled, so a retired org would otherwise come back
+# on the next boot; rebuilding from scratch also drops its token from disk.
+for unit in /etc/systemd/system/bk-metrics*.service; do
+  [ -e "$unit" ] || continue
+  systemctl disable "$(basename "$unit")" || true
+  rm -f "$unit"
+done
+rm -rf /etc/bk-metrics
 
 install -d -m 0700 /etc/bk-metrics
 umask 077


### PR DESCRIPTION
## The duplication

Every build should contribute exactly one `E2E_SUMMARY` row to `step_execution_logs`. It averages **1.58**:

| org | builds | E2E_SUMMARY rows | avg copies | excess |
|---|---|---|---|---|
| NULL (pre-08-29) | 10,276 | 16,260 | 1.582 | 36.8% |
| tpu-commons | 805 | 1,281 | 1.591 | 37.2% |
| vllm | 14 | 24 | 1.714 | 41.7% |

It is not cross-pipeline or cross-org contamination — of 459,629 duplicate groups table-wide, **zero** span a pipeline and **zero** span an org. It is the same job of the same build written more than once.

Counts and sums read about a third high. Durations are unaffected: the copies are byte-identical, so averages and percentiles already agree with the Buildkite API (spot-checked build `#5` of `vllm-torchtpu-ci` — BigQuery `12.031 / 0.439` and `435.361 / 0.507` against the API's identical values).

**Cause.** The puller asks for builds finished in the last 15 minutes (`main.py:29`) but runs every 10, so each build in the 5-minute overlap is fetched by two consecutive runs. With a 15-min lookback on a 10-min cron, half of all builds land in the overlap and get 2 copies — a predicted average of 1.50 against the observed 1.58. Dedup was delegated to `insert_rows_json(row_ids=…)`, which becomes BigQuery's streaming `insertId`: best-effort over roughly a minute, so it never fires across a 10-minute gap. Scheduler retries account for the rest of the tail, since the function inserts and only then returns 500.

## The fix

Make the write idempotent rather than hoping the insert window covers it. The key the code already derives from the build and job UUIDs is persisted as a `row_key` column, the batch is loaded to a staging table, and a `MERGE` inserts only unmatched rows. Re-sends and retries become no-ops, so the lookback can keep overrunning the cron and covering gaps.

`bigquery.jobUser` is added to the function service account — MERGE and load jobs need job-creation rights that streaming inserts do not, so without it this would 403 in production.

Dashboards should read the new `step_execution_logs_deduped` view.

**Two limits.** The view's fallback key for pre-existing rows cannot separate parallel jobs of one step that share a name, state and duration, so those still collapse — only rows written after this deploys are exactly deduped. And the first run after deploy may re-insert one window, since existing rows have `row_key = NULL` and will not match.

## Stale exporters

The monitoring host kept exporting metrics for an org already dropped from `buildkite_token_secret_ids`. The startup script stops every `bk-metrics` unit on boot but leaves the retired org's unit *enabled*, so systemd starts it again on the next boot — the config change was latent. The script now sweeps units whose org is no longer configured, removing the unit and its token file.

`bk-metrics-tpu-commons` has already been stopped and removed by hand on `vllm-ci-monitoring-cpu-0`; `bk-metrics-vllm` is untouched and active. This change stops it coming back.

## Verification

`terraform validate` and `fmt` clean; the template was rendered through `terraform console` and the sweep exercised against a fixture (keeps `vllm`, removes `tpu-commons` and a hyphenated `legacy-org`, along with their env files).

Running the view's SQL against the live table cuts 1,411,897 rows to 843,681 (−40.2%), with `E2E_SUMMARY` at 11,092 rows across 11,093 distinct builds — exactly one per build.

`terraform plan`: `3 to add, 3 to change, 1 to destroy`. The destroy is the source zip being replaced; no data resource is touched.

```
module.ci_monitoring.google_bigquery_table.step_logs              updated in-place
module.ci_monitoring.google_bigquery_table.step_logs_deduped      created
module.ci_monitoring.google_cloudfunctions2_function.webhook_receiver  updated in-place
module.ci_monitoring.google_compute_instance.monitoring_instance  updated in-place
module.ci_monitoring.google_project_iam_member.bq_job_user        created
module.ci_monitoring.google_storage_bucket_object.source_object   replaced
```

Not applied. Apply from main once #518 has merged, so the plan does not also see that PR's fleet deletions.

## Also done, not in this diff

The Ops View dashboard is not code-managed, so it was repointed directly: `buildkite/tpu_commons/{WaitingJobsCount,BusyAgentPercentage,IdleAgentCount}` → `buildkite/vllm/…`. Those three metric names were the only edits; zero `tpu_commons` references remain and all three widgets return live data.