### PR TITLE
[CI] Accept generated AMD mirror keys in retry builds

### DIFF
--- a/buildkite/pipeline_generator/README.md
+++ b/buildkite/pipeline_generator/README.md
@@ -80,7 +80,9 @@ The generator relies on several environment variables, typically provided by Bui
 *   `VLLM_USE_PRECOMPILED`: Set to "1" to force use of precompiled wheels.
 *   `VLLM_CI_ONLY_STEP_KEYS`: A non-empty JSON array of stable step keys. When
     set, the generator emits those steps and their transitive dependencies,
-    ignoring normal source-file selection. Unknown keys fail generation.
+    ignoring normal source-file selection. Generated AMD mirror keys such as
+    `amd-multi-modal-processor` are accepted and select only the mirror plus
+    its AMD dependencies. Unknown keys fail generation.
 
 Kubernetes-backed test jobs read `BUILDKITE_ANALYTICS_TOKEN` from the
 `buildkite-analytics-token-secret` Secret's `token` key when it is available.

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -594,6 +594,10 @@ def convert_group_step_to_buildkite_step(
         group_steps_list = []
         for step in steps:
             step_key = step.key or _generate_step_key(step.label)
+            # In a retry build a step may be present only because its AMD
+            # mirror was requested; then emit the mirror but not the step.
+            only_step_keys = global_config["only_step_keys"]
+            include_step = only_step_keys is None or step_key in only_step_keys
             if is_amd_gpu_device(step.device):
                 amd_commands = [f"export VLLM_TEST_GROUP_NAME={step_key}"]
                 amd_commands.extend(
@@ -683,7 +687,7 @@ def convert_group_step_to_buildkite_step(
                     step.timeout_in_minutes
                 )
 
-            if not _step_should_run(step, list_file_diff):
+            if include_step and not _step_should_run(step, list_file_diff):
                 block_step = _create_block_step(
                     block=f"Run {step.label}",
                     key=f"block-{step_key}",
@@ -704,13 +708,14 @@ def convert_group_step_to_buildkite_step(
                 if step.device == DeviceType.L4 and not step.retry:
                     buildkite_step.retry = K8S_RETRY
 
-            group_steps_list.append(buildkite_step)
+            if include_step:
+                group_steps_list.append(buildkite_step)
 
             # Create AMD mirror step and its block step if specified/applicable
             if (
                 step.mirror
                 and step.mirror.get("amd")
-                and global_config["only_step_keys"] is None
+                and (only_step_keys is None or f"amd-{step_key}" in only_step_keys)
             ):
                 amd = step.mirror["amd"]
                 amd_no_plugin = amd.get("no_plugin", False)
@@ -849,7 +854,7 @@ def _get_amd_mirror_effective_step(step: Step, amd: Dict[str, Any]) -> Step:
 
     return step.model_copy(
         update={
-            "key": None,
+            "key": f"amd-{step.key or _generate_step_key(step.label)}",
             "device": amd["device"],
             "dind": amd.get("dind", True),
             "optional": amd.get("optional", step.optional),

--- a/buildkite/pipeline_generator/pipeline_generator.py
+++ b/buildkite/pipeline_generator/pipeline_generator.py
@@ -4,6 +4,7 @@ from typing import FrozenSet, List, Optional, Tuple
 
 import yaml
 
+from amd import normalize_amd_depends_on
 from buildkite_step import (
     _generate_step_key,
     add_precommit_dependency,
@@ -52,9 +53,17 @@ class PipelineGenerator:
         steps = []
         for job_dir in global_config["job_dirs"]:
             steps.extend(read_steps_from_job_dir(job_dir))
-        steps, selected_step_keys = select_steps_and_dependencies(
-            steps, global_config["only_step_keys"]
-        )
+        try:
+            steps, selected_step_keys = select_steps_and_dependencies(
+                steps, global_config["only_step_keys"]
+            )
+        except ValueError as error:
+            # Surface the reason on the build page, not only in the bootstrap log.
+            subprocess.run(
+                ["buildkite-agent", "annotate", str(error), "--style", "error"],
+                check=False,
+            )
+            raise
         global_config["only_step_keys"] = selected_step_keys
         grouped_steps = group_steps(steps)
 
@@ -93,6 +102,7 @@ def select_steps_and_dependencies(
         return steps, None
 
     steps_by_key = {}
+    dependencies_by_key = {}
     for step in steps:
         # Steps without an explicit key are uploaded with a label-derived key
         # (see convert_group_step_to_buildkite_step), so retry builds reference
@@ -102,6 +112,19 @@ def select_steps_and_dependencies(
         if step.key in steps_by_key:
             raise ValueError(f"Duplicate CI step key: {step.key}")
         steps_by_key[step.key] = step
+        dependencies_by_key[step.key] = step.depends_on or []
+
+        # AMD mirrors are uploaded as generated `amd-<key>` steps, so retry
+        # builds reference them by that key too.
+        amd_mirror = (step.mirror or {}).get("amd")
+        if amd_mirror:
+            mirror_key = f"amd-{step.key}"
+            if mirror_key in steps_by_key:
+                raise ValueError(f"Duplicate CI step key: {mirror_key}")
+            steps_by_key[mirror_key] = step
+            dependencies_by_key[mirror_key] = normalize_amd_depends_on(
+                amd_mirror.get("depends_on")
+            )
 
     missing = requested_step_keys - steps_by_key.keys()
     if missing:
@@ -111,7 +134,7 @@ def select_steps_and_dependencies(
     pending = list(requested_step_keys)
     while pending:
         step_key = pending.pop()
-        for dependency in steps_by_key[step_key].depends_on or []:
+        for dependency in dependencies_by_key[step_key]:
             if dependency not in steps_by_key:
                 raise ValueError(
                     f"CI step {step_key} depends on unknown step {dependency}."
@@ -120,7 +143,11 @@ def select_steps_and_dependencies(
                 selected_step_keys.add(dependency)
                 pending.append(dependency)
 
-    selected = [step for step in steps if step.key in selected_step_keys]
+    selected = [
+        step
+        for step in steps
+        if step.key in selected_step_keys or f"amd-{step.key}" in selected_step_keys
+    ]
     return selected, frozenset(selected_step_keys)
 
 

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -119,6 +119,45 @@ def test_selected_steps_support_label_generated_keys():
     )
 
 
+def test_selected_steps_support_amd_mirror_keys(fake_global_config):
+    steps = [
+        Step(label="AMD image", key="image-build-amd", commands=["build"]),
+        Step(
+            label="Multimodal Processor",
+            group="Models - Multimodal",
+            key="multi-modal-processor",
+            commands=["test"],
+            mirror={
+                "amd": {
+                    "device": "mi355_1",
+                    "dind": False,
+                    "depends_on": ["image-build-amd"],
+                }
+            },
+        ),
+        Step(label="Other", key="other", commands=["other"]),
+    ]
+
+    selected, selected_keys = select_steps_and_dependencies(
+        steps, frozenset({"amd-multi-modal-processor"})
+    )
+    fake_global_config["only_step_keys"] = selected_keys
+    groups = buildkite_step.convert_group_step_to_buildkite_step(
+        group_steps(selected)
+    )
+    generated_keys = [job.key for group in groups for job in group.steps]
+
+    assert [step.key for step in selected] == [
+        "image-build-amd",
+        "multi-modal-processor",
+    ]
+    assert selected_keys == frozenset(
+        {"image-build-amd", "amd-multi-modal-processor"}
+    )
+    # The NVIDIA parent is neither emitted nor blocked; the mirror runs unblocked.
+    assert generated_keys == ["image-build-amd", "amd-multi-modal-processor"]
+
+
 def test_selected_steps_reject_duplicate_generated_key():
     steps = [
         Step(label="Test", key="test", commands=["a"]),

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -119,13 +119,22 @@ def test_selected_steps_support_label_generated_keys():
     )
 
 
-def test_selected_steps_support_amd_mirror_keys(fake_global_config):
+@pytest.mark.parametrize(
+    ("key", "generated_key"),
+    [
+        ("multi-modal-processor", "multi-modal-processor"),
+        (None, "multimodal-processor"),
+    ],
+)
+def test_selected_steps_support_amd_mirror_keys(
+    fake_global_config, key, generated_key
+):
     steps = [
         Step(label="AMD image", key="image-build-amd", commands=["build"]),
         Step(
             label="Multimodal Processor",
             group="Models - Multimodal",
-            key="multi-modal-processor",
+            key=key,
             commands=["test"],
             mirror={
                 "amd": {
@@ -139,7 +148,7 @@ def test_selected_steps_support_amd_mirror_keys(fake_global_config):
     ]
 
     selected, selected_keys = select_steps_and_dependencies(
-        steps, frozenset({"amd-multi-modal-processor"})
+        steps, frozenset({f"amd-{generated_key}"})
     )
     fake_global_config["only_step_keys"] = selected_keys
     groups = buildkite_step.convert_group_step_to_buildkite_step(
@@ -149,13 +158,11 @@ def test_selected_steps_support_amd_mirror_keys(fake_global_config):
 
     assert [step.key for step in selected] == [
         "image-build-amd",
-        "multi-modal-processor",
+        generated_key,
     ]
-    assert selected_keys == frozenset(
-        {"image-build-amd", "amd-multi-modal-processor"}
-    )
+    assert selected_keys == frozenset({"image-build-amd", f"amd-{generated_key}"})
     # The NVIDIA parent is neither emitted nor blocked; the mirror runs unblocked.
-    assert generated_keys == ["image-build-amd", "amd-multi-modal-processor"]
+    assert generated_keys == ["image-build-amd", f"amd-{generated_key}"]
 
 
 def test_selected_steps_reject_duplicate_generated_key():


### PR DESCRIPTION
## Problem

A cross-commit `/ci retry` forwards the source build's failed step keys via `VLLM_CI_ONLY_STEP_KEYS`. For an AMD mirror step, Buildkite emits the generated key `amd-<key>`, which the pipeline generator does not know (it only knows keys declared in `.buildkite/**/*.yaml`), so bootstrap dies with `Unknown CI step key(s)` and the retry produces nothing. Worse, the *next* retry uses the dead retry build as its source, sees only `bootstrap` failed, and retries `bootstrap` — the original failures are lost. (Incident: builds 87066 → 87079 → 87081.)

## Change

- `select_steps_and_dependencies` registers `amd-<key>` (with normalized AMD dependencies in a `dependencies_by_key` dict) for every step that has a `mirror.amd` block. A duplicate mirror key raises. The hard `ValueError("Unknown CI step key(s): …")` stays.
- In `convert_group_step_to_buildkite_step`, `include_step` gates the NVIDIA parent's block step and emission; the mirror condition becomes `only_step_keys is None or f"amd-{step_key}" in only_step_keys`.
- `_get_amd_mirror_effective_step` gives the copy `key=f"amd-{step.key or _generate_step_key(step.label)}"` so `_step_should_run` sees the mirror key in retry mode. Normal mode is unaffected (`amd-…` never matches the `image-build` prefix or `AMD_ALWAYS_RUN_STEP_KEYS`).
- `generate()` wraps the selection call in `try/except ValueError`, runs `buildkite-agent annotate <message> --style error` (`check=False`), and re-raises — the error shows on the build page above the job list instead of only in the bootstrap log.
- One sentence of README under `VLLM_CI_ONLY_STEP_KEYS`; one new test.

Diff: +83/−10 across 4 files.

## Tests

`python -m pytest buildkite/tests` → **104 passed** (103 existing unchanged + new `test_selected_steps_support_amd_mirror_keys`). Normal-mode pipeline output is byte-identical to `main`.

Manual-verification matrix (generator run from a vllm checkout): `VLLM_CI_ONLY_STEP_KEYS` unset → byte-identical pipeline; `["multi-modal-processor"]` → byte-identical; `["amd-multi-modal-processor"]` → previously `ValueError`, now emits `image-build-amd`, `ensure-ci-base-amd`, `refresh-rocm-base-amd`, `amd-multi-modal-processor` with no parent and no block step; `["bootstrap"]` → still `ValueError`, now also annotated on the build page.

Companion bot-side change (setup-failure comment, never retry `bootstrap`): separate PR against vllm-project/vllm, being opened concurrently; safe to merge in either order.