### PR TITLE
tpu-inference/k8s: the manager cluster

### DIFF
--- a/terraform/gcp_old/tpu-inference/k8s/.gitignore
+++ b/terraform/gcp_old/tpu-inference/k8s/.gitignore
@@ -1,0 +1,4 @@
+# The repo root ignores *.tfvars as likely to hold secrets. This one holds
+# project ids, regions and CIDR blocks, and needs to be reviewed alongside the
+# code that reads it. Left ignored, every edit needs `git add -f` to commit.
+!prod.auto.tfvars

--- a/terraform/gcp_old/tpu-inference/k8s/.terraform.lock.hcl
+++ b/terraform/gcp_old/tpu-inference/k8s/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.46.1"
+  constraints = "~> 7.41"
+  hashes = [
+    "h1:Hgv4BX9846ucZ6XcEql0DPfACoXqlcLat9SjUAn7YLI=",
+    "h1:oaPjmiPJz4rtO1CCcQ53YsY+Xr/vUEvmYRz10SGieuk=",
+    "zh:2e0e513915988d80582f8db7ff18c6242b8f4fad977d428feb11bcbd30d8ba95",
+    "zh:44ebe20d2a548c4318cc75497b7de0ded4bcb5867dbc9d7418f1941d5f6c5c2c",
+    "zh:48016a7ad372f27aa44b4f4611eb24fc634b05b0c25b84ca55a359f525f5a36f",
+    "zh:726fc1bbacf317bf946b53adc71248f890f78ede639c7d9e6fc52716668fd0ef",
+    "zh:9944d3128c69217d976844d936dd642d07140412d56e04bada95da189be37bdb",
+    "zh:a77548865bd320243641389763d3696b05c540d1cbb9868b249371626bab4132",
+    "zh:af6a79150120844c45236dd8d0e39fec76ef50528f5de9a623acbfb96108e4b8",
+    "zh:c1f3a7b1652db3a9f429cb749e9a4a3efcbf980d9d90f2634f25973931f2eedc",
+    "zh:d18255642cae2f00cf5a2946652a17cbf59a0d65c56bc0aac31d2509a360000e",
+    "zh:df3a71bf6d245a9f7c6548680055c22ecc8432f664b3d93d2ea0363f4c4d56ad",
+    "zh:e406cc8194485420bee42af19e3a545272a5ce45bc9ce7d5ac4438fb1a3f6fc6",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/gcp_old/tpu-inference/k8s/backend.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "tpu_commons_ci-infra_tf"
+    prefix = "terraform/cloud-ullm-inference-ci-cd-k8s-state"
+  }
+}

--- a/terraform/gcp_old/tpu-inference/k8s/iam.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/iam.tf
@@ -1,0 +1,15 @@
+# Referenced from the cluster's auto_provisioning_defaults; see manager.tf for
+# what happens if nodes are left on the project default instead.
+resource "google_service_account" "manager_nodes" {
+  project      = var.project_id
+  account_id   = "${var.name_prefix}-mgr-node"
+  display_name = "Manager GKE Node SA"
+}
+
+resource "google_project_iam_member" "manager_nodes" {
+  for_each = local.manager_node_service_account_roles
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.manager_nodes.email}"
+}

--- a/terraform/gcp_old/tpu-inference/k8s/locals.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/locals.tf
@@ -1,0 +1,19 @@
+locals {
+  common_labels = merge(var.labels, {
+    managed_by = "terraform"
+    component  = "tpu-ci"
+  })
+
+  # Keep this list to what a node needs to boot, log and report metrics. Every
+  # pod scheduled to a node can reach that node's identity, so anything a
+  # workload needs belongs on the workload's own service account through
+  # Workload Identity instead.
+  #
+  # container.defaultNodeServiceAccount is GKE's maintained definition of that
+  # minimum. artifactregistry.reader is not in it and has to be added
+  # separately; a node needs it to pull private images.
+  manager_node_service_account_roles = toset([
+    "roles/container.defaultNodeServiceAccount",
+    "roles/artifactregistry.reader",
+  ])
+}

--- a/terraform/gcp_old/tpu-inference/k8s/manager.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/manager.tf
@@ -1,0 +1,98 @@
+# The manager cluster: the one place that is always up. It holds the Buildkite
+# controller and the Kueue control plane, and it must hold no accelerators, so
+# that nothing running here competes with a test for chips. Worker clusters hold
+# the TPUs and attach to this one through Fleet.
+#
+# Autopilot is ForceNew: switching to Standard rebuilds the cluster and every
+# workload on it.
+
+# Nodes are private, so egress - image pulls, Buildkite's API, Secret Manager -
+# has to go through Cloud NAT.
+resource "google_compute_router" "manager" {
+  name    = "${var.name_prefix}-mgr-router"
+  project = var.project_id
+  region  = var.manager_region
+  network = var.network
+}
+
+resource "google_compute_router_nat" "manager" {
+  name                               = "${var.name_prefix}-mgr-nat"
+  project                            = var.project_id
+  region                             = var.manager_region
+  router                             = google_compute_router.manager.name
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}
+
+resource "google_container_cluster" "manager" {
+  project  = var.project_id
+  name     = "${var.name_prefix}-manager"
+  location = var.manager_region
+
+  network    = var.network
+  subnetwork = var.manager_subnetwork
+
+  enable_autopilot    = true
+  deletion_protection = var.deletion_protection
+
+  release_channel {
+    channel = var.release_channel
+  }
+
+  fleet {
+    project = var.project_id
+  }
+
+  # The fleet-clusterinventory-* labels make GKE Fleet generate ClusterProfile
+  # objects in kueue-system, which is what lets MultiKueue authenticate to
+  # workers with federated credentials instead of a stored kubeconfig and bearer
+  # token. Nothing reads them until Kueue is installed; they are set now because
+  # they have to be present when the fleet is registered.
+  resource_labels = merge(local.common_labels, {
+    fleet-clusterinventory-management-cluster = "true"
+    fleet-clusterinventory-namespace          = "kueue-system"
+    role                                      = "manager"
+  })
+
+  # Autopilot has no node pool to hang a service account on, so this is the only
+  # place to keep nodes off the project default compute account - which holds
+  # tpu.admin, storage.admin and project-wide secretmanager.secretAccessor,
+  # because the bare-metal agent VMs share it.
+  #
+  # `enabled` must stay unset: on Autopilot the autoscaler is always on and
+  # setting it is an error. Only auto_provisioning_defaults is honoured.
+  cluster_autoscaling {
+    auto_provisioning_defaults {
+      service_account = google_service_account.manager_nodes.email
+      oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+    }
+  }
+
+  private_cluster_config {
+    enable_private_nodes    = true
+    enable_private_endpoint = var.enable_private_endpoint
+    master_ipv4_cidr_block  = var.manager_master_ipv4_cidr_block
+
+    # Worker clusters are in other regions and all of them reach this control
+    # plane.
+    master_global_access_config {
+      enabled = true
+    }
+  }
+
+  secret_manager_config {
+    enabled = true
+    rotation_config {
+      enabled           = true
+      rotation_interval = "300s"
+    }
+  }
+
+  secret_sync_config {
+    enabled = true
+    rotation_config {
+      enabled           = true
+      rotation_interval = "300s"
+    }
+  }
+}

--- a/terraform/gcp_old/tpu-inference/k8s/prod.auto.tfvars
+++ b/terraform/gcp_old/tpu-inference/k8s/prod.auto.tfvars
@@ -1,0 +1,16 @@
+project_id  = "cloud-ullm-inference-ci-cd"
+name_prefix = "tpu-ci"
+network     = "projects/cloud-ullm-inference-ci-cd/global/networks/default"
+
+# us-central1 to sit with the rest of the CI control plane: the monitoring VM,
+# the cache buckets, and the Artifact Registry these nodes pull from. The
+# manager holds no TPUs, so it is not tied to a reservation's zone.
+manager_region                 = "us-central1"
+manager_subnetwork             = "projects/cloud-ullm-inference-ci-cd/regions/us-central1/subnetworks/default"
+manager_master_ipv4_cidr_block = "172.16.0.0/28"
+
+labels = {
+  environment = "production"
+  workload    = "tpu-ci"
+  owner       = "tpu-inference"
+}

--- a/terraform/gcp_old/tpu-inference/k8s/providers.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/providers.tf
@@ -1,0 +1,3 @@
+provider "google" {
+  project = var.project_id
+}

--- a/terraform/gcp_old/tpu-inference/k8s/variables.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/variables.tf
@@ -1,0 +1,52 @@
+variable "project_id" {
+  type        = string
+  description = "GCP project holding the manager cluster."
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for created resources."
+  default     = "tpu-ci"
+}
+
+variable "network" {
+  type        = string
+  description = "Self link of the network the manager cluster sits on."
+}
+
+variable "manager_region" {
+  type        = string
+  description = "Region for the manager cluster. Regional, not zonal: the control plane is the only thing every TPU lane depends on, and a zonal one goes away during a zone's maintenance."
+}
+
+variable "manager_subnetwork" {
+  type        = string
+  description = "Self link of the subnetwork for manager nodes."
+}
+
+variable "manager_master_ipv4_cidr_block" {
+  type        = string
+  description = "RFC1918 /28 for the manager control plane. Must not overlap any worker cluster's block, because the manager peers with all of them."
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "Labels applied to every resource that takes them."
+  default     = {}
+}
+
+variable "deletion_protection" {
+  type    = bool
+  default = false
+}
+
+variable "release_channel" {
+  type    = string
+  default = "REGULAR"
+}
+
+variable "enable_private_endpoint" {
+  type        = bool
+  description = "Whether the control plane is reachable only from inside the VPC. False while the cluster is administered from laptops and from Buildkite agents that live outside it."
+  default     = false
+}

--- a/terraform/gcp_old/tpu-inference/k8s/versions.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.41"
+    }
+  }
+}


### PR DESCRIPTION
First of eight PRs standing up a GKE + Kueue lane for tpu-inference CI alongside the bare-metal
Buildkite agent fleet. This one creates a regional **Autopilot** cluster in
`cloud-ullm-inference-ci-cd` that holds no accelerators: the Buildkite controller and the Kueue
control plane will live here, so neither competes for a chip with the tests it schedules, and a
worker cluster draining for maintenance cannot take the scheduler down. Nothing here is on any
pipeline's path.

Supersedes the manager half of #438, which stays open as the reference the split is cut from. The
PoC it replaces was torn down on 2026-09-08.

`terraform validate` passes. Not applied yet — that is the acceptance check for this PR.

### Why Autopilot

The steady state is ~2 vCPU of controllers plus one small launcher pod per in-flight step. The
Standard version of this cluster was three `e2-standard-4` nodes pinned up permanently, because a
regional pool needs a floor in every zone. When `queue: cpu` moves into the cluster (§8 of the
migration plan) the shape stays the same — a few hundred short, bursty, unprivileged jobs a day,
which is exactly what Autopilot is for and what a fixed pool sizes badly.

**Worker clusters stay Standard and must** — TPU pools need reservation affinity on a named
reservation, the `google.com/tpu` taint, COMPACT placement with an explicit topology, and
whole-slice atomic scaling. Those are the decisions Autopilot and node auto-provisioning take away.
Same reason NAP is not used here: the manager has one workload shape and no scheduling decision
worth delegating.

`enable_autopilot` is ForceNew, so it is settled before the first apply rather than after.

### The one Autopilot footgun, called out

Autopilot has no node pool to attach a service account to, which makes it easy to miss that its
nodes still run as one. The default is the project default compute SA — which on this project holds
`tpu.admin`, `storage.admin` and project-wide `secretmanager.secretAccessor`, because the agent VMs
share it. It is set here via `cluster_autoscaling.auto_provisioning_defaults.service_account`, pointing at a
service account this module always creates.

### Node service account

`roles/container.defaultNodeServiceAccount` plus `roles/artifactregistry.reader`, rather than the
older five-role recipe. The managed role is GKE's own definition of the node minimum and is strictly
narrower: it reaches the two metric *list* permissions directly instead of via
`roles/monitoring.viewer`, which would also grant read on every metric, dashboard and alert policy
in the project. `artifactregistry.reader` is separate because the managed role deliberately omits
it.

### What Autopilot costs us

Privileged containers, hostPath and host networking, so no `docker:dind` on the manager. This does
not constrain the plan: real work, CPU or TPU, is a Kueue workload on a Standard worker cluster, and
only controllers and launcher pods run here. Image builds are a separate decision, settled in §8.1 of the
migration plan: every viable builder on Autopilot is a form of delegation, because `buildkitd` needs
`CAP_SYS_ADMIN` and Kaniko is archived — so the builds go to **Cloud Build**, and no cluster here
ever needs a privileged container. (Mounting the host Docker socket is unavailable on
Standard too; GKE nodes have run containerd since 1.24.)

### Other deviations from #438

- `manager.tf` / `workers.tf` rather than one `clusters.tf`, so the file boundary matches the PR
  boundary and PR 2 is purely additive.
- State in the existing `tpu_commons_ci-infra_tf` bucket at prefix
  `terraform/cloud-ullm-inference-ci-cd-k8s-state`, matching the other three roots. All eight PRs
  share this prefix.
- Provider pinned to `google ~> 7.41`, lock file carrying `linux_amd64` as well as `darwin_arm64`.
- A nested `.gitignore` un-ignores `prod.auto.tfvars`; left ignored it needs `git add -f` on every
  edit.

### No `create_service_accounts` toggle

An earlier draft had `create_service_accounts` / `manager_node_service_account` so a deployment
could adopt a pre-existing account. That was for the test project, where a separate process wipes
Terraform-created resources; no resources remain there, so the flags encoded a hypothetical and cost
a three-way `coalesce` ending in the literal `"default"` plus a precondition guarding it. The module
now creates the account unconditionally. `terraform import` covers the adoption case if it returns.

### One thing to weigh in on

`artifactregistry.reader` is at **project** scope. It could be scoped to specific repositories, and
per our resource-IAM rule it should be. Left project-wide because it is not yet clear which repos
the manager pulls from, and the last attempt to narrow AR reader broke a build (64ca84f). Suggest
scoping once PRs 3 and 6 make the image list concrete.

