### PR TITLE
Revert "Disable Ascend NPU tests by default (#517)"

### DIFF
--- a/buildkite/pipeline_generator/README.md
+++ b/buildkite/pipeline_generator/README.md
@@ -76,7 +76,6 @@ The generator relies on several environment variables, typically provided by Bui
 *   `TORCH_NIGHTLY`: Set to "1" to build and run the *entire* test suite against torch nightly (full run, not just the tagged subset). Also forces a full run on the pinned torch. Intended to be set on the scheduled build.
 *   `RUN_ALL`: Set to "1" to force run all steps.
 *   `SKIP_TIMEOUT`: Set to "1" at pipeline generation time to omit all configured step timeouts.
-*   `ENABLE_ASCEND_TESTS`: Ascend NPU test steps are disabled by default. Set to "1" at pipeline generation time to re-enable them.
 *   `DOCS_ONLY_DISABLE`: Set to "0" to enable skipping CI for doc-only changes.
 *   `VLLM_USE_PRECOMPILED`: Set to "1" to force use of precompiled wheels.
 *   `VLLM_CI_ONLY_STEP_KEYS`: A non-empty JSON array of stable step keys. When

--- a/buildkite/pipeline_generator/buildkite_step.py
+++ b/buildkite/pipeline_generator/buildkite_step.py
@@ -37,9 +37,6 @@ PRECOMMIT_MAX_WAIT = 3600  # 30 minutes
 PRECOMMIT_WAIT_INTERVAL = 60
 
 SKIP_TIMEOUT_ENV_VAR = "SKIP_TIMEOUT"
-# Ascend NPU tests are disabled by default. Set to "1" at pipeline generation
-# time to re-enable Ascend NPU test steps.
-ENABLE_ASCEND_TESTS_ENV_VAR = "ENABLE_ASCEND_TESTS"
 EXIT_STATUS_NEGATIVE_ONE_RETRY = {"exit_status": -1, "limit": 1}
 
 # Pod-level failures on EKS surface as agent stops / lost pods rather than
@@ -593,21 +590,10 @@ def convert_group_step_to_buildkite_step(
 
     amd_hardware_steps = []
 
-    # Ascend NPU tests are disabled by default. Set ENABLE_ASCEND_TESTS=1 at
-    # pipeline generation time to re-enable them without reverting this change.
-    ascend_tests_disabled = os.getenv(ENABLE_ASCEND_TESTS_ENV_VAR) != "1"
-    if ascend_tests_disabled:
-        print(
-            "Ascend NPU test steps are disabled by default; set "
-            f"{ENABLE_ASCEND_TESTS_ENV_VAR}=1 to re-enable."
-        )
-
     for group, steps in group_steps.items():
         group_steps_list = []
         for step in steps:
             step_key = step.key or _generate_step_key(step.label)
-            if ascend_tests_disabled and step.device == DeviceType.ASCEND:
-                continue
             if is_amd_gpu_device(step.device):
                 amd_commands = [f"export VLLM_TEST_GROUP_NAME={step_key}"]
                 amd_commands.extend(

--- a/buildkite/tests/pipeline_generator/test_step.py
+++ b/buildkite/tests/pipeline_generator/test_step.py
@@ -822,52 +822,5 @@ def test_step_explicitly_listing_excluded_subtree_still_matches():
     )
 
 
-def _ascend_test_step():
-    return Step(
-        label="Ascend NPU Test",
-        group="Hardware",
-        key="ascend-npu-test",
-        device="ascend_npu",
-        no_plugin=True,
-        commands=["bash .buildkite/scripts/hardware_ci/run-npu-test.sh"],
-    )
-
-
-def test_ascend_tests_disabled_by_default(monkeypatch):
-    monkeypatch.delenv(buildkite_step.ENABLE_ASCEND_TESTS_ENV_VAR, raising=False)
-    step = _ascend_test_step()
-
-    group_steps = buildkite_step.convert_group_step_to_buildkite_step(
-        {step.group: [step]}
-    )
-
-    command_steps = [
-        command_step
-        for group_step in group_steps
-        for command_step in group_step.steps
-        if isinstance(command_step, buildkite_step.BuildkiteCommandStep)
-    ]
-    assert command_steps == []
-
-
-def test_enable_ascend_tests_env_var_restores_ascend_steps(monkeypatch):
-    monkeypatch.setenv(buildkite_step.ENABLE_ASCEND_TESTS_ENV_VAR, "1")
-    step = _ascend_test_step()
-
-    group_steps = buildkite_step.convert_group_step_to_buildkite_step(
-        {step.group: [step]}
-    )
-
-    command_steps = [
-        command_step
-        for group_step in group_steps
-        for command_step in group_step.steps
-        if isinstance(command_step, buildkite_step.BuildkiteCommandStep)
-    ]
-    assert [command_step.label for command_step in command_steps] == [
-        "Ascend NPU Test"
-    ]
-
-
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
This reverts commit 72e0ddcc8d3542f59a0be1a70469275d200b1bf3 (https://github.com/vllm-project/ci-infra/pull/517).

Ascend NPU test steps are generated normally again; the `ENABLE_ASCEND_TESTS` escape hatch is removed.

Pipeline generator tests pass locally (103 passed).