### PR TITLE
tpu-ci k8s: name TPU pools for their machine type as well as their topology

### DIFF
--- a/terraform/gcp_old/tpu-inference/k8s/prod.auto.tfvars
+++ b/terraform/gcp_old/tpu-inference/k8s/prod.auto.tfvars
@@ -36,7 +36,7 @@ worker_clusters = {
     # reservation, since those chips stay with one shape once booted, so it is
     # kept small.
     tpu_node_pools = {
-      v6e-1x1 = {
+      v6e-1t-1x1 = {
         machine_type     = "ct6e-standard-1t"
         topology         = "1x1"
         reservation_name = "cloudtpu-20260828173000-731402396"
@@ -45,7 +45,7 @@ worker_clusters = {
         min_nodes = 2
         max_nodes = 26
       }
-      v6e-2x4 = {
+      v6e-8t-2x4 = {
         machine_type     = "ct6e-standard-8t"
         topology         = "2x4"
         reservation_name = "cloudtpu-20260828173000-731402396"

--- a/terraform/gcp_old/tpu-inference/k8s/variables.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/variables.tf
@@ -75,6 +75,12 @@ variable "worker_clusters" {
     # One per TPU shape this cluster can run, keyed by node pool name. Names
     # have to be unique across all clusters, not just within one, because the
     # pools are flattened into a single map to create them.
+    #
+    # Named <generation>-<chips per host>-<topology>, e.g. v6e-8t-2x4. The
+    # middle part is the machine type's suffix, and it is what makes the name
+    # unique: a topology does not determine the machine type. 2x4 is eight
+    # chips either as one ct6e-standard-8t or as two ct6e-standard-4t, and
+    # those differ in pod count, chips per pod and JobSet parallelism.
     tpu_node_pools = optional(map(object({
       # The machine type is the VM, the topology the slice asked of it. Matching
       # shapes mean one VM holds the whole slice; a larger topology means one


### PR DESCRIPTION
Renames the two v6e node pools: `v6e-1x1` → `ct6e-standard-1t-1x1`, `v6e-2x4` → `ct6e-standard-8t-2x4`.

A topology does not determine a machine type. `2x4` is eight chips either as one `ct6e-standard-8t` or as two `ct6e-standard-4t`, and GKE labels the nodes of both pools `cloud.google.com/gke-tpu-topology: 2x4` — so the names collide, and a pod selecting on accelerator + topology cannot tell the pools apart.

The name is the whole shape, so it is no longer written down: `tpu_node_pools` becomes a list of `machine_type` + `topology` and `locals.tf` joins the two. `is_multi_host` comes out of the same fields, retiring the table of single-host topologies per machine type.

Nothing collides today. This lands before the Kueue PR, whose queues are named after these pools.

The pool name is the `for_each` key and is ForceNew, so both pools are recreated. Neither held a workload.
