### PR TITLE
tpu-ci k8s: stop indexing the node service account bindings by role

### DIFF
--- a/terraform/gcp_old/tpu-inference/k8s/iam.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/iam.tf
@@ -51,3 +51,22 @@ resource "google_artifact_registry_repository_iam_member" "worker_nodes" {
   role       = "roles/artifactregistry.reader"
   member     = "serviceAccount:${google_service_account.worker_nodes[each.value.worker_name].email}"
 }
+
+# Lets the manager's Kueue controller reach a worker's API server through
+# Connect Gateway. It authenticates as its Kubernetes service account directly,
+# with no Google service account in between, so there is no key and nothing to
+# rotate; gke-gcloud-auth-plugin turns that identity into the gateway's token.
+#
+# Per membership, not per project: a gatewayEditor on the project would also be
+# an editor of every cluster registered to the fleet later. What the controller
+# may then do inside the worker is the kueue-multikueue-remote ClusterRole,
+# which the generated manifests bind to this same principal.
+resource "google_gke_hub_membership_iam_member" "kueue_manager_gateway" {
+  for_each = var.worker_clusters
+
+  project       = each.value.project
+  location      = google_container_cluster.worker[each.key].fleet[0].membership_location
+  membership_id = google_container_cluster.worker[each.key].fleet[0].membership_id
+  role          = "roles/gkehub.gatewayEditor"
+  member        = local.kueue_controller_principal
+}

--- a/terraform/gcp_old/tpu-inference/k8s/iam.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/iam.tf
@@ -6,11 +6,17 @@ resource "google_service_account" "manager_nodes" {
   display_name = "Manager GKE Node SA"
 }
 
+# container.defaultNodeServiceAccount is GKE's maintained definition of what a
+# node needs to boot, log and report metrics, and a node gets nothing beyond it.
+# Every pod scheduled to a node can reach that node's identity, so anything a
+# workload needs belongs on the workload's own service account through Workload
+# Identity instead.
+#
+# It does not cover pulling private images; that is granted per repository
+# below, from var.image_repositories, to both node accounts.
 resource "google_project_iam_member" "manager_nodes" {
-  for_each = local.node_service_account_roles
-
   project = var.project_id
-  role    = each.value
+  role    = "roles/container.defaultNodeServiceAccount"
   member  = "serviceAccount:${google_service_account.manager_nodes.email}"
 }
 
@@ -35,11 +41,25 @@ resource "google_service_account" "worker_nodes" {
 }
 
 resource "google_project_iam_member" "worker_nodes" {
-  for_each = local.worker_node_role_bindings
+  for_each = var.worker_clusters
 
   project = each.value.project
-  role    = each.value.role
-  member  = "serviceAccount:${google_service_account.worker_nodes[each.value.worker_name].email}"
+  role    = "roles/container.defaultNodeServiceAccount"
+  member  = "serviceAccount:${google_service_account.worker_nodes[each.key].email}"
+}
+
+# Both bindings used to be indexed by role as well, back when a list of roles
+# looked like it would grow. Without these Terraform would revoke and re-grant
+# rather than re-index, and a moved block cannot be generated, so a new worker
+# cluster needs a line here until these are deleted after the next apply.
+moved {
+  from = google_project_iam_member.manager_nodes["roles/container.defaultNodeServiceAccount"]
+  to   = google_project_iam_member.manager_nodes
+}
+
+moved {
+  from = google_project_iam_member.worker_nodes["us-east5/roles/container.defaultNodeServiceAccount"]
+  to   = google_project_iam_member.worker_nodes["us-east5"]
 }
 
 resource "google_artifact_registry_repository_iam_member" "worker_nodes" {

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/common-config.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/common-config.yaml
@@ -1,0 +1,39 @@
+# Kueue controller configuration, on the manager and on every worker.
+#
+# The manager holds the queues and the quota but no TPUs: it admits a workload
+# and MultiKueue mirrors it onto a worker, whose own Kueue admits it a second
+# time against local quota and runs it. Both sides therefore have to agree on
+# what a workload is and on how it is admitted, which is everything in this
+# file. manager-config.yaml adds the keys only the dispatching side needs, and
+# is appended to this one by generate_manifests.py.
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+manageJobsWithoutQueueName: false
+health:
+  healthProbeBindAddress: :8081
+metrics:
+  bindAddress: :8443
+webhook:
+  port: 9443
+leaderElection:
+  leaderElect: true
+  resourceName: c1f6bfd2.kueue.x-k8s.io
+resources:
+  # Check only the resources a ClusterQueue declares. A TPU pod also requests
+  # cpu, memory and ephemeral-storage - its own, its gcsfuse sidecar's, and the
+  # helper containers agent-stack-k8s injects - and under the default
+  # BlockUndeclared any of those would make the workload inadmissible against a
+  # queue that covers google.com/tpu alone. The kube scheduler enforces them
+  # against node capacity, which is where they belong.
+  quotaCheckStrategy: IgnoreUndeclared
+integrations:
+  frameworks:
+    - batch/job
+    # Multi-pod workloads: multi-host TPU slices and prefill/decode disagg.
+    # A batch/v1 Job cannot span hosts.
+    - jobset.x-k8s.io/jobset
+waitForPodsReady:
+  # Inert without `enable: true`. Turning it on adds readiness-timeout eviction
+  # and requeue accounting, which changes how preemption behaves.
+  blockAdmission: false
+  timeout: 10800s

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/queues/00-namespace.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/queues/00-namespace.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: buildkite
+  labels:
+    # baseline enforced rather than restricted: a TPU pod needs the
+    # google.com/tpu device, and the gcsfuse sidecar GKE injects runs with
+    # settings restricted rejects. warn/audit stay at restricted so anything
+    # that does not need the exemption still shows up.
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/queues/10-queues.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/queues/10-queues.yaml
@@ -1,0 +1,110 @@
+---
+# One flavor per TPU generation, and deliberately no nodeLabels.
+#
+# The flavor, not the queue, is Kueue's quota partition: quota is counted per
+# flavor, cohort borrowing is per flavor, and Kueue skips a flavor whose
+# nodeLabels conflict with what a podSet already asks for. A flavor per shape
+# would therefore make it impossible for a 1-chip job to use idle 8-chip
+# capacity, whatever the numbers said. Bare and shared, the per-shape queues
+# above it can lend to each other.
+#
+# Placement is the workload's: it carries the gke-tpu-accelerator,
+# gke-tpu-topology and gke-accelerator-count nodeSelectors itself.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: ct6e
+---
+# One queue per TPU shape, all of a generation's queues in one cohort, so that
+# nominalQuota is chips this shape can always have and no other shape can hold
+# the reservation against it, while whatever it is not using is lent out.
+#
+# reclaimWithinCohort stays Never: a lender waits for the borrower's workloads
+# to finish rather than evicting them. Eviction returns the accounting at once
+# but not the hardware, since eight chips freed across eight single-chip nodes
+# still have to scale down before an 8-chip node can boot, and the jobs killed
+# to get there have to run again.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: ct6e-standard-1t-1x1
+spec:
+  cohortName: ct6e
+  preemption:
+    reclaimWithinCohort: Never
+    withinClusterQueue: LowerPriority
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: buildkite
+  admissionChecksStrategy:
+    admissionChecks:
+      - name: ct6e-standard-1t-1x1-multikueue-dispatch
+  resourceGroups:
+    # google.com/tpu is the only resource under quota. The cpu and memory a
+    # workload, its gcsfuse sidecar and any helper containers request are
+    # ignored here (quotaCheckStrategy: IgnoreUndeclared) and enforced by the
+    # kube scheduler against node capacity.
+    - coveredResources:
+        - google.com/tpu
+      flavors:
+        - name: ct6e
+          resources:
+            - name: google.com/tpu
+              # Chips, not nodes. This is a ceiling on what Kueue will admit at
+              # once, not a promise that a slice of the right shape is free.
+              nominalQuota: 18
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: ct6e-standard-1t-1x1
+  namespace: buildkite
+spec:
+  clusterQueue: ct6e-standard-1t-1x1
+---
+# One queue per TPU shape, all of a generation's queues in one cohort, so that
+# nominalQuota is chips this shape can always have and no other shape can hold
+# the reservation against it, while whatever it is not using is lent out.
+#
+# reclaimWithinCohort stays Never: a lender waits for the borrower's workloads
+# to finish rather than evicting them. Eviction returns the accounting at once
+# but not the hardware, since eight chips freed across eight single-chip nodes
+# still have to scale down before an 8-chip node can boot, and the jobs killed
+# to get there have to run again.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: ct6e-standard-8t-2x4
+spec:
+  cohortName: ct6e
+  preemption:
+    reclaimWithinCohort: Never
+    withinClusterQueue: LowerPriority
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: buildkite
+  admissionChecksStrategy:
+    admissionChecks:
+      - name: ct6e-standard-8t-2x4-multikueue-dispatch
+  resourceGroups:
+    # google.com/tpu is the only resource under quota. The cpu and memory a
+    # workload, its gcsfuse sidecar and any helper containers request are
+    # ignored here (quotaCheckStrategy: IgnoreUndeclared) and enforced by the
+    # kube scheduler against node capacity.
+    - coveredResources:
+        - google.com/tpu
+      flavors:
+        - name: ct6e
+          resources:
+            - name: google.com/tpu
+              # Chips, not nodes. This is a ceiling on what Kueue will admit at
+              # once, not a promise that a slice of the right shape is free.
+              nominalQuota: 8
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: ct6e-standard-8t-2x4
+  namespace: buildkite
+spec:
+  clusterQueue: ct6e-standard-8t-2x4

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/queues/20-multikueue.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/queues/20-multikueue.yaml
@@ -1,0 +1,62 @@
+---
+# A worker the manager may dispatch to. The credentials come from a
+# ClusterProfile that GKE's fleet writes into kueue-system by itself, because
+# the manager cluster carries the labels fleet-clusterinventory-management-
+# cluster=true and fleet-clusterinventory-namespace=kueue-system. Nothing here
+# holds a token for the worker.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: MultiKueueCluster
+metadata:
+  name: tpu-ci-us-east5
+spec:
+  clusterSource:
+    clusterProfileRef:
+      name: tpu-ci-us-east5-us-east5
+---
+# Makes a ClusterQueue on the manager dispatch rather than run. A workload that
+# passes quota is held until MultiKueue has placed it on a worker.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: AdmissionCheck
+metadata:
+  name: ct6e-standard-1t-1x1-multikueue-dispatch
+spec:
+  controllerName: kueue.x-k8s.io/multikueue
+  parameters:
+    apiGroup: kueue.x-k8s.io
+    kind: MultiKueueConfig
+    name: ct6e-standard-1t-1x1-workers
+---
+# The workers that have a node pool of this shape, and so the ones an
+# AdmissionCheck for it may place onto. Kueue picks the first that admits the
+# workload.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: MultiKueueConfig
+metadata:
+  name: ct6e-standard-1t-1x1-workers
+spec:
+  clusters:
+    - tpu-ci-us-east5
+---
+# Makes a ClusterQueue on the manager dispatch rather than run. A workload that
+# passes quota is held until MultiKueue has placed it on a worker.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: AdmissionCheck
+metadata:
+  name: ct6e-standard-8t-2x4-multikueue-dispatch
+spec:
+  controllerName: kueue.x-k8s.io/multikueue
+  parameters:
+    apiGroup: kueue.x-k8s.io
+    kind: MultiKueueConfig
+    name: ct6e-standard-8t-2x4-workers
+---
+# The workers that have a node pool of this shape, and so the ones an
+# AdmissionCheck for it may place onto. Kueue picks the first that admits the
+# workload.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: MultiKueueConfig
+metadata:
+  name: ct6e-standard-8t-2x4-workers
+spec:
+  clusters:
+    - tpu-ci-us-east5

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/system/10-kueue-config.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/system/10-kueue-config.yaml
@@ -1,0 +1,78 @@
+---
+# Overrides the ConfigMap that ships inside the upstream Kueue release, which
+# is why the name and namespace are fixed rather than templated: the manager
+# Deployment mounts this exact object at /controller_manager_config.yaml.
+#
+# Applied after the upstream manifests and under our own field manager, so a
+# server-side apply of a new Kueue version restores upstream's default and this
+# immediately puts ours back. Changing it does not restart anything, so the
+# deploy script rolls the Deployment afterwards.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kueue-manager-config
+  namespace: kueue-system
+data:
+  controller_manager_config.yaml: |
+    # Kueue controller configuration, on the manager and on every worker.
+    #
+    # The manager holds the queues and the quota but no TPUs: it admits a workload
+    # and MultiKueue mirrors it onto a worker, whose own Kueue admits it a second
+    # time against local quota and runs it. Both sides therefore have to agree on
+    # what a workload is and on how it is admitted, which is everything in this
+    # file. manager-config.yaml adds the keys only the dispatching side needs, and
+    # is appended to this one by generate_manifests.py.
+    apiVersion: config.kueue.x-k8s.io/v1beta2
+    kind: Configuration
+    manageJobsWithoutQueueName: false
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: :8443
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: c1f6bfd2.kueue.x-k8s.io
+    resources:
+      # Check only the resources a ClusterQueue declares. A TPU pod also requests
+      # cpu, memory and ephemeral-storage - its own, its gcsfuse sidecar's, and the
+      # helper containers agent-stack-k8s injects - and under the default
+      # BlockUndeclared any of those would make the workload inadmissible against a
+      # queue that covers google.com/tpu alone. The kube scheduler enforces them
+      # against node capacity, which is where they belong.
+      quotaCheckStrategy: IgnoreUndeclared
+    integrations:
+      frameworks:
+        - batch/job
+        # Multi-pod workloads: multi-host TPU slices and prefill/decode disagg.
+        # A batch/v1 Job cannot span hosts.
+        - jobset.x-k8s.io/jobset
+    waitForPodsReady:
+      # Inert without `enable: true`. Turning it on adds readiness-timeout eviction
+      # and requeue accounting, which changes how preemption behaves.
+      blockAdmission: false
+      timeout: 10800s
+    # What the manager's Kueue adds to common-config.yaml: it is the only cluster
+    # that dispatches, so it is the only one that needs a way to reach a worker.
+    #
+    # Appended to that file rather than merged into it, so every key here has to be
+    # a top-level key the common file does not already set. generate_manifests.py
+    # refuses to render if that stops being true.
+    featureGates:
+      # MultiKueue reads worker credentials from ClusterProfile objects rather than
+      # from kubeconfig Secrets. GKE's fleet writes those profiles itself, so no
+      # long-lived token for a worker cluster exists anywhere.
+      MultiKueueClusterProfile: true
+    multiKueue:
+      clusterProfile:
+        accessProviders:
+          # The binary that turns this cluster's Workload Identity into a token for
+          # a worker's Connect Gateway endpoint. Put on the controller pod by
+          # generate_manifests.py; the name matches the accessProvider GKE's fleet
+          # names in the ClusterProfile status.
+          - name: google
+            execConfig:
+              apiVersion: client.authentication.k8s.io/v1beta1
+              command: /plugins/gcp-auth-plugin
+              interactiveMode: Never

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/system/20-auth-plugin.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/system/20-auth-plugin.yaml
@@ -1,0 +1,53 @@
+---
+# Puts a Kubernetes credential plugin on the manager controller's filesystem.
+#
+# MultiKueue reaches the workers through ClusterProfiles, whose access provider
+# is "google": the endpoint is a Connect Gateway URL and the credential is a
+# Google OAuth token. Kueue mints that token by executing the command named in
+# multiKueue.clusterProfile.accessProviders, and the upstream Kueue image
+# contains no such binary. This mounts one.
+#
+# A partial object, applied server-side after the upstream release manifests.
+# Field ownership is per list item - by container name, by volume name, by
+# mount path - so none of this collides with what upstream sets on the same
+# Deployment, and neither apply undoes the other.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kueue-controller-manager
+  namespace: kueue-system
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: add-gcp-auth-plugin
+          image: gcr.io/google.com/cloudsdktool/google-cloud-cli:584.0.0
+          command: ["cp", "/usr/lib/google-cloud-sdk/bin/gke-gcloud-auth-plugin", "/plugins/gcp-auth-plugin"]
+          volumeMounts:
+            - name: clusterprofile-plugins
+              mountPath: /plugins
+          securityContext:
+            # The pod runs with runAsNonRoot and the gcloud image's default user
+            # is root, so a uid has to be named here or the kubelet refuses to
+            # start the container. Any uid works: the binary is world readable
+            # and an emptyDir is world writable.
+            runAsNonRoot: true
+            runAsUser: 65532
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      containers:
+        # Named to match the container in the upstream Deployment; this adds a
+        # mount to it and leaves every other field alone.
+        - name: manager
+          volumeMounts:
+            - name: clusterprofile-plugins
+              mountPath: /plugins
+      volumes:
+        - name: clusterprofile-plugins
+          emptyDir: {}

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/worker-us-east5/queues/00-namespace.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/worker-us-east5/queues/00-namespace.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: buildkite
+  labels:
+    # baseline enforced rather than restricted: a TPU pod needs the
+    # google.com/tpu device, and the gcsfuse sidecar GKE injects runs with
+    # settings restricted rejects. warn/audit stay at restricted so anything
+    # that does not need the exemption still shows up.
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/worker-us-east5/queues/10-queues.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/worker-us-east5/queues/10-queues.yaml
@@ -1,0 +1,104 @@
+---
+# One flavor per TPU generation, and deliberately no nodeLabels.
+#
+# The flavor, not the queue, is Kueue's quota partition: quota is counted per
+# flavor, cohort borrowing is per flavor, and Kueue skips a flavor whose
+# nodeLabels conflict with what a podSet already asks for. A flavor per shape
+# would therefore make it impossible for a 1-chip job to use idle 8-chip
+# capacity, whatever the numbers said. Bare and shared, the per-shape queues
+# above it can lend to each other.
+#
+# Placement is the workload's: it carries the gke-tpu-accelerator,
+# gke-tpu-topology and gke-accelerator-count nodeSelectors itself.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: ct6e
+---
+# One queue per TPU shape, all of a generation's queues in one cohort, so that
+# nominalQuota is chips this shape can always have and no other shape can hold
+# the reservation against it, while whatever it is not using is lent out.
+#
+# reclaimWithinCohort stays Never: a lender waits for the borrower's workloads
+# to finish rather than evicting them. Eviction returns the accounting at once
+# but not the hardware, since eight chips freed across eight single-chip nodes
+# still have to scale down before an 8-chip node can boot, and the jobs killed
+# to get there have to run again.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: ct6e-standard-1t-1x1
+spec:
+  cohortName: ct6e
+  preemption:
+    reclaimWithinCohort: Never
+    withinClusterQueue: LowerPriority
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: buildkite
+  resourceGroups:
+    # google.com/tpu is the only resource under quota. The cpu and memory a
+    # workload, its gcsfuse sidecar and any helper containers request are
+    # ignored here (quotaCheckStrategy: IgnoreUndeclared) and enforced by the
+    # kube scheduler against node capacity.
+    - coveredResources:
+        - google.com/tpu
+      flavors:
+        - name: ct6e
+          resources:
+            - name: google.com/tpu
+              # Chips, not nodes. This is a ceiling on what Kueue will admit at
+              # once, not a promise that a slice of the right shape is free.
+              nominalQuota: 18
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: ct6e-standard-1t-1x1
+  namespace: buildkite
+spec:
+  clusterQueue: ct6e-standard-1t-1x1
+---
+# One queue per TPU shape, all of a generation's queues in one cohort, so that
+# nominalQuota is chips this shape can always have and no other shape can hold
+# the reservation against it, while whatever it is not using is lent out.
+#
+# reclaimWithinCohort stays Never: a lender waits for the borrower's workloads
+# to finish rather than evicting them. Eviction returns the accounting at once
+# but not the hardware, since eight chips freed across eight single-chip nodes
+# still have to scale down before an 8-chip node can boot, and the jobs killed
+# to get there have to run again.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: ct6e-standard-8t-2x4
+spec:
+  cohortName: ct6e
+  preemption:
+    reclaimWithinCohort: Never
+    withinClusterQueue: LowerPriority
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: buildkite
+  resourceGroups:
+    # google.com/tpu is the only resource under quota. The cpu and memory a
+    # workload, its gcsfuse sidecar and any helper containers request are
+    # ignored here (quotaCheckStrategy: IgnoreUndeclared) and enforced by the
+    # kube scheduler against node capacity.
+    - coveredResources:
+        - google.com/tpu
+      flavors:
+        - name: ct6e
+          resources:
+            - name: google.com/tpu
+              # Chips, not nodes. This is a ceiling on what Kueue will admit at
+              # once, not a promise that a slice of the right shape is free.
+              nominalQuota: 8
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: ct6e-standard-8t-2x4
+  namespace: buildkite
+spec:
+  clusterQueue: ct6e-standard-8t-2x4

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/worker-us-east5/queues/20-multikueue-rbac.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/worker-us-east5/queues/20-multikueue-rbac.yaml
@@ -1,0 +1,62 @@
+---
+# What the manager's Kueue controller may do in this worker cluster, reached
+# over Connect Gateway as the manager's Workload Identity.
+#
+# MultiKueue's manager only mirrors objects: it creates the Job or JobSet here,
+# watches it, copies status back, and deletes it when the workload finishes or
+# is evicted. This grants that and nothing else, because the alternative is a
+# controller in another project holding broad rights over a cluster that runs
+# workload images built from pull requests.
+#
+# If dispatch breaks, the symptom is workloads admitted on the manager with no
+# pods appearing here, and the Kueue controller logging a forbidden error
+# naming the verb it wanted. Add that verb.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kueue-multikueue-remote
+rules:
+  # The mirrored workload objects themselves.
+  - apiGroups: ["kueue.x-k8s.io"]
+    resources: ["workloads"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["kueue.x-k8s.io"]
+    resources: ["workloads/status", "workloads/finalizers"]
+    verbs: ["get", "update", "patch"]
+  # The two job kinds this fleet dispatches. Both are enabled in
+  # worker-config.yaml and must match the manager's framework list.
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs/status"]
+    verbs: ["get"]
+  - apiGroups: ["jobset.x-k8s.io"]
+    resources: ["jobsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["jobset.x-k8s.io"]
+    resources: ["jobsets/status"]
+    verbs: ["get"]
+  # Status reporting: why a workload is pending, and which pods it produced.
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kueue-multikueue-remote
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kueue-multikueue-remote
+subjects:
+  # Connect Gateway presents a federated Workload Identity principal in this
+  # form, so the binding is to a User rather than to a ServiceAccount in this
+  # cluster - the manager's controller has no identity here.
+  - kind: User
+    name: serviceAccount:cloud-ullm-inference-ci-cd.svc.id.goog[kueue-system/kueue-controller-manager]
+    apiGroup: rbac.authorization.k8s.io

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/worker-us-east5/system/10-kueue-config.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/worker-us-east5/system/10-kueue-config.yaml
@@ -1,0 +1,55 @@
+---
+# Overrides the ConfigMap that ships inside the upstream Kueue release, which
+# is why the name and namespace are fixed rather than templated: the manager
+# Deployment mounts this exact object at /controller_manager_config.yaml.
+#
+# Applied after the upstream manifests and under our own field manager, so a
+# server-side apply of a new Kueue version restores upstream's default and this
+# immediately puts ours back. Changing it does not restart anything, so the
+# deploy script rolls the Deployment afterwards.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kueue-manager-config
+  namespace: kueue-system
+data:
+  controller_manager_config.yaml: |
+    # Kueue controller configuration, on the manager and on every worker.
+    #
+    # The manager holds the queues and the quota but no TPUs: it admits a workload
+    # and MultiKueue mirrors it onto a worker, whose own Kueue admits it a second
+    # time against local quota and runs it. Both sides therefore have to agree on
+    # what a workload is and on how it is admitted, which is everything in this
+    # file. manager-config.yaml adds the keys only the dispatching side needs, and
+    # is appended to this one by generate_manifests.py.
+    apiVersion: config.kueue.x-k8s.io/v1beta2
+    kind: Configuration
+    manageJobsWithoutQueueName: false
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: :8443
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: c1f6bfd2.kueue.x-k8s.io
+    resources:
+      # Check only the resources a ClusterQueue declares. A TPU pod also requests
+      # cpu, memory and ephemeral-storage - its own, its gcsfuse sidecar's, and the
+      # helper containers agent-stack-k8s injects - and under the default
+      # BlockUndeclared any of those would make the workload inadmissible against a
+      # queue that covers google.com/tpu alone. The kube scheduler enforces them
+      # against node capacity, which is where they belong.
+      quotaCheckStrategy: IgnoreUndeclared
+    integrations:
+      frameworks:
+        - batch/job
+        # Multi-pod workloads: multi-host TPU slices and prefill/decode disagg.
+        # A batch/v1 Job cannot span hosts.
+        - jobset.x-k8s.io/jobset
+    waitForPodsReady:
+      # Inert without `enable: true`. Turning it on adds readiness-timeout eviction
+      # and requeue accounting, which changes how preemption behaves.
+      blockAdmission: false
+      timeout: 10800s

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/manager-config.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/manager-config.yaml
@@ -1,0 +1,23 @@
+# What the manager's Kueue adds to common-config.yaml: it is the only cluster
+# that dispatches, so it is the only one that needs a way to reach a worker.
+#
+# Appended to that file rather than merged into it, so every key here has to be
+# a top-level key the common file does not already set. generate_manifests.py
+# refuses to render if that stops being true.
+featureGates:
+  # MultiKueue reads worker credentials from ClusterProfile objects rather than
+  # from kubeconfig Secrets. GKE's fleet writes those profiles itself, so no
+  # long-lived token for a worker cluster exists anywhere.
+  MultiKueueClusterProfile: true
+multiKueue:
+  clusterProfile:
+    accessProviders:
+      # The binary that turns this cluster's Workload Identity into a token for
+      # a worker's Connect Gateway endpoint. Put on the controller pod by
+      # generate_manifests.py; the name matches the accessProvider GKE's fleet
+      # names in the ClusterProfile status.
+      - name: google
+        execConfig:
+          apiVersion: client.authentication.k8s.io/v1beta1
+          command: /plugins/gcp-auth-plugin
+          interactiveMode: Never

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/admission_check.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/admission_check.yaml.tpl
@@ -1,0 +1,13 @@
+---
+# Makes a ClusterQueue on the manager dispatch rather than run. A workload that
+# passes quota is held until MultiKueue has placed it on a worker.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: AdmissionCheck
+metadata:
+  name: ${QUEUE_NAME}-multikueue-dispatch
+spec:
+  controllerName: kueue.x-k8s.io/multikueue
+  parameters:
+    apiGroup: kueue.x-k8s.io
+    kind: MultiKueueConfig
+    name: ${QUEUE_NAME}-workers

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/auth_plugin_overlay.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/auth_plugin_overlay.yaml.tpl
@@ -1,0 +1,53 @@
+---
+# Puts a Kubernetes credential plugin on the manager controller's filesystem.
+#
+# MultiKueue reaches the workers through ClusterProfiles, whose access provider
+# is "google": the endpoint is a Connect Gateway URL and the credential is a
+# Google OAuth token. Kueue mints that token by executing the command named in
+# multiKueue.clusterProfile.accessProviders, and the upstream Kueue image
+# contains no such binary. This mounts one.
+#
+# A partial object, applied server-side after the upstream release manifests.
+# Field ownership is per list item - by container name, by volume name, by
+# mount path - so none of this collides with what upstream sets on the same
+# Deployment, and neither apply undoes the other.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kueue-controller-manager
+  namespace: kueue-system
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: add-gcp-auth-plugin
+          image: ${AUTH_PLUGIN_IMAGE}
+          command: ["cp", "${AUTH_PLUGIN_SRC}", "/plugins/gcp-auth-plugin"]
+          volumeMounts:
+            - name: clusterprofile-plugins
+              mountPath: /plugins
+          securityContext:
+            # The pod runs with runAsNonRoot and the gcloud image's default user
+            # is root, so a uid has to be named here or the kubelet refuses to
+            # start the container. Any uid works: the binary is world readable
+            # and an emptyDir is world writable.
+            runAsNonRoot: true
+            runAsUser: 65532
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      containers:
+        # Named to match the container in the upstream Deployment; this adds a
+        # mount to it and leaves every other field alone.
+        - name: manager
+          volumeMounts:
+            - name: clusterprofile-plugins
+              mountPath: /plugins
+      volumes:
+        - name: clusterprofile-plugins
+          emptyDir: {}

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/kueue_config.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/kueue_config.yaml.tpl
@@ -1,0 +1,17 @@
+---
+# Overrides the ConfigMap that ships inside the upstream Kueue release, which
+# is why the name and namespace are fixed rather than templated: the manager
+# Deployment mounts this exact object at /controller_manager_config.yaml.
+#
+# Applied after the upstream manifests and under our own field manager, so a
+# server-side apply of a new Kueue version restores upstream's default and this
+# immediately puts ours back. Changing it does not restart anything, so the
+# deploy script rolls the Deployment afterwards.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kueue-manager-config
+  namespace: kueue-system
+data:
+  controller_manager_config.yaml: |
+${CONFIG}

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/multikueue_cluster.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/multikueue_cluster.yaml.tpl
@@ -1,0 +1,14 @@
+---
+# A worker the manager may dispatch to. The credentials come from a
+# ClusterProfile that GKE's fleet writes into kueue-system by itself, because
+# the manager cluster carries the labels fleet-clusterinventory-management-
+# cluster=true and fleet-clusterinventory-namespace=kueue-system. Nothing here
+# holds a token for the worker.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: MultiKueueCluster
+metadata:
+  name: ${WORKER_NAME}
+spec:
+  clusterSource:
+    clusterProfileRef:
+      name: ${CLUSTER_PROFILE_NAME}

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/multikueue_config.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/multikueue_config.yaml.tpl
@@ -1,0 +1,11 @@
+---
+# The workers that have a node pool of this shape, and so the ones an
+# AdmissionCheck for it may place onto. Kueue picks the first that admits the
+# workload.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: MultiKueueConfig
+metadata:
+  name: ${QUEUE_NAME}-workers
+spec:
+  clusters:
+${WORKER_LIST}

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/multikueue_rbac_worker.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/multikueue_rbac_worker.yaml.tpl
@@ -1,0 +1,62 @@
+---
+# What the manager's Kueue controller may do in this worker cluster, reached
+# over Connect Gateway as the manager's Workload Identity.
+#
+# MultiKueue's manager only mirrors objects: it creates the Job or JobSet here,
+# watches it, copies status back, and deletes it when the workload finishes or
+# is evicted. This grants that and nothing else, because the alternative is a
+# controller in another project holding broad rights over a cluster that runs
+# workload images built from pull requests.
+#
+# If dispatch breaks, the symptom is workloads admitted on the manager with no
+# pods appearing here, and the Kueue controller logging a forbidden error
+# naming the verb it wanted. Add that verb.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kueue-multikueue-remote
+rules:
+  # The mirrored workload objects themselves.
+  - apiGroups: ["kueue.x-k8s.io"]
+    resources: ["workloads"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["kueue.x-k8s.io"]
+    resources: ["workloads/status", "workloads/finalizers"]
+    verbs: ["get", "update", "patch"]
+  # The two job kinds this fleet dispatches. Both are enabled in
+  # worker-config.yaml and must match the manager's framework list.
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs/status"]
+    verbs: ["get"]
+  - apiGroups: ["jobset.x-k8s.io"]
+    resources: ["jobsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["jobset.x-k8s.io"]
+    resources: ["jobsets/status"]
+    verbs: ["get"]
+  # Status reporting: why a workload is pending, and which pods it produced.
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kueue-multikueue-remote
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kueue-multikueue-remote
+subjects:
+  # Connect Gateway presents a federated Workload Identity principal in this
+  # form, so the binding is to a User rather than to a ServiceAccount in this
+  # cluster - the manager's controller has no identity here.
+  - kind: User
+    name: serviceAccount:${PROJECT_ID}.svc.id.goog[kueue-system/kueue-controller-manager]
+    apiGroup: rbac.authorization.k8s.io

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/namespace.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/namespace.yaml.tpl
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${NAMESPACE}
+  labels:
+    # baseline enforced rather than restricted: a TPU pod needs the
+    # google.com/tpu device, and the gcsfuse sidecar GKE injects runs with
+    # settings restricted rejects. warn/audit stay at restricted so anything
+    # that does not need the exemption still shows up.
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/queue_group.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/queue_group.yaml.tpl
@@ -1,0 +1,44 @@
+---
+# One queue per TPU shape, all of a generation's queues in one cohort, so that
+# nominalQuota is chips this shape can always have and no other shape can hold
+# the reservation against it, while whatever it is not using is lent out.
+#
+# reclaimWithinCohort stays Never: a lender waits for the borrower's workloads
+# to finish rather than evicting them. Eviction returns the accounting at once
+# but not the hardware, since eight chips freed across eight single-chip nodes
+# still have to scale down before an 8-chip node can boot, and the jobs killed
+# to get there have to run again.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: ${QUEUE_NAME}
+spec:
+  cohortName: ${ACCELERATOR}
+  preemption:
+    reclaimWithinCohort: Never
+    withinClusterQueue: LowerPriority
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: ${NAMESPACE}${ADMISSION_CHECKS}
+  resourceGroups:
+    # google.com/tpu is the only resource under quota. The cpu and memory a
+    # workload, its gcsfuse sidecar and any helper containers request are
+    # ignored here (quotaCheckStrategy: IgnoreUndeclared) and enforced by the
+    # kube scheduler against node capacity.
+    - coveredResources:
+        - google.com/tpu
+      flavors:
+        - name: ${ACCELERATOR}
+          resources:
+            - name: google.com/tpu
+              # Chips, not nodes. This is a ceiling on what Kueue will admit at
+              # once, not a promise that a slice of the right shape is free.
+              nominalQuota: ${NOMINAL_QUOTA}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: ${QUEUE_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterQueue: ${QUEUE_NAME}

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/resource_flavor.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/resource_flavor.yaml.tpl
@@ -1,0 +1,16 @@
+---
+# One flavor per TPU generation, and deliberately no nodeLabels.
+#
+# The flavor, not the queue, is Kueue's quota partition: quota is counted per
+# flavor, cohort borrowing is per flavor, and Kueue skips a flavor whose
+# nodeLabels conflict with what a podSet already asks for. A flavor per shape
+# would therefore make it impossible for a 1-chip job to use idle 8-chip
+# capacity, whatever the numbers said. Bare and shared, the per-shape queues
+# above it can lend to each other.
+#
+# Placement is the workload's: it carries the gke-tpu-accelerator,
+# gke-tpu-topology and gke-accelerator-count nodeSelectors itself.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: ${ACCELERATOR}

--- a/terraform/gcp_old/tpu-inference/k8s/locals.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/locals.tf
@@ -4,6 +4,16 @@ locals {
     component  = "tpu-ci"
   })
 
+  # The Kueue controller on the manager cluster, as IAM sees it. Workload
+  # Identity federates a Kubernetes service account into a principal in its own
+  # right, so this can hold roles without a Google service account to
+  # impersonate. The name is Kueue's own and is fixed by its release manifests.
+  kueue_controller_principal = join("", [
+    "principal://iam.googleapis.com/projects/${data.google_project.manager.number}",
+    "/locations/global/workloadIdentityPools/${var.project_id}.svc.id.goog",
+    "/subject/ns/kueue-system/sa/kueue-controller-manager",
+  ])
+
   # Every cluster's pools in one map, since one resource creates them all.
   #
   # A pool is named for its shape - the machine type and the topology asked of

--- a/terraform/gcp_old/tpu-inference/k8s/locals.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/locals.tf
@@ -49,34 +49,9 @@ locals {
     ]) : "${pool.worker}/${pool.name}" => pool
   }
 
-  # Keep this list to what a node needs to boot, log and report metrics. Every
-  # pod scheduled to a node can reach that node's identity, so anything a
-  # workload needs belongs on the workload's own service account through
-  # Workload Identity instead.
-  #
-  # container.defaultNodeServiceAccount is GKE's maintained definition of that
-  # minimum. It does not cover pulling private images; that is granted per
-  # repository in iam.tf, from var.image_repositories, to both node accounts.
-  node_service_account_roles = toset([
-    "roles/container.defaultNodeServiceAccount",
-  ])
-
   manager_repository_bindings = {
     for repo in var.image_repositories :
     "${repo.location}/${repo.repository}" => repo
-  }
-
-  worker_node_role_bindings = {
-    for item in flatten([
-      for worker_name, worker in var.worker_clusters : [
-        for role in local.node_service_account_roles : {
-          key         = "${worker_name}/${role}"
-          worker_name = worker_name
-          project     = worker.project
-          role        = role
-        }
-      ]
-    ]) : item.key => item
   }
 
   worker_node_repository_bindings = {

--- a/terraform/gcp_old/tpu-inference/k8s/locals.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/locals.tf
@@ -4,37 +4,39 @@ locals {
     component  = "tpu-ci"
   })
 
-  # The slice one VM of a TPU machine type covers, for the generations this
-  # fleet has chips in. v6e topologies are 2D, v7x 3D. The trailing count is
-  # chips per VM, unlike the Buildkite queue names, where tpu7x-8 counts
-  # TensorCores and is the four chips of a tpu7x-standard-4t.
-  single_host_topology = {
-    "ct6e-standard-1t"  = "1x1"
-    "ct6e-standard-4t"  = "2x2"
-    "ct6e-standard-8t"  = "2x4"
-    "tpu7x-standard-1t" = "1x1x1"
-    "tpu7x-standard-4t" = "2x2x1"
-  }
-
-  # Every cluster's pools in one map, since one resource creates them all. A
-  # name used by two clusters collides here rather than silently losing a pool.
+  # Every cluster's pools in one map, since one resource creates them all.
+  #
+  # A pool is named for its shape - the machine type and the topology asked of
+  # that machine, e.g. ct6e-standard-8t-2x4 - and the name is built here rather
+  # than given in the tfvars, so it cannot describe hardware the pool does not
+  # have. The map is keyed by cluster as well, because the name only has to be
+  # unique inside its own cluster and two regions running the same shape should
+  # name it the same thing.
   tpu_node_pools = {
     for pool in flatten([
       for worker_name, worker in var.worker_clusters : [
-        for pool_name, pool in worker.tpu_node_pools : merge(pool, {
-          name   = pool_name
-          worker = worker_name
+        for pool in worker.tpu_node_pools : [
+          # dims is the topology's dimensions padded to three with 1s, so that the
+          # product below is one expression: Terraform has no product(), and v7x
+          # topologies are 3D where v6e's are 2D.
+          for dims in [concat([for d in split("x", pool.topology) : parseint(d, 10)], [1, 1])] :
+          merge(pool, {
+            name   = "${pool.machine_type}-${pool.topology}"
+            worker = worker_name
 
-          # One VM covering the whole slice is the ordinary case, and needs no
-          # placement policy. Anything wider is a slice GKE has to place as a
-          # unit across several VMs, which it only does from one.
-          is_multi_host = pool.topology != local.single_host_topology[pool.machine_type]
-
-          cluster_project  = worker.project
-          cluster_location = worker.location
-        })
+            # One VM covering the whole slice is the ordinary case, and needs no
+            # placement policy. Anything wider is a slice GKE has to place as a
+            # unit across several VMs, which it only does from one. The machine
+            # type's suffix is chips per VM, unlike the Buildkite queue names,
+            # where tpu7x-8 counts TensorCores and is a four-chip
+            # tpu7x-standard-4t.
+            is_multi_host = dims[0] * dims[1] * dims[2] > parseint(
+              trimsuffix(reverse(split("-", pool.machine_type))[0], "t"), 10
+            )
+          })
+        ]
       ]
-    ]) : pool.name => pool
+    ]) : "${pool.worker}/${pool.name}" => pool
   }
 
   # Keep this list to what a node needs to boot, log and report metrics. Every

--- a/terraform/gcp_old/tpu-inference/k8s/prod.auto.tfvars
+++ b/terraform/gcp_old/tpu-inference/k8s/prod.auto.tfvars
@@ -20,6 +20,12 @@ image_repositories = [
   { location = "us-central1", repository = "vllm-on-tpu-docker-container" },
 ]
 
+kueue_version  = "0.19.0"
+jobset_version = "0.12.0"
+
+auth_plugin_image       = "gcr.io/google.com/cloudsdktool/google-cloud-cli:584.0.0"
+auth_plugin_source_path = "/usr/lib/google-cloud-sdk/bin/gke-gcloud-auth-plugin"
+
 # Keyed by region. The cluster pins no zones; the reservation's zone
 # (us-east5-a) belongs to the TPU pools that draw on it.
 worker_clusters = {
@@ -31,10 +37,11 @@ worker_clusters = {
     master_ipv4_cidr_block = "172.16.0.32/28"
 
     # Reservation cloudtpu-20260828173000-731402396 in us-east5-a: 128 v6e
-    # chips, 102 in use, 26 free. max_nodes sums to more than 26 so the shapes
-    # compete for what is free. min_nodes is the part that does partition the
-    # reservation, since those chips stay with one shape once booted, so it is
-    # kept small.
+    # chips, 102 in use, 26 free. nominal_nodes splits those 26 between the
+    # shapes so neither starves the other; max_nodes sums to more, so a shape
+    # borrowing the cohort's idle quota can still boot the nodes for it.
+    # min_nodes is the part that really does partition the reservation, since
+    # those chips stay with one shape once booted, so it is kept small.
     tpu_node_pools = [
       {
         machine_type     = "ct6e-standard-1t"
@@ -42,8 +49,9 @@ worker_clusters = {
         reservation_name = "cloudtpu-20260828173000-731402396"
         zone             = "us-east5-a"
 
-        min_nodes = 2
-        max_nodes = 26
+        min_nodes     = 2
+        nominal_nodes = 18
+        max_nodes     = 26
       },
       {
         machine_type     = "ct6e-standard-8t"
@@ -54,7 +62,10 @@ worker_clusters = {
         # No floor: eight chips is too much of what is free to leave parked, so
         # this shape boots a node per job.
         min_nodes = 0
-        max_nodes = 3
+        # One slice, which is what the disagg benchmark takes. Room for two more
+        # by borrowing whatever the single-chip queue is not using.
+        nominal_nodes = 1
+        max_nodes     = 3
       },
     ]
   }

--- a/terraform/gcp_old/tpu-inference/k8s/prod.auto.tfvars
+++ b/terraform/gcp_old/tpu-inference/k8s/prod.auto.tfvars
@@ -35,8 +35,8 @@ worker_clusters = {
     # compete for what is free. min_nodes is the part that does partition the
     # reservation, since those chips stay with one shape once booted, so it is
     # kept small.
-    tpu_node_pools = {
-      v6e-1t-1x1 = {
+    tpu_node_pools = [
+      {
         machine_type     = "ct6e-standard-1t"
         topology         = "1x1"
         reservation_name = "cloudtpu-20260828173000-731402396"
@@ -44,8 +44,8 @@ worker_clusters = {
 
         min_nodes = 2
         max_nodes = 26
-      }
-      v6e-8t-2x4 = {
+      },
+      {
         machine_type     = "ct6e-standard-8t"
         topology         = "2x4"
         reservation_name = "cloudtpu-20260828173000-731402396"
@@ -55,8 +55,8 @@ worker_clusters = {
         # this shape boots a node per job.
         min_nodes = 0
         max_nodes = 3
-      }
-    }
+      },
+    ]
   }
 }
 

--- a/terraform/gcp_old/tpu-inference/k8s/scripts/deploy_manifests.py
+++ b/terraform/gcp_old/tpu-inference/k8s/scripts/deploy_manifests.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Install Kueue and JobSet on every cluster in prod.auto.tfvars and apply this
+fleet's configuration on top.
+
+Not Terraform: the Kubernetes and Helm providers need a reachable API server at
+plan time, which turns creating a cluster and configuring it into two separate
+runs with a hand-edited variable between them. Here the clusters Terraform built
+are the input and every apply is idempotent, so this is safe to re-run and the
+plan is `kubectl diff`.
+
+  pip install -r scripts/requirements.txt
+
+  ./scripts/deploy_manifests.py              # diff, then confirm before applying
+  ./scripts/deploy_manifests.py --diff-only  # show what would change and stop
+  ./scripts/deploy_manifests.py --yes        # no prompt
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from generate_manifests import DEFAULT_OUT, TFVARS, generate, load_tfvars
+
+UPSTREAM_MANIFESTS = {
+    "kueue": "https://github.com/kubernetes-sigs/kueue/releases/download/v{version}/manifests.yaml",
+    "jobset": "https://github.com/kubernetes-sigs/jobset/releases/download/v{version}/manifests.yaml",
+}
+
+
+def upstream(name: str, index: dict) -> str:
+    return UPSTREAM_MANIFESTS[name].format(version=index[f"{name}_version"])
+
+
+def run(*args: str, quiet: bool = False) -> None:
+    """Run a command, or stop. There is no recovering from a failure here: what
+    we would be continuing from is a half-configured cluster."""
+    stdout = subprocess.DEVNULL if quiet else None
+    if subprocess.run(args, stdout=stdout).returncode:
+        raise SystemExit(f"failed: {shlex.join(args)}")
+
+
+def show_diff(*args: str) -> bool:
+    """Preview one apply. False if the preview could not be produced.
+
+    A failure is not fatal. Before the first install there is no kueue-system
+    namespace to diff namespaced objects against, so diff cannot work and there
+    is nothing yet to be careful about; afterwards a failure is worth seeing but
+    the apply would report it too. Either way the operator is told the preview
+    is incomplete before being asked to confirm.
+    """
+    # kubectl diff exits 1 when there are differences and above that when it
+    # failed, so only the second is a problem.
+    if subprocess.run(["kubectl", "diff", *args]).returncode > 1:
+        # On stderr, next to the error it is explaining.
+        print("  (could not diff the above; nothing installed yet, "
+              "or the cluster rejected it)", file=sys.stderr)
+        return False
+    return True
+
+
+def apply_ssa(*args: str) -> None:
+    """Server-side is mandatory, not a preference: the workloads and jobsets
+    CRDs are each over a megabyte, and a client-side apply stores the whole
+    object in the last-applied-configuration annotation, capped at 256 KB.
+
+    --force-conflicts is how our ConfigMap override survives. Applying an
+    upstream release hands ownership of every field it sets back to upstream;
+    taking it back is the point of applying ours afterwards. Field ownership is
+    per list item, so the auth plugin's container, volume and mount collide with
+    nothing.
+    """
+    run("kubectl", "apply", "--server-side", "--force-conflicts", *args)
+
+
+def deploy_cluster(cluster: dict, index: dict, diff_only: bool) -> bool:
+    """Configure one cluster, or preview it. False if the preview was partial."""
+    base = DEFAULT_OUT / cluster["dir"]
+
+    print(f"\n=== {cluster['name']} ({cluster['location']}, {cluster['role']}) ===")
+
+    # Only stdout is dropped. A failure here would otherwise leave the previous
+    # cluster selected and quietly apply one cluster's manifests to another.
+    run("gcloud", "container", "clusters", "get-credentials", cluster["name"],
+        "--project", cluster["project"], "--location", cluster["location"],
+        quiet=True)
+
+    if diff_only:
+        # A list, not a generator: all three previews should be shown, and all()
+        # would stop at the first one that could not be produced.
+        return all([
+            show_diff("-f", upstream("jobset", index)),
+            show_diff("-f", upstream("kueue", index)),
+            show_diff("-R", "-f", str(base)),
+        ])
+
+    # JobSet first: Kueue only enables its jobset integration for a CRD that
+    # exists when the controller starts, and the rollout at the end is what makes
+    # that true on a fresh cluster.
+    apply_ssa("-f", upstream("jobset", index))
+    apply_ssa("-f", upstream("kueue", index))
+
+    # Immediately after, so the window in which the controller could come up on
+    # upstream's default configuration - no MultiKueue, quota checks blocking on
+    # undeclared resources - is as short as possible.
+    apply_ssa("-R", "-f", str(base / "system"))
+
+    run("kubectl", "wait", "--for=condition=Established", "--timeout=180s",
+        "crd/clusterqueues.kueue.x-k8s.io",
+        "crd/localqueues.kueue.x-k8s.io",
+        "crd/resourceflavors.kueue.x-k8s.io",
+        "crd/jobsets.jobset.x-k8s.io")
+
+    # Picks up both the ConfigMap and the plugin: a mounted ConfigMap changing
+    # does not restart anything by itself.
+    run("kubectl", "rollout", "restart",
+        "deployment/kueue-controller-manager", "-n", "kueue-system")
+    run("kubectl", "rollout", "status", "deployment/kueue-controller-manager",
+        "-n", "kueue-system", "--timeout=300s")
+    run("kubectl", "rollout", "status", "deployment/jobset-controller-manager",
+        "-n", "jobset-system", "--timeout=300s")
+
+    # Last, because ClusterQueue and LocalQueue go through Kueue's validating
+    # webhook, which is the controller that just restarted.
+    apply_ssa("-R", "-f", str(base / "queues"))
+    return True
+
+
+def verify_generated() -> dict:
+    """Re-render the manifests, and refuse to deploy a committed tree that has
+    drifted from them.
+
+    A stale generated/ would silently deploy the previous tfvars, and the diff
+    below would look clean. The cluster list comes back from that same render
+    rather than from a file of its own, so what is deployed and what was checked
+    cannot describe different fleets.
+    """
+    with tempfile.TemporaryDirectory() as fresh:
+        index = generate(load_tfvars(TFVARS), Path(fresh))
+        if subprocess.run(["diff", "-ru", str(DEFAULT_OUT), fresh]).returncode:
+            raise SystemExit(
+                "\nkueue/generated is out of date: "
+                "run scripts/generate_manifests.py and commit."
+            )
+    return index
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--diff-only", action="store_true",
+                        help="show what would change and stop")
+    parser.add_argument("--yes", "-y", action="store_true",
+                        help="apply without prompting")
+    args = parser.parse_args()
+
+    # Our output is interleaved with kubectl's and gcloud's, which write to the
+    # terminal directly. Left buffered, every heading here arrives after the
+    # output it was meant to introduce.
+    sys.stdout.reconfigure(line_buffering=True)
+
+    for tool in ("kubectl", "gcloud"):
+        if shutil.which(tool) is None:
+            raise SystemExit(f"{tool} is not on PATH")
+
+    # Do not touch the operator's own kubeconfig or leave a context selected.
+    with tempfile.TemporaryDirectory() as kubeconfig_dir:
+        os.environ["KUBECONFIG"] = str(Path(kubeconfig_dir) / "config")
+
+        index = verify_generated()
+        # In the order the generator listed them: the manager first, so its
+        # queues exist before a worker starts reporting to them.
+        clusters = index["clusters"]
+        print(f"Kueue v{index['kueue_version']}, JobSet v{index['jobset_version']}, "
+              f"{len(clusters)} cluster(s).")
+
+        if not args.diff_only and not args.yes:
+            complete = all([
+                deploy_cluster(c, index, diff_only=True) for c in clusters
+            ])
+            print()
+            if not complete:
+                print("Part of the preview above is missing; "
+                      "read the notes before answering.")
+            if input(f"Apply to all {len(clusters)} cluster(s)? [y/N] ").lower() != "y":
+                raise SystemExit("aborted")
+
+        for cluster in clusters:
+            deploy_cluster(cluster, index, diff_only=args.diff_only)
+
+    print("\ndone")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/terraform/gcp_old/tpu-inference/k8s/scripts/generate_manifests.py
+++ b/terraform/gcp_old/tpu-inference/k8s/scripts/generate_manifests.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Render the Kueue objects for every cluster from prod.auto.tfvars.
+
+Kueue's queues have to agree with the node pools Terraform builds: a quota that
+does not match the reservation either strands chips or admits work that can
+never be scheduled. Reading the same tfvars Terraform reads keeps the two from
+drifting, at the cost of parsing HCL here.
+
+The output goes to kueue/generated/, which is committed. Reviewing a queue
+change means reading the diff of the YAML that will be applied, not inferring
+it from a template, and deploy_manifests.py refuses to run if the committed
+tree does not match a fresh render.
+
+generate() also returns the fleet it just rendered - the versions to install and
+the clusters to install them on - which is how deploy_manifests.py knows where
+to go, rather than from an index file that would be a third thing to keep in
+step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+import hcl2
+
+ROOT = Path(__file__).resolve().parent.parent
+TFVARS = ROOT / "prod.auto.tfvars"
+TEMPLATES = ROOT / "kueue" / "templates"
+DEFAULT_OUT = ROOT / "kueue" / "generated"
+
+# The one namespace, on the manager and on every worker. The agent-stack-k8s
+# controller, the launcher pods it creates and the workloads those submit all
+# share it, because a LocalQueue is namespaced and a workload names its queue
+# from inside its own namespace. It exists on the workers too because MultiKueue
+# mirrors a workload into the namespace it came from.
+NAMESPACE = "buildkite"
+
+
+def clean(value):
+    """Undo python-hcl2's quoting of bare identifiers.
+
+    hcl2 hands back object keys and unquoted values as the literal source text,
+    so a key written `us-east5` arrives as `"${us-east5}"` or `'us-east5'`
+    depending on where it sat. Strip that back to the string HCL means.
+    """
+    if isinstance(value, str):
+        if value.startswith("${") and value.endswith("}"):
+            value = value[2:-1]
+        return value.strip("\"'")
+    return value
+
+
+def load_tfvars(path: Path) -> dict:
+    with path.open() as f:
+        raw = hcl2.load(f)
+    return {k: clean_deep(v) for k, v in raw.items()}
+
+
+def clean_deep(value):
+    if isinstance(value, dict):
+        return {clean(k): clean_deep(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [clean_deep(v) for v in value]
+    return clean(value)
+
+
+def render(name: str, **values) -> str:
+    text = (TEMPLATES / f"{name}.yaml.tpl").read_text()
+    for key, value in values.items():
+        placeholder = "${" + key + "}"
+        if placeholder not in text:
+            raise KeyError(f"{name}.yaml.tpl has no {placeholder}")
+        text = text.replace(placeholder, str(value))
+    left = [line for line in text.splitlines() if "${" in line]
+    if left:
+        raise KeyError(f"{name}.yaml.tpl left unsubstituted: {left}")
+    return text
+
+
+def indent(text: str, spaces: int) -> str:
+    pad = " " * spaces
+    return "\n".join(pad + line if line else "" for line in text.rstrip().splitlines())
+
+
+def cohort(queue: str) -> str:
+    """The machine family, which names the ResourceFlavor and the cohort."""
+    return queue.split("-")[0]
+
+
+def shapes(worker: dict) -> dict[str, int]:
+    """Chips under quota per node pool in a worker cluster, keyed by queue.
+
+    A queue is named for its node pool - <machine type>-<topology>, e.g.
+    ct6e-standard-8t-2x4, joined the same way locals.tf joins it - rather than
+    for the cluster's copy of that pool, because two regions running the same
+    shape are one queue on the manager and MultiKueue picks the region.
+    """
+    return {
+        f"{pool['machine_type']}-{pool['topology']}": (
+            # The machine type's last field is chips per VM, unlike the
+            # Buildkite queue names, where tpu7x-8 counts TensorCores and is a
+            # four-chip tpu7x-standard-4t.
+            int(pool["nominal_nodes"])
+            * int(pool["machine_type"].rsplit("-", 1)[-1].removesuffix("t"))
+        )
+        for pool in worker.get("tpu_node_pools", [])
+    }
+
+
+def queues(shapes: dict[str, int], checks: bool) -> str:
+    """A flavor per machine family, then a queue per shape sharing it.
+
+    checks is what separates the manager from a worker: on the manager every
+    queue carries a MultiKueue AdmissionCheck, so passing quota there means the
+    workload is dispatched rather than run.
+    """
+    out = [
+        render("resource_flavor", ACCELERATOR=family)
+        for family in sorted({cohort(name) for name in shapes})
+    ]
+    for name, chips in sorted(shapes.items()):
+        out.append(
+            render(
+                "queue_group",
+                QUEUE_NAME=name,
+                ACCELERATOR=cohort(name),
+                NAMESPACE=NAMESPACE,
+                NOMINAL_QUOTA=chips,
+                ADMISSION_CHECKS=(
+                    "\n  admissionChecksStrategy:\n"
+                    "    admissionChecks:\n"
+                    f"      - name: {name}-multikueue-dispatch"
+                    if checks
+                    else ""
+                ),
+            )
+        )
+    return "".join(out)
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text.rstrip() + "\n")
+
+
+def generate(tfvars: dict, out_dir: Path) -> dict:
+    project = tfvars["project_id"]
+    prefix = tfvars["name_prefix"]
+    workers = tfvars.get("worker_clusters", {})
+
+    manager_name = f"{prefix}-manager"
+    manager_dir = "manager"
+
+    # Per shape, the workers that can run it and the chips they add up to. The
+    # manager's quota is the fleet's, because it admits on behalf of all of
+    # them; each worker then admits again against its own.
+    fleet: dict[str, dict] = {}
+    clusters = [
+        {
+            "dir": manager_dir,
+            "role": "manager",
+            "project": project,
+            "location": tfvars["manager_region"],
+            "name": manager_name,
+        }
+    ]
+
+    for worker_key in sorted(workers):
+        worker = workers[worker_key]
+        cluster_name = f"{prefix}-{worker_key}"
+        worker_dir = f"worker-{worker_key}"
+        clusters.append(
+            {
+                "dir": worker_dir,
+                "role": "worker",
+                "project": worker["project"],
+                "location": worker["location"],
+                "name": cluster_name,
+            }
+        )
+
+        local = shapes(worker)
+        for name, chips in local.items():
+            entry = fleet.setdefault(name, {"chips": 0, "workers": []})
+            entry["chips"] += chips
+            entry["workers"].append(cluster_name)
+
+        base = out_dir / worker_dir
+        write(base / "system" / "10-kueue-config.yaml", kueue_config("worker"))
+        write(base / "queues" / "00-namespace.yaml", render("namespace", NAMESPACE=NAMESPACE))
+        write(base / "queues" / "10-queues.yaml", queues(local, checks=False))
+        write(
+            base / "queues" / "20-multikueue-rbac.yaml",
+            render("multikueue_rbac_worker", PROJECT_ID=project),
+        )
+
+    base = out_dir / manager_dir
+    write(base / "system" / "10-kueue-config.yaml", kueue_config("manager"))
+    write(
+        base / "system" / "20-auth-plugin.yaml",
+        render(
+            "auth_plugin_overlay",
+            AUTH_PLUGIN_IMAGE=tfvars["auth_plugin_image"],
+            AUTH_PLUGIN_SRC=tfvars["auth_plugin_source_path"],
+        ),
+    )
+    write(base / "queues" / "00-namespace.yaml", render("namespace", NAMESPACE=NAMESPACE))
+    write(
+        base / "queues" / "10-queues.yaml",
+        queues(
+            {name: entry["chips"] for name, entry in fleet.items()},
+            checks=True,
+        ),
+    )
+    write(
+        base / "queues" / "20-multikueue.yaml",
+        "".join(
+            render("multikueue_cluster", WORKER_NAME=name, CLUSTER_PROFILE_NAME=profile)
+            for name, profile in sorted(
+                {
+                    c["name"]: f"{c['name']}-{c['location']}"
+                    for c in clusters
+                    if c["role"] == "worker"
+                }.items()
+            )
+        )
+        + "".join(
+            render("admission_check", QUEUE_NAME=queue)
+            + render(
+                "multikueue_config",
+                QUEUE_NAME=queue,
+                WORKER_LIST="\n".join(
+                    f"    - {name}" for name in sorted(entry["workers"])
+                ),
+            )
+            for queue, entry in sorted(fleet.items())
+        ),
+    )
+
+    return {
+        "kueue_version": tfvars["kueue_version"],
+        "jobset_version": tfvars["jobset_version"],
+        "clusters": clusters,
+    }
+
+
+def top_level_keys(text: str) -> set[str]:
+    """The keys a YAML document sets at column zero."""
+    return {
+        line.split(":", 1)[0]
+        for line in text.splitlines()
+        if ":" in line and line[:1].isalpha()
+    }
+
+
+def kueue_config(role: str) -> str:
+    """The controller ConfigMap: the shared configuration, plus the manager's.
+
+    The two sides admit the same workload, so most of the configuration has to
+    be the same on both and lives in one file rather than in two that a comment
+    asks you to keep in step. The manager's extra keys are appended, which is
+    only sound while the two files set disjoint top-level keys, so that is
+    checked rather than trusted.
+    """
+    text = (ROOT / "kueue" / "common-config.yaml").read_text()
+    if role == "manager":
+        extra = (ROOT / "kueue" / "manager-config.yaml").read_text()
+        clash = top_level_keys(text) & top_level_keys(extra)
+        if clash:
+            raise KeyError(
+                f"manager-config.yaml also sets {sorted(clash)}; appending it to "
+                f"common-config.yaml would leave the key twice in one document"
+            )
+        text = f"{text.rstrip()}\n{extra}"
+    return render("kueue_config", CONFIG=indent(text, 4))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT)
+    args = parser.parse_args()
+
+    tfvars = load_tfvars(TFVARS)
+
+    # Rendered into a fresh tree so a cluster or a generation that goes away
+    # leaves no file behind for deploy_manifests.py to keep applying.
+    if args.out_dir.exists():
+        shutil.rmtree(args.out_dir)
+    generate(tfvars, args.out_dir)
+
+    print(f"wrote {args.out_dir}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/terraform/gcp_old/tpu-inference/k8s/scripts/requirements.txt
+++ b/terraform/gcp_old/tpu-inference/k8s/scripts/requirements.txt
@@ -1,0 +1,3 @@
+# For generate_manifests.py, which reads prod.auto.tfvars so that the queues
+# and the node pools cannot describe different reservations.
+python-hcl2==8.1.2

--- a/terraform/gcp_old/tpu-inference/k8s/variables.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/variables.tf
@@ -72,19 +72,16 @@ variable "worker_clusters" {
     system_min_nodes    = optional(number, 1)
     system_max_nodes    = optional(number, 3)
 
-    # One per TPU shape this cluster can run, keyed by node pool name. Names
-    # have to be unique across all clusters, not just within one, because the
-    # pools are flattened into a single map to create them.
-    #
-    # Named <generation>-<chips per host>-<topology>, e.g. v6e-8t-2x4. The
-    # middle part is the machine type's suffix, and it is what makes the name
-    # unique: a topology does not determine the machine type. 2x4 is eight
-    # chips either as one ct6e-standard-8t or as two ct6e-standard-4t, and
-    # those differ in pod count, chips per pod and JobSet parallelism.
-    tpu_node_pools = optional(map(object({
-      # The machine type is the VM, the topology the slice asked of it. Matching
-      # shapes mean one VM holds the whole slice; a larger topology means one
-      # slice across several, which GKE only builds from a placement policy.
+    # One per TPU shape this cluster can run. A list rather than a map, because
+    # the node pool's name is its shape - <machine type>-<topology>, e.g.
+    # ct6e-standard-8t-2x4 - and locals.tf builds it from the two fields below
+    # rather than taking it from here, so it cannot name hardware the pool does
+    # not have.
+    tpu_node_pools = optional(list(object({
+      # The machine type is the VM, the topology the slice asked of it. Both are
+      # needed because a topology does not imply a machine type: 2x4 is eight
+      # chips either as one ct6e-standard-8t or as two ct6e-standard-4t, and
+      # those differ in pod count, chips per pod and JobSet parallelism.
       machine_type = string
       topology     = string
 
@@ -99,7 +96,7 @@ variable "worker_clusters" {
       # Above this pool's share of the reservation, so the shapes compete for
       # free chips; the reservation running out is what stops a scale-up.
       max_nodes = number
-    })), {})
+    })), [])
   }))
   description = "Worker clusters keyed by a short name. location is a region; the cluster pins no zones, because only a TPU node cares which zone it is in and its own node pool pins it there."
   default     = {}
@@ -110,6 +107,18 @@ variable "worker_clusters" {
       length(regexall("^[a-z0-9]+-[a-z0-9]+[0-9]$", w.location)) > 0
     ])
     error_message = "worker_clusters[*].location must be a region, not a zone: a zone here silently gets a zonal control plane, and changing it later rebuilds the cluster."
+  }
+
+  # The pool name is derived, so a repeated shape does not collide loudly the
+  # way a repeated map key would - it silently drops one of the two pools.
+  validation {
+    condition = alltrue([
+      for w in values(var.worker_clusters) :
+      length(distinct([
+        for p in w.tpu_node_pools : "${p.machine_type}-${p.topology}"
+      ])) == length(w.tpu_node_pools)
+    ])
+    error_message = "Two tpu_node_pools in one worker cluster have the same machine type and topology. The node pool is named for that pair, so the second would overwrite the first."
   }
 }
 

--- a/terraform/gcp_old/tpu-inference/k8s/variables.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/variables.tf
@@ -60,6 +60,31 @@ variable "image_repositories" {
   default     = []
 }
 
+# The four variables below are read by scripts/generate_manifests.py, not by
+# any resource here. They live in the same tfvars so that the cluster and what
+# runs on it are described in one place and change in one review, and so that
+# `terraform validate` type-checks them.
+
+variable "kueue_version" {
+  type        = string
+  description = "Kueue release to install, without the leading v. Its manifests are fetched from the GitHub release at deploy time; a tag is immutable, so pinning one pins the bytes."
+}
+
+variable "jobset_version" {
+  type        = string
+  description = "JobSet release to install, without the leading v. Kueue's jobset integration needs the CRD present, so this is installed first."
+}
+
+variable "auth_plugin_image" {
+  type        = string
+  description = "Image the manager's Kueue controller copies its Connect Gateway credential plugin out of. The Google CLI image is the only place Google publishes gke-gcloud-auth-plugin as a container; the binary is static, so it runs in Kueue's distroless image."
+}
+
+variable "auth_plugin_source_path" {
+  type        = string
+  description = "Path to the credential plugin inside auth_plugin_image."
+}
+
 variable "worker_clusters" {
   type = map(object({
     project                = string
@@ -76,7 +101,7 @@ variable "worker_clusters" {
     # the node pool's name is its shape - <machine type>-<topology>, e.g.
     # ct6e-standard-8t-2x4 - and locals.tf builds it from the two fields below
     # rather than taking it from here, so it cannot name hardware the pool does
-    # not have.
+    # not have. generate_manifests.py names the shape's Kueue queue the same way.
     tpu_node_pools = optional(list(object({
       # The machine type is the VM, the topology the slice asked of it. Both are
       # needed because a topology does not imply a machine type: 2x4 is eight
@@ -96,6 +121,15 @@ variable "worker_clusters" {
       # Above this pool's share of the reservation, so the shapes compete for
       # free chips; the reservation running out is what stops a scale-up.
       max_nodes = number
+
+      # This shape's share of the reservation, and the only one of the three
+      # counts that no resource here reads: generate_manifests.py turns it into
+      # the nominalQuota of the shape's ClusterQueue. Chips a shape can always
+      # get, so the shapes cannot starve each other, while the queues sit in
+      # one cohort and lend out whatever is idle. Summed across a cluster's
+      # pools it should be the chips the reservation actually has free, which
+      # is what max_nodes deliberately oversubscribes.
+      nominal_nodes = number
     })), [])
   }))
   description = "Worker clusters keyed by a short name. location is a region; the cluster pins no zones, because only a TPU node cares which zone it is in and its own node pool pins it there."

--- a/terraform/gcp_old/tpu-inference/k8s/workers.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/workers.tf
@@ -131,10 +131,10 @@ resource "google_container_node_pool" "worker_system" {
 resource "google_container_node_pool" "worker_tpu" {
   for_each = local.tpu_node_pools
 
-  name     = each.key
-  project  = each.value.cluster_project
+  name     = each.value.name
+  project  = google_container_cluster.worker[each.value.worker].project
   cluster  = google_container_cluster.worker[each.value.worker].name
-  location = each.value.cluster_location
+  location = google_container_cluster.worker[each.value.worker].location
 
   # The cluster pins no zones, so without this the pool spreads across the
   # region and lands in zones that cannot serve the reservation.
@@ -169,7 +169,7 @@ resource "google_container_node_pool" "worker_tpu" {
 
     labels = {
       "tpu-ci.google.com/worker"  = each.value.worker
-      "tpu-ci.google.com/profile" = each.key
+      "tpu-ci.google.com/profile" = each.value.name
     }
 
     # Nothing lands on a TPU node unless it asked for one.


### PR DESCRIPTION
There is one role, `container.defaultNodeServiceAccount`. A single-element `toset` crossed with the worker clusters gave `worker_node_role_bindings` — twelve lines of `flatten` to arrive at one binding per worker — and made both resources read as if the interesting question were which roles a node holds.

It isn't. The interesting question is that a node holds nothing beyond GKE's own minimum, because every pod on a node can reach the node's identity. That's now a comment on the resource instead of a structure implying a list that never grew.

Both addresses lose an index, so `moved` blocks keep Terraform from revoking and re-granting; the plan shows two moves and no other IAM change. They can be deleted after the next apply.

Stacked on #526.