### PR TITLE
tpu-ci k8s: derive the TPU pool name instead of writing it down

### DIFF
--- a/terraform/gcp_old/tpu-inference/k8s/locals.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/locals.tf
@@ -4,37 +4,39 @@ locals {
     component  = "tpu-ci"
   })
 
-  # The slice one VM of a TPU machine type covers, for the generations this
-  # fleet has chips in. v6e topologies are 2D, v7x 3D. The trailing count is
-  # chips per VM, unlike the Buildkite queue names, where tpu7x-8 counts
-  # TensorCores and is the four chips of a tpu7x-standard-4t.
-  single_host_topology = {
-    "ct6e-standard-1t"  = "1x1"
-    "ct6e-standard-4t"  = "2x2"
-    "ct6e-standard-8t"  = "2x4"
-    "tpu7x-standard-1t" = "1x1x1"
-    "tpu7x-standard-4t" = "2x2x1"
-  }
-
-  # Every cluster's pools in one map, since one resource creates them all. A
-  # name used by two clusters collides here rather than silently losing a pool.
+  # Every cluster's pools in one map, since one resource creates them all.
+  #
+  # A pool is named for its shape - the machine type and the topology asked of
+  # that machine, e.g. ct6e-standard-8t-2x4 - and the name is built here rather
+  # than given in the tfvars, so it cannot describe hardware the pool does not
+  # have. The map is keyed by cluster as well, because the name only has to be
+  # unique inside its own cluster and two regions running the same shape should
+  # name it the same thing.
   tpu_node_pools = {
     for pool in flatten([
       for worker_name, worker in var.worker_clusters : [
-        for pool_name, pool in worker.tpu_node_pools : merge(pool, {
-          name   = pool_name
-          worker = worker_name
+        for pool in worker.tpu_node_pools : [
+          # dims is the topology's dimensions padded to three with 1s, so that the
+          # product below is one expression: Terraform has no product(), and v7x
+          # topologies are 3D where v6e's are 2D.
+          for dims in [concat([for d in split("x", pool.topology) : parseint(d, 10)], [1, 1])] :
+          merge(pool, {
+            name   = "${pool.machine_type}-${pool.topology}"
+            worker = worker_name
 
-          # One VM covering the whole slice is the ordinary case, and needs no
-          # placement policy. Anything wider is a slice GKE has to place as a
-          # unit across several VMs, which it only does from one.
-          is_multi_host = pool.topology != local.single_host_topology[pool.machine_type]
-
-          cluster_project  = worker.project
-          cluster_location = worker.location
-        })
+            # One VM covering the whole slice is the ordinary case, and needs no
+            # placement policy. Anything wider is a slice GKE has to place as a
+            # unit across several VMs, which it only does from one. The machine
+            # type's suffix is chips per VM, unlike the Buildkite queue names,
+            # where tpu7x-8 counts TensorCores and is a four-chip
+            # tpu7x-standard-4t.
+            is_multi_host = dims[0] * dims[1] * dims[2] > parseint(
+              trimsuffix(reverse(split("-", pool.machine_type))[0], "t"), 10
+            )
+          })
+        ]
       ]
-    ]) : pool.name => pool
+    ]) : "${pool.worker}/${pool.name}" => pool
   }
 
   # Keep this list to what a node needs to boot, log and report metrics. Every

--- a/terraform/gcp_old/tpu-inference/k8s/prod.auto.tfvars
+++ b/terraform/gcp_old/tpu-inference/k8s/prod.auto.tfvars
@@ -35,8 +35,8 @@ worker_clusters = {
     # compete for what is free. min_nodes is the part that does partition the
     # reservation, since those chips stay with one shape once booted, so it is
     # kept small.
-    tpu_node_pools = {
-      v6e-1t-1x1 = {
+    tpu_node_pools = [
+      {
         machine_type     = "ct6e-standard-1t"
         topology         = "1x1"
         reservation_name = "cloudtpu-20260828173000-731402396"
@@ -44,8 +44,8 @@ worker_clusters = {
 
         min_nodes = 2
         max_nodes = 26
-      }
-      v6e-8t-2x4 = {
+      },
+      {
         machine_type     = "ct6e-standard-8t"
         topology         = "2x4"
         reservation_name = "cloudtpu-20260828173000-731402396"
@@ -55,8 +55,8 @@ worker_clusters = {
         # this shape boots a node per job.
         min_nodes = 0
         max_nodes = 3
-      }
-    }
+      },
+    ]
   }
 }
 

--- a/terraform/gcp_old/tpu-inference/k8s/variables.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/variables.tf
@@ -72,19 +72,16 @@ variable "worker_clusters" {
     system_min_nodes    = optional(number, 1)
     system_max_nodes    = optional(number, 3)
 
-    # One per TPU shape this cluster can run, keyed by node pool name. Names
-    # have to be unique across all clusters, not just within one, because the
-    # pools are flattened into a single map to create them.
-    #
-    # Named <generation>-<chips per host>-<topology>, e.g. v6e-8t-2x4. The
-    # middle part is the machine type's suffix, and it is what makes the name
-    # unique: a topology does not determine the machine type. 2x4 is eight
-    # chips either as one ct6e-standard-8t or as two ct6e-standard-4t, and
-    # those differ in pod count, chips per pod and JobSet parallelism.
-    tpu_node_pools = optional(map(object({
-      # The machine type is the VM, the topology the slice asked of it. Matching
-      # shapes mean one VM holds the whole slice; a larger topology means one
-      # slice across several, which GKE only builds from a placement policy.
+    # One per TPU shape this cluster can run. A list rather than a map, because
+    # the node pool's name is its shape - <machine type>-<topology>, e.g.
+    # ct6e-standard-8t-2x4 - and locals.tf builds it from the two fields below
+    # rather than taking it from here, so it cannot name hardware the pool does
+    # not have.
+    tpu_node_pools = optional(list(object({
+      # The machine type is the VM, the topology the slice asked of it. Both are
+      # needed because a topology does not imply a machine type: 2x4 is eight
+      # chips either as one ct6e-standard-8t or as two ct6e-standard-4t, and
+      # those differ in pod count, chips per pod and JobSet parallelism.
       machine_type = string
       topology     = string
 
@@ -99,7 +96,7 @@ variable "worker_clusters" {
       # Above this pool's share of the reservation, so the shapes compete for
       # free chips; the reservation running out is what stops a scale-up.
       max_nodes = number
-    })), {})
+    })), [])
   }))
   description = "Worker clusters keyed by a short name. location is a region; the cluster pins no zones, because only a TPU node cares which zone it is in and its own node pool pins it there."
   default     = {}
@@ -110,6 +107,18 @@ variable "worker_clusters" {
       length(regexall("^[a-z0-9]+-[a-z0-9]+[0-9]$", w.location)) > 0
     ])
     error_message = "worker_clusters[*].location must be a region, not a zone: a zone here silently gets a zonal control plane, and changing it later rebuilds the cluster."
+  }
+
+  # The pool name is derived, so a repeated shape does not collide loudly the
+  # way a repeated map key would - it silently drops one of the two pools.
+  validation {
+    condition = alltrue([
+      for w in values(var.worker_clusters) :
+      length(distinct([
+        for p in w.tpu_node_pools : "${p.machine_type}-${p.topology}"
+      ])) == length(w.tpu_node_pools)
+    ])
+    error_message = "Two tpu_node_pools in one worker cluster have the same machine type and topology. The node pool is named for that pair, so the second would overwrite the first."
   }
 }
 

--- a/terraform/gcp_old/tpu-inference/k8s/workers.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/workers.tf
@@ -131,10 +131,10 @@ resource "google_container_node_pool" "worker_system" {
 resource "google_container_node_pool" "worker_tpu" {
   for_each = local.tpu_node_pools
 
-  name     = each.key
-  project  = each.value.cluster_project
+  name     = each.value.name
+  project  = google_container_cluster.worker[each.value.worker].project
   cluster  = google_container_cluster.worker[each.value.worker].name
-  location = each.value.cluster_location
+  location = google_container_cluster.worker[each.value.worker].location
 
   # The cluster pins no zones, so without this the pool spreads across the
   # region and lands in zones that cannot serve the reservation.
@@ -169,7 +169,7 @@ resource "google_container_node_pool" "worker_tpu" {
 
     labels = {
       "tpu-ci.google.com/worker"  = each.value.worker
-      "tpu-ci.google.com/profile" = each.key
+      "tpu-ci.google.com/profile" = each.value.name
     }
 
     # Nothing lands on a TPU node unless it asked for one.


### PR DESCRIPTION
`v6e-1t-1x1` → `ct6e-standard-1t-1x1`, `v6e-8t-2x4` → `ct6e-standard-8t-2x4`.

#525 made the name carry chips per host, but as a hand-written map key sitting next to the `machine_type` and `topology` it was supposed to describe, and as `v6e-8t` rather than the machine type itself. Both halves of that go here: `tpu_node_pools` becomes a list of `machine_type` + `topology`, and `locals.tf` joins them into the name.

`is_multi_host` comes out of the same two fields — chips in the topology against chips on one VM — which retires the `single_host_topology` table.

`cluster_project`/`cluster_location` go too: they were copies of fields the node pool resource already has, since it resolves `google_container_cluster.worker[...]` two lines away for the cluster name.

A validation replaces the uniqueness the map key gave for free.

`terraform plan`: 2 to add, 2 to destroy. The pool name is ForceNew and neither pool holds a workload.

Lands before #526, whose queues are named after these pools.