### PR TITLE
tpu-ci k8s: trim the comments to what the code needs

### DIFF
--- a/terraform/gcp_old/tpu-inference/k8s/cache.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/cache.tf
@@ -1,20 +1,18 @@
 # A cache bucket pair per worker cluster, in that cluster's own region.
 #
 # The caches are the largest single lever on how efficiently the fleet uses its
-# chips, and distance is what decides their cost. Measured from a pod against a
-# bucket 10,000 km away, a compilation-cache miss took 502ms; against a bucket
-# in the cluster's region, 36ms. A compile-heavy step asks whether an entry
-# exists far more often than it reads one, so that difference moved a full suite
-# from 1.60x bare metal's chip-minutes to 0.80x.
+# chips, and distance decides their cost: a compilation-cache miss costs about
+# 502ms against a bucket 10,000 km away and 36ms against one in the cluster's
+# region. A compile-heavy step asks whether an entry exists far more often than
+# it reads one, so out-of-region caches roughly double a suite's chip-minutes.
 #
 # Two buckets rather than one with two prefixes. The gcsfuse CSI driver
 # identifies a volume by volumeHandle, which is the bucket name, so two
-# PersistentVolumes over one bucket are a single volume to the kubelet: it
-# mounts once and both mountPaths land on the same directory. That is not
-# hypothetical - /cache/jax listed the model cache. Separate buckets also let
-# the two keep their own retention, which they want, since compilation output is
-# cheap to recreate and churns constantly while a model is expensive to fetch
-# and rarely changes.
+# PersistentVolumes over one bucket are one volume to the kubelet: it mounts
+# once and both mountPaths land on the same directory, so /cache/jax lists the
+# model cache. It also lets the two keep their own retention: compilation
+# output is cheap to recreate and churns, a model is expensive to fetch and
+# rarely changes.
 
 resource "google_storage_bucket" "workload" {
   for_each = local.workload_buckets
@@ -26,31 +24,23 @@ resource "google_storage_bucket" "workload" {
   uniform_bucket_level_access = true
   storage_class               = "STANDARD"
 
-  # Real folders, chosen now because it cannot be chosen later: hierarchical
-  # namespace is fixed when a bucket is created and changing it means replacing
-  # the bucket.
+  # Real folders, and fixed at creation - changing it means replacing the
+  # bucket. It matters because of how gcsfuse writes: every write goes to a
+  # temporary object and is then renamed, which on a flat bucket is a copy plus
+  # a delete. HNS makes it an atomic folder operation with up to 8x the initial
+  # QPS limit. Requires uniform bucket-level access, set above.
   #
-  # It matters here because of how gcsfuse writes. Every write goes to a
-  # temporary object and is then renamed, and on a flat bucket a rename is a
-  # copy followed by a delete. HNS makes it a folder operation - atomic, and
-  # with up to 8x the initial QPS limit. Requires uniform bucket-level access,
-  # which is set above.
-  #
-  # What it costs: no object versioning, retention lock, bucket lock,
-  # cross-bucket replication or object-level ACLs. A rebuildable cache uses
-  # none of those.
+  # It rules out object versioning, retention and bucket lock, cross-bucket
+  # replication and object-level ACLs. A rebuildable cache uses none of those.
   hierarchical_namespace {
     enabled = true
   }
 
-  # No soft delete. It is on by default with a seven-day retention, and
-  # soft-deleted objects keep accruing storage charges for the whole of it.
-  #
-  # That is the wrong default for these buckets specifically: gcsfuse renames
-  # through copy-and-delete, and the lifecycle rule below deletes on a schedule,
-  # so a cache generates deletions continuously. Retaining a week of them would
-  # cost more than the cache itself, to protect data that is by construction
-  # recomputable.
+  # No soft delete. It defaults to on with seven days' retention, and
+  # soft-deleted objects accrue storage charges for the whole of it. A cache
+  # deletes continuously - gcsfuse renames through copy-and-delete, and the
+  # lifecycle rule below expires on a schedule - so a week of them would cost
+  # more than the cache itself, to protect data that is recomputable.
   soft_delete_policy {
     retention_duration_seconds = 0
   }
@@ -94,19 +84,13 @@ resource "google_storage_bucket" "workload" {
   })
 }
 
-# Bucket-scoped and additive on purpose.
+# Bucket-scoped and additive on purpose. _member manages exactly one (bucket,
+# role, member) tuple; _binding would own the whole role and _policy the whole
+# bucket, either of which fights anything else managing IAM here.
 #
-# _member manages exactly one (bucket, role, member) tuple. _binding would own
-# the whole role and _policy the whole bucket, either of which fights anything
-# else that manages IAM here - terraform reverting their change, them reverting
-# terraform's.
-#
-# The member is the Kubernetes service account itself, federated by Workload
-# Identity into a principal that can hold a role. There is no Google service
-# account to impersonate and so no key anywhere. It is granted to tpu-workload
-# rather than to the namespace's default account, because default is what a pod
-# gets when it names none - and the launcher will run images named by a pull
-# request.
+# Granted to tpu-workload rather than the namespace's default account, since
+# default is what a pod gets when it names none - and the launcher will run
+# images named by a pull request.
 resource "google_storage_bucket_iam_member" "workload" {
   for_each = local.workload_buckets
 

--- a/terraform/gcp_old/tpu-inference/k8s/iam.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/iam.tf
@@ -63,17 +63,14 @@ resource "google_artifact_registry_repository_iam_member" "worker_nodes" {
 # with no Google service account in between, so there is no key and nothing to
 # rotate; gke-gcloud-auth-plugin turns that identity into the gateway's token.
 #
-# On the project, which is the one grant here that is not scoped to the resource
-# it is about. Connect Gateway does not check gkehub.gateway.get against the
-# fleet membership; it checks its own resource, projects/<project>/
-# gkeMemberships/<id>, which carries no location and which a binding on the
-# membership does not cover. The same principal holding gatewayEditor on the
-# membership is refused with PERMISSION_DENIED, and the call succeeds only once
-# the role is held project-wide.
+# On the project - the one grant here not scoped to the resource it is about.
+# Connect Gateway checks gkehub.gateway.get against its own
+# projects/<project>/gkeMemberships/<id> resource, which a binding on the fleet
+# membership does not cover: the same principal holding gatewayEditor on the
+# membership is refused with PERMISSION_DENIED.
 #
-# So the bound on what the controller may do in a worker is not in IAM but in
-# the worker: the kueue-multikueue-remote ClusterRole that the generated
-# manifests bind to this principal is the whole of its access there.
+# So what bounds the controller inside a worker is not IAM but the
+# kueue-multikueue-remote ClusterRole the generated manifests bind it to there.
 resource "google_project_iam_member" "kueue_manager_gateway" {
   for_each = toset([for w in var.worker_clusters : w.project])
 
@@ -87,13 +84,12 @@ resource "google_project_iam_member" "kueue_manager_gateway" {
 # scope for the reason above and no other: in a worker the launcher can do
 # nothing beyond the tpu-launcher-log-reader ClusterRole bound to it there.
 #
-# gatewayReader, not the controller's gatewayEditor, since reading logs is get,
-# list and watch. gkehub.viewer alongside it because resolving the membership -
-# `gcloud container fleet memberships get-credentials` - reads the membership.
+# gatewayReader rather than gatewayEditor, since reading logs is get, list and
+# watch; gkehub.viewer alongside it because resolving the membership reads it.
 #
-# On var.project_id whatever project a worker runs in: workers.tf registers
-# every cluster into this project's fleet, so this is where the membership and
-# the gkeMemberships resource the gateway checks both live.
+# On var.project_id whatever project a worker runs in - workers.tf registers
+# every cluster into this project's fleet, so that is where the gkeMemberships
+# resource the gateway checks lives.
 resource "google_project_iam_member" "launcher_gateway" {
   for_each = toset(["roles/gkehub.gatewayReader", "roles/gkehub.viewer"])
 

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/common-config.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/common-config.yaml
@@ -1,11 +1,9 @@
 # Kueue controller configuration, on the manager and on every worker.
 #
-# The manager holds the queues and the quota but no TPUs: it admits a workload
-# and MultiKueue mirrors it onto a worker, whose own Kueue admits it a second
-# time against local quota and runs it. Both sides therefore have to agree on
-# what a workload is and on how it is admitted, which is everything in this
-# file. manager-config.yaml adds the keys only the dispatching side needs, and
-# is appended to this one by generate_manifests.py.
+# A workload is admitted twice - once by the manager against fleet quota, again
+# by the worker against local quota - so both sides have to agree on what a
+# workload is and how it is admitted, which is everything in this file.
+# manager-config.yaml adds the keys only the dispatching side needs.
 apiVersion: config.kueue.x-k8s.io/v1beta2
 kind: Configuration
 manageJobsWithoutQueueName: false
@@ -20,11 +18,10 @@ leaderElection:
   resourceName: c1f6bfd2.kueue.x-k8s.io
 resources:
   # Check only the resources a ClusterQueue declares. A TPU pod also requests
-  # cpu, memory and ephemeral-storage - its own, its gcsfuse sidecar's, and the
-  # helper containers agent-stack-k8s injects - and under the default
-  # BlockUndeclared any of those would make the workload inadmissible against a
-  # queue that covers google.com/tpu alone. The kube scheduler enforces them
-  # against node capacity, which is where they belong.
+  # cpu, memory and ephemeral-storage - its own and its gcsfuse sidecar's - and
+  # under the default BlockUndeclared any of those makes the workload
+  # inadmissible against a queue covering google.com/tpu alone. The kube
+  # scheduler enforces them against node capacity, which is where they belong.
   quotaCheckStrategy: IgnoreUndeclared
 integrations:
   frameworks:

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/charts/agent-stack-k8s.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/charts/agent-stack-k8s.yaml
@@ -3,39 +3,26 @@
 # Change the tfvars or kueue/templates/ and re-run the generator. An edit made
 # here is never applied: deploy_manifests.py re-renders and refuses to deploy a
 # tree that does not match.
-# Values for the agent-stack-k8s chart. Not a manifest: deploy_manifests.py
-# renders the chart with this and applies the result, so nothing under charts/
-# is ever applied on its own.
+# Values for the agent-stack-k8s chart. deploy_manifests.py renders the chart
+# with these and applies the result; helm is a renderer here, so there is no
+# release and no in-cluster Helm state.
 #
-# Committed and generated for the same reason the queues are - what the fleet is
-# configured to do should be readable in a diff. The chart's own output is not
-# committed, the way the Kueue and JobSet releases are not: it is upstream, it is
-# pinned by version, and helm is used here as a renderer and nothing more. There
-# is no release, no history and no in-cluster Helm state to reconcile against.
-#
-# Deliberately short. The chart writes the controller's config file by pasting
-# this block under three keys of its own - agent-token-secret, namespace and id -
-# and the controller parses that file with a YAML decoder that rejects a
-# duplicated key. So anything the chart already derives has to be left out and
-# set the way the chart derives it: the namespace from the render's --namespace,
-# the id from the release name.
+# Deliberately short. The chart pastes this block under three keys of its own -
+# agent-token-secret, namespace and id - and the controller parses the result
+# with a decoder that rejects a duplicated key, so anything the chart derives
+# must be left out.
 
-# Where the token comes from. The chart takes a Secret name, not a value, and
-# this one is written by the SecretSync in workload/ - so the token reaches the
-# cluster once, from Secret Manager, and the chart only refers to it.
-#
+# The chart takes a Secret name, not a value; workload/'s SecretSync writes it.
 # It becomes envFrom on the controller, so every key in that Secret is an
 # environment variable on it. Ours holds exactly one.
 agentStackSecret: buildkite-agent-token
 
 config:
-  # One queue, and one controller behind it. A Buildkite queue no longer encodes
-  # a TPU shape: every TPU step goes through the launcher, which names a profile
-  # and submits the real workload to Kueue. Adding a shape is a regenerated
-  # profile registry, not another agent or another queue.
+  # One queue for the whole fleet. A queue does not encode a TPU shape: every
+  # TPU step goes through the launcher, so adding a shape is a regenerated
+  # profile registry rather than another queue.
   #
-  # The organization is not named anywhere here. The controller has not needed it
-  # since it stopped using the GraphQL API in 0.28.0; it now takes the org and
-  # the cluster from the agent token, which is why that token has to be a
+  # The organization is not named here. The controller takes the org and the
+  # cluster from the agent token, which is why that token has to be a
   # cluster's and not the organization's.
   queue: kube

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/queues/10-queues.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/queues/10-queues.yaml
@@ -6,15 +6,11 @@
 ---
 # One flavor per TPU generation, and deliberately no nodeLabels.
 #
-# The flavor, not the queue, is Kueue's quota partition: quota is counted per
-# flavor, cohort borrowing is per flavor, and Kueue skips a flavor whose
-# nodeLabels conflict with what a podSet already asks for. A flavor per shape
-# would therefore make it impossible for a 1-chip job to use idle 8-chip
-# capacity, whatever the numbers said. Bare and shared, the per-shape queues
-# above it can lend to each other.
-#
-# Placement is the workload's: it carries the gke-tpu-accelerator,
-# gke-tpu-topology and gke-accelerator-count nodeSelectors itself.
+# The flavor, not the queue, is Kueue's quota partition, and Kueue skips a
+# flavor whose nodeLabels conflict with what a podSet asks for. A flavor per
+# shape would therefore stop a 1-chip job borrowing idle 8-chip capacity,
+# whatever the numbers said. Placement is the workload's anyway: it carries the
+# TPU nodeSelectors itself.
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
@@ -45,10 +41,9 @@ spec:
     admissionChecks:
       - name: ct6e-standard-1t-1x1-multikueue-dispatch
   resourceGroups:
-    # google.com/tpu is the only resource under quota. The cpu and memory a
-    # workload, its gcsfuse sidecar and any helper containers request are
-    # ignored here (quotaCheckStrategy: IgnoreUndeclared) and enforced by the
-    # kube scheduler against node capacity.
+    # google.com/tpu is the only resource under quota; everything else a pod
+    # requests is left to the kube scheduler. See quotaCheckStrategy in
+    # common-config.yaml.
     - coveredResources:
         - google.com/tpu
       flavors:
@@ -92,10 +87,9 @@ spec:
     admissionChecks:
       - name: ct6e-standard-8t-2x4-multikueue-dispatch
   resourceGroups:
-    # google.com/tpu is the only resource under quota. The cpu and memory a
-    # workload, its gcsfuse sidecar and any helper containers request are
-    # ignored here (quotaCheckStrategy: IgnoreUndeclared) and enforced by the
-    # kube scheduler against node capacity.
+    # google.com/tpu is the only resource under quota; everything else a pod
+    # requests is left to the kube scheduler. See quotaCheckStrategy in
+    # common-config.yaml.
     - coveredResources:
         - google.com/tpu
       flavors:

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/system/10-kueue-config.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/system/10-kueue-config.yaml
@@ -21,12 +21,10 @@ data:
   controller_manager_config.yaml: |
     # Kueue controller configuration, on the manager and on every worker.
     #
-    # The manager holds the queues and the quota but no TPUs: it admits a workload
-    # and MultiKueue mirrors it onto a worker, whose own Kueue admits it a second
-    # time against local quota and runs it. Both sides therefore have to agree on
-    # what a workload is and on how it is admitted, which is everything in this
-    # file. manager-config.yaml adds the keys only the dispatching side needs, and
-    # is appended to this one by generate_manifests.py.
+    # A workload is admitted twice - once by the manager against fleet quota, again
+    # by the worker against local quota - so both sides have to agree on what a
+    # workload is and how it is admitted, which is everything in this file.
+    # manager-config.yaml adds the keys only the dispatching side needs.
     apiVersion: config.kueue.x-k8s.io/v1beta2
     kind: Configuration
     manageJobsWithoutQueueName: false
@@ -41,11 +39,10 @@ data:
       resourceName: c1f6bfd2.kueue.x-k8s.io
     resources:
       # Check only the resources a ClusterQueue declares. A TPU pod also requests
-      # cpu, memory and ephemeral-storage - its own, its gcsfuse sidecar's, and the
-      # helper containers agent-stack-k8s injects - and under the default
-      # BlockUndeclared any of those would make the workload inadmissible against a
-      # queue that covers google.com/tpu alone. The kube scheduler enforces them
-      # against node capacity, which is where they belong.
+      # cpu, memory and ephemeral-storage - its own and its gcsfuse sidecar's - and
+      # under the default BlockUndeclared any of those makes the workload
+      # inadmissible against a queue covering google.com/tpu alone. The kube
+      # scheduler enforces them against node capacity, which is where they belong.
       quotaCheckStrategy: IgnoreUndeclared
     integrations:
       frameworks:
@@ -61,9 +58,8 @@ data:
     # What the manager's Kueue adds to common-config.yaml: it is the only cluster
     # that dispatches, so it is the only one that needs a way to reach a worker.
     #
-    # Appended to that file rather than merged into it, so every key here has to be
-    # a top-level key the common file does not already set. generate_manifests.py
-    # refuses to render if that stops being true.
+    # Appended to that file rather than merged, so every key here has to be one the
+    # common file does not set. generate_manifests.py refuses to render otherwise.
     featureGates:
       # MultiKueue reads worker credentials from ClusterProfile objects rather than
       # from kubeconfig Secrets. GKE's fleet writes those profiles itself, so no
@@ -81,11 +77,10 @@ data:
               apiVersion: client.authentication.k8s.io/v1beta1
               command: /plugins/gcp-auth-plugin
               args:
-                # Without this the plugin mints its token by shelling out to
-                # `gcloud config config-helper`, and there is no gcloud in Kueue's
-                # distroless image. Application default credentials come from the
-                # GKE metadata server instead, which is where Workload Identity
-                # hands the controller its own identity - the one the gatewayEditor
-                # binding in iam.tf is granted to.
+                # Without this the plugin shells out to `gcloud config
+                # config-helper`, and Kueue's image is distroless. Application
+                # default credentials come from the metadata server instead, which
+                # is where Workload Identity hands the controller the identity
+                # iam.tf grants gatewayEditor to.
                 - --use_application_default_credentials
               interactiveMode: Never

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/workload/00-agent-token.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/workload/00-agent-token.yaml
@@ -7,47 +7,36 @@
 # The Buildkite agent token, pulled out of Secret Manager and into a Kubernetes
 # Secret the agent-stack-k8s chart can be pointed at.
 #
-# GKE's own SecretSync, not External Secrets. There is no controller to install
-# and none to run: the reconciler lives in the GKE control plane, so nothing
-# here appears in `kubectl get pods` and there is nothing for the deploy script
-# to wait on. Enabling it is a cluster field, `secret_sync_config` in manager.tf.
+# GKE's own SecretSync, not External Secrets: the reconciler runs in the control
+# plane, so there is no controller to install and nothing for the deploy script
+# to wait on. Enabling it is `secret_sync_config` in manager.tf.
 #
-# Manager only, and not because a worker does no Buildkite work - a TPU pod
-# uploads its own artifacts, writes meta-data and reports to Test Engine, since
-# it is the only thing that can see its own output files. It is that it does so
-# with a different credential.
-#
-# This one is the org registration token. It is what an agent presents to
-# Buildkite to register and claim a job, and the only things that register are
-# the agent-stack-k8s controller and the agent pods it creates, both here. What
-# a workload pod calls `buildkite-agent` with is BUILDKITE_AGENT_ACCESS_TOKEN,
-# which the agent is handed back after registering: it is scoped to the one job,
-# it dies with it, and the launcher forwards it as a plain environment variable.
-# Nothing syncs it and nothing needs to.
-#
-# So syncing this secret to a worker would put a long-lived org credential next
-# to pods running images named by a pull request, and buy nothing.
+# Manager only. This is the org registration token, and the only things that
+# register are the controller and the agent pods it creates, both here. A TPU
+# pod does call `buildkite-agent` - it is the only thing that can see its own
+# output files - but with BUILDKITE_AGENT_ACCESS_TOKEN, which is scoped to the
+# one job and forwarded as a plain environment variable. Syncing this one to a
+# worker would put a long-lived org credential next to pods running images
+# named by a pull request, and buy nothing.
 
 # The identity the sync reads Secret Manager as. Its own, not tpu-workload:
-# these are two different jobs - one may read the agent token, the other may
-# write to the caches - and a workload image named by a pull request runs as the
-# second. Nothing mounts this account, so nothing that runs here can use it.
+# one may read the agent token, the other may write to the caches, and a
+# workload image named by a pull request runs as the second. Nothing mounts
+# this account, so nothing that runs here can use it.
 #
 # No Google service account annotation: secrets.tf grants the accessor role
-# straight to the Workload Identity principal for this account, so there is
-# nothing to impersonate and no key to rotate.
+# straight to the Workload Identity principal, so there is nothing to
+# impersonate and no key to rotate.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: secret-sync
   namespace: buildkite
 ---
-# Which secret, and what to call it on the way through. The path is internal:
-# it names the value inside this class so the SecretSync below can refer to it,
-# and it is never a file anywhere - nothing mounts this class as a CSI volume.
-#
-# `versions/latest` rather than a pinned version, because rotation is the point.
-# A new version is picked up on the next poll.
+# Which secret, and what to call it on the way through. `path` is internal - it
+# names the value for the SecretSync below, and is never a file anywhere, since
+# nothing mounts this class as a CSI volume. `versions/latest` because rotation
+# is the point: a new version is picked up on the next poll.
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
@@ -62,18 +51,13 @@ spec:
 ---
 # The Secret itself, which takes this object's own name. The key is not ours to
 # choose - agent-stack-k8s reads BUILDKITE_AGENT_TOKEN out of whatever Secret it
-# is pointed at - but the name is, and it comes from the generator rather than
-# from here, because the chart's values have to name the same Secret.
+# is pointed at - but the name is, and it comes from the generator, because the
+# chart's values have to name the same Secret.
 #
-# Rotation updates this object in place - same name, new value, within about
-# five minutes of a new Secret Manager version. There is no watch, only a poll,
-# so treat five minutes as the bound. Pods that read the token at startup pick
-# it up on their next start; the controller holds its copy for the life of its
-# process, so rotating the token also means restarting that Deployment.
-#
-# The Secret lands in this namespace because there is nowhere else it could:
-# SecretSync has no target-namespace field and writes only beside itself. That
-# is where it is wanted anyway.
+# Rotation updates this object in place, within about five minutes of a new
+# Secret Manager version: there is no watch, only a poll. The controller holds
+# its copy for the life of its process, so rotating the token also means
+# restarting that Deployment.
 apiVersion: secret-sync.gke.io/v1
 kind: SecretSync
 metadata:

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/workers/cloud-ullm-inference-ci-cd/us-east5/queues/10-queues.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/workers/cloud-ullm-inference-ci-cd/us-east5/queues/10-queues.yaml
@@ -6,15 +6,11 @@
 ---
 # One flavor per TPU generation, and deliberately no nodeLabels.
 #
-# The flavor, not the queue, is Kueue's quota partition: quota is counted per
-# flavor, cohort borrowing is per flavor, and Kueue skips a flavor whose
-# nodeLabels conflict with what a podSet already asks for. A flavor per shape
-# would therefore make it impossible for a 1-chip job to use idle 8-chip
-# capacity, whatever the numbers said. Bare and shared, the per-shape queues
-# above it can lend to each other.
-#
-# Placement is the workload's: it carries the gke-tpu-accelerator,
-# gke-tpu-topology and gke-accelerator-count nodeSelectors itself.
+# The flavor, not the queue, is Kueue's quota partition, and Kueue skips a
+# flavor whose nodeLabels conflict with what a podSet asks for. A flavor per
+# shape would therefore stop a 1-chip job borrowing idle 8-chip capacity,
+# whatever the numbers said. Placement is the workload's anyway: it carries the
+# TPU nodeSelectors itself.
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
@@ -42,10 +38,9 @@ spec:
     matchLabels:
       kubernetes.io/metadata.name: buildkite
   resourceGroups:
-    # google.com/tpu is the only resource under quota. The cpu and memory a
-    # workload, its gcsfuse sidecar and any helper containers request are
-    # ignored here (quotaCheckStrategy: IgnoreUndeclared) and enforced by the
-    # kube scheduler against node capacity.
+    # google.com/tpu is the only resource under quota; everything else a pod
+    # requests is left to the kube scheduler. See quotaCheckStrategy in
+    # common-config.yaml.
     - coveredResources:
         - google.com/tpu
       flavors:
@@ -86,10 +81,9 @@ spec:
     matchLabels:
       kubernetes.io/metadata.name: buildkite
   resourceGroups:
-    # google.com/tpu is the only resource under quota. The cpu and memory a
-    # workload, its gcsfuse sidecar and any helper containers request are
-    # ignored here (quotaCheckStrategy: IgnoreUndeclared) and enforced by the
-    # kube scheduler against node capacity.
+    # google.com/tpu is the only resource under quota; everything else a pod
+    # requests is left to the kube scheduler. See quotaCheckStrategy in
+    # common-config.yaml.
     - coveredResources:
         - google.com/tpu
       flavors:

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/workers/cloud-ullm-inference-ci-cd/us-east5/system/10-kueue-config.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/workers/cloud-ullm-inference-ci-cd/us-east5/system/10-kueue-config.yaml
@@ -21,12 +21,10 @@ data:
   controller_manager_config.yaml: |
     # Kueue controller configuration, on the manager and on every worker.
     #
-    # The manager holds the queues and the quota but no TPUs: it admits a workload
-    # and MultiKueue mirrors it onto a worker, whose own Kueue admits it a second
-    # time against local quota and runs it. Both sides therefore have to agree on
-    # what a workload is and on how it is admitted, which is everything in this
-    # file. manager-config.yaml adds the keys only the dispatching side needs, and
-    # is appended to this one by generate_manifests.py.
+    # A workload is admitted twice - once by the manager against fleet quota, again
+    # by the worker against local quota - so both sides have to agree on what a
+    # workload is and how it is admitted, which is everything in this file.
+    # manager-config.yaml adds the keys only the dispatching side needs.
     apiVersion: config.kueue.x-k8s.io/v1beta2
     kind: Configuration
     manageJobsWithoutQueueName: false
@@ -41,11 +39,10 @@ data:
       resourceName: c1f6bfd2.kueue.x-k8s.io
     resources:
       # Check only the resources a ClusterQueue declares. A TPU pod also requests
-      # cpu, memory and ephemeral-storage - its own, its gcsfuse sidecar's, and the
-      # helper containers agent-stack-k8s injects - and under the default
-      # BlockUndeclared any of those would make the workload inadmissible against a
-      # queue that covers google.com/tpu alone. The kube scheduler enforces them
-      # against node capacity, which is where they belong.
+      # cpu, memory and ephemeral-storage - its own and its gcsfuse sidecar's - and
+      # under the default BlockUndeclared any of those makes the workload
+      # inadmissible against a queue covering google.com/tpu alone. The kube
+      # scheduler enforces them against node capacity, which is where they belong.
       quotaCheckStrategy: IgnoreUndeclared
     integrations:
       frameworks:

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/workers/cloud-ullm-inference-ci-cd/us-east5/workload/00-service-account.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/workers/cloud-ullm-inference-ci-cd/us-east5/workload/00-service-account.yaml
@@ -6,11 +6,9 @@
 ---
 # The identity a TPU workload runs as.
 #
-# Named rather than `default`, which is what every pod in the namespace gets
-# when none is set. The cache buckets grant object access to this principal, and
-# `default` would hand that to anything scheduled here - including a workload
-# image named by a pull request, since the launcher accepts any image it is
-# given.
+# Named rather than `default`: the cache buckets grant object access to this
+# principal, and `default` is what every pod in the namespace gets when none is
+# set - which would extend that access to anything scheduled here.
 #
 # No Google service account annotation: cache.tf grants the roles directly to
 # cloud-ullm-inference-ci-cd.svc.id.goog[buildkite/tpu-workload], so there is nothing to

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/workers/cloud-ullm-inference-ci-cd/us-east5/workload/10-cache-volumes.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/workers/cloud-ullm-inference-ci-cd/us-east5/workload/10-cache-volumes.yaml
@@ -6,19 +6,14 @@
 ---
 # The caches, as claims a pod can name without knowing where they live.
 #
-# Static PersistentVolumes rather than inline CSI volumes in the workload
-# manifest. The bucket is regional - a cache 10,000 km away costs 502ms per miss
-# against 36ms in-region - so its name differs per cluster, and putting it in
-# the workload would mean every manifest, pipeline and step carrying a bucket
-# name it has no business knowing. Here the claim names are identical in every
-# region and the binding is infrastructure, which also survives MultiKueue
-# placing a job somewhere other than where it was submitted: the claim resolves
-# at mount time, in whichever cluster the pod actually landed in.
-#
-# Created here rather than by the workload because MultiKueue copies only the
-# Job. A claim created where the launcher runs would not exist where the pod
-# does. These are static and shared, and gcsfuse serves ReadWriteMany, so every
-# pod mounts the same claim at once.
+# Static PersistentVolumes rather than inline CSI volumes in the workload. The
+# bucket is regional (see cache.tf), so its name differs per cluster, and in
+# the workload it would mean every manifest and step carrying a bucket name it
+# has no business knowing. Here the claim names are identical everywhere and
+# resolve at mount time, in whichever cluster MultiKueue actually landed the
+# pod in - which also has to be here rather than created by the workload,
+# because MultiKueue copies only the Job. gcsfuse serves ReadWriteMany, so
+# every pod mounts the same claim at once.
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -37,17 +32,15 @@ spec:
     name: jax-cache
   mountOptions:
     - implicit-dirs
-    # Scoped to this cache, not the whole bucket. The bucket is per purpose but
-    # will hold more than one kind of compilation cache, so this one lives under
-    # its own prefix and the mount says so - otherwise the metadata prefetch
-    # walks every other kind at mount time to reach this one. A second kind gets
+    # Scoped to this cache, not the whole bucket, so the metadata prefetch does
+    # not walk every other kind of cache in it at mount time. A second kind gets
     # its own PersistentVolume with its own only-dir.
     - only-dir=jax_cache
     # Thousands of small content-addressed files, read far more often than
-    # written. Never expire metadata: every access stats the object, the default
-    # TTL is 60s, and re-stating over the network is what a compile-heavy step
-    # would otherwise spend its time on. Safe to pin because an entry's name
-    # encodes its contents, so a name never changes meaning.
+    # written. Never expire metadata: every access stats the object, and at the
+    # default 60s TTL a compile-heavy step spends its time re-stating over the
+    # network. Safe to pin because an entry's name encodes its contents, so a
+    # name never changes meaning.
     - metadata-cache:ttl-secs:-1
     - metadata-cache:stat-cache-max-size-mb:-1
     - metadata-cache:type-cache-max-size-mb:-1
@@ -72,17 +65,14 @@ spec:
       # Redundant here: every pod uses the same service account against the same
       # bucket, and the check costs IAM and STS calls on the startup path.
       skipCSIBucketAccessCheck: "true"
-      # 8Gi against the model mount's 65Gi. Compilation entries are thousands of
-      # small files and a run reads a fraction of a namespace that is only ~34GB
-      # whole, so the rest of the node's cache is worth more to the models.
+      # 8Gi against the model mount's 65Gi: a run reads a fraction of a
+      # namespace that is only ~34GB whole, so the rest of the node's cache is
+      # worth more to the models. Explicit rather than -1, which fills the
+      # volume and then starts failing writes.
       #
-      # Explicit rather than -1: this is the threshold gcsfuse evicts against,
-      # and with -1 it fills the volume and then starts failing writes.
-      #
-      # One figure, not one per machine type: a PersistentVolume is a single
-      # object per cluster and every profile's pods bind the same claim, so it
-      # has to hold on the smallest shape we run. Sized for ct6e-standard-1t's
-      # 176 GB, and conservative above it.
+      # One figure, not one per machine type: a PersistentVolume is one object
+      # per cluster and every profile binds the same claim, so it has to hold on
+      # the smallest shape we run - ct6e-standard-1t's 176 GB.
       fileCacheCapacity: "8Gi"
       # Defaults to false, which sends random reads past the cache to GCS.
       fileCacheForRangeRead: "true"
@@ -112,10 +102,9 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  # Ignored, as above, and worth repeating here because this mount holds
-  # multi-gigabyte checkpoints and 1Gi reads like a limit. It is not one: the
-  # driver never enforces capacity on a bucket. What does bound anything is
-  # fileCacheCapacity below, which sizes the on-node cache.
+  # Ignored, as above - worth repeating because this mount holds multi-gigabyte
+  # checkpoints and 1Gi reads like a limit. It is not one. What bounds anything
+  # is fileCacheCapacity below, which sizes the on-node cache.
   capacity:
     storage: 1Gi
   storageClassName: ""
@@ -147,20 +136,16 @@ spec:
     volumeAttributes:
       gcsfuseMetadataPrefetchOnMount: "true"
       skipCSIBucketAccessCheck: "true"
-      # 65Gi. fileCacheForRangeRead below pulls a whole object into the cache on
-      # a partial read, and gcsfuse will not cache an object that does not fit
-      # the remaining capacity - so at 20Gi the larger checkpoints, read a few
-      # layers at a time, were refetched on every load and evicted the small
-      # models that would have fit. That was 84.6m of a 111.8m step; at 56Gi the
-      # same work took 23.8m and the step reached parity with bare metal. 73Gi
-      # was no better than 56Gi, so the working set already fits and the
-      # difference is ~25 GiB of node returned to the tests.
+      # 65Gi, which holds the whole working set. fileCacheForRangeRead below
+      # pulls an object into the cache on a partial read, and gcsfuse will not
+      # cache an object that does not fit the remaining capacity, so a capacity
+      # under the largest checkpoint refetches it on every load and evicts the
+      # small models that would have fit.
       #
       # The pod must back this with a gke-gcsfuse-cache volume at least this
       # large, or the sidecar falls back to 5GiB of ephemeral storage and the
-      # capacity is nominal. The launcher substitutes FUSE_CACHE_SIZE for that
-      # - half the machine type's memory, the volume being a RAM-backed
-      # emptyDir - and every shape this fleet runs clears 65Gi.
+      # capacity is nominal. The launcher sizes that volume at half the machine
+      # type's memory, and every shape this fleet runs clears 65Gi.
       fileCacheCapacity: "65Gi"
       # safetensors are memory-mapped, which is nothing but random reads. With
       # this false a 2.88 GiB checkpoint page-faulted over the network until the

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/launcher/Dockerfile
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/launcher/Dockerfile
@@ -1,11 +1,11 @@
 # The launcher image: the Google Cloud CLI plus PyYAML.
 #
 # The CLI image for the three things only it ships together - kubectl, gcloud,
-# and gke-gcloud-auth-plugin, without which the Connect Gateway credentials are
-# useless. PyYAML because it is the one thing it does not: the image's Python
-# is 3.13 and the only YAML under the SDK root is a Python 2 PyYAML whose own
-# imports fail. Installed here rather than at job time, so PyPI is not in the
-# path of every TPU step.
+# and gke-gcloud-auth-plugin, without which Connect Gateway credentials are
+# useless. PyYAML because it is the one thing it does not: the only YAML under
+# the SDK root is a Python 2 PyYAML whose imports fail on the image's 3.13.
+# Installed here rather than at job time, so PyPI is not in the path of every
+# TPU step.
 ARG CLOUD_SDK_VERSION
 FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:${CLOUD_SDK_VERSION}
 

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/launcher/cloudbuild.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/launcher/cloudbuild.yaml
@@ -13,8 +13,8 @@ substitutions:
   # Bumped when this Dockerfile changes without the base image changing, so a
   # tag always names one set of bytes.
   _REVISION: "1"
-  # The fleet's own repository, not tpu-inference-ci: that one holds the CI
-  # images a test runs, built from the tpu-inference repo and named by a step.
+  # The fleet's own repository, not tpu-inference-ci, which holds the CI images
+  # a test runs.
   _IMAGE: us-central1-docker.pkg.dev/cloud-ullm-inference-ci-cd/tpu-ci/launcher
 
 steps:

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/launcher/job.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/launcher/job.yaml
@@ -45,19 +45,16 @@ spec:
         # of thousands of entries and a prefetch that runs out of memory falls
         # back to a lookup per miss.
         gke-gcsfuse/metadata-prefetch-memory-limit: "2Gi"
-        # Unlimited sidecar CPU and memory. Parallel downloads are the whole
-        # reason a multi-gigabyte checkpoint arrives in one pass rather than
-        # eight sequential ones, and they are CPU-bound; the default limits
-        # throttle exactly the work we tuned for. Permitted on Standard
-        # clusters only, which these are.
+        # Unlimited sidecar CPU and memory. Parallel downloads are what make a
+        # multi-gigabyte checkpoint arrive in one pass rather than eight
+        # sequential ones, and they are CPU-bound, so the default limits
+        # throttle them. Permitted on Standard clusters only, which these are.
         gke-gcsfuse/cpu-limit: "0"
         gke-gcsfuse/memory-limit: "0"
     spec:
       restartPolicy: Never
-      # The identity the cache buckets authorise. Named rather than left as
-      # `default`, which every pod without this field runs as: granting cache
-      # writes to `default` would extend them to anything scheduled in this
-      # namespace, and a step chooses its own image.
+      # The identity the cache buckets authorise; see workload_sa.yaml.tpl for
+      # why it is not `default`.
       serviceAccountName: tpu-workload
       nodeSelector:
         cloud.google.com/gke-tpu-accelerator: ${ACCELERATOR_LABEL}
@@ -104,16 +101,15 @@ spec:
               mountPath: /cache/hf/hub
       volumes:
         # Backing store for the gcsfuse file cache, in RAM. The launcher sets
-        # sizeLimit from the machine type: half of host memory, which is 80Gi
-        # on ct6e-standard-1t's 176 GB and 670Gi on ct6e-standard-8t's 1440 GB,
-        # and one fixed number would be unsafe on the smallest or waste most of
-        # the largest. A sizeLimit, not a reservation - tmpfs holds only what is
-        # written.
+        # sizeLimit to half the machine type's memory - 80Gi on
+        # ct6e-standard-1t, 670Gi on ct6e-standard-8t - since one fixed number
+        # would be unsafe on the smallest shape or waste most of the largest.
+        # A sizeLimit, not a reservation: tmpfs holds only what is written.
         #
-        # Without this volume the sidecar falls back to 5GiB of ephemeral
-        # storage and fileCacheCapacity becomes a cheque it cannot cash: build
-        # 239 spent 113.6m of part2 loading checkpoints that way, against 8.8m
-        # with a cache that fits.
+        # Without it the sidecar falls back to 5GiB of ephemeral storage and
+        # fileCacheCapacity becomes a cheque it cannot cash - checkpoints are
+        # then refetched on every load, which costs more than an order of
+        # magnitude in load time.
         - name: gke-gcsfuse-cache
           emptyDir:
             medium: Memory
@@ -123,15 +119,10 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 16Gi
-        # Both caches are claims, not mounts.
-        #
-        # The bucket is regional - a cache in another region costs 502ms per
-        # miss against 36ms in-region - so its name differs per cluster. The
-        # PersistentVolume behind these claims holds it, created by ci-infra
-        # alongside the cluster, and the claim names are identical everywhere.
-        # That is also what survives MultiKueue placing this Job in another
-        # region: the claim resolves at mount time, in whichever cluster the pod
-        # landed in, where an inline volume is rendered before submission.
+        # Both caches are claims, not mounts: the bucket is regional, so its
+        # name differs per cluster, and only a claim resolves at mount time in
+        # whichever cluster MultiKueue placed this Job in. An inline volume
+        # would be rendered before submission. See cache_volumes.yaml.tpl.
         - name: jax-cache
           persistentVolumeClaim:
             claimName: jax-cache

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/launcher/launch.py
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/launcher/launch.py
@@ -712,10 +712,9 @@ def worker_pods(env, job_id):
     """This workload's pods on the worker, or None if they could not be read.
 
     One read per turn of the loop, shared by everything that wants them: what
-    the pods are doing, what they printed, and why they stopped. They used to
-    be fetched once each, which is three round trips through Connect Gateway
-    for one answer - and the polling ahead of the first log line is deliberately
-    quick, so it was the busiest moment that paid for it three times.
+    the pods are doing, what they printed, and why they stopped. Fetching per
+    reader would cost three Connect Gateway round trips for one answer, and the
+    polling ahead of the first log line is deliberately quick.
 
     None rather than an empty list, because "no pods yet" and "could not ask"
     read differently in a step log.

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/manager-config.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/manager-config.yaml
@@ -1,9 +1,8 @@
 # What the manager's Kueue adds to common-config.yaml: it is the only cluster
 # that dispatches, so it is the only one that needs a way to reach a worker.
 #
-# Appended to that file rather than merged into it, so every key here has to be
-# a top-level key the common file does not already set. generate_manifests.py
-# refuses to render if that stops being true.
+# Appended to that file rather than merged, so every key here has to be one the
+# common file does not set. generate_manifests.py refuses to render otherwise.
 featureGates:
   # MultiKueue reads worker credentials from ClusterProfile objects rather than
   # from kubeconfig Secrets. GKE's fleet writes those profiles itself, so no
@@ -21,11 +20,10 @@ multiKueue:
           apiVersion: client.authentication.k8s.io/v1beta1
           command: /plugins/gcp-auth-plugin
           args:
-            # Without this the plugin mints its token by shelling out to
-            # `gcloud config config-helper`, and there is no gcloud in Kueue's
-            # distroless image. Application default credentials come from the
-            # GKE metadata server instead, which is where Workload Identity
-            # hands the controller its own identity - the one the gatewayEditor
-            # binding in iam.tf is granted to.
+            # Without this the plugin shells out to `gcloud config
+            # config-helper`, and Kueue's image is distroless. Application
+            # default credentials come from the metadata server instead, which
+            # is where Workload Identity hands the controller the identity
+            # iam.tf grants gatewayEditor to.
             - --use_application_default_credentials
           interactiveMode: Never

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/agent_stack_values.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/agent_stack_values.yaml.tpl
@@ -1,36 +1,23 @@
-# Values for the agent-stack-k8s chart. Not a manifest: deploy_manifests.py
-# renders the chart with this and applies the result, so nothing under charts/
-# is ever applied on its own.
+# Values for the agent-stack-k8s chart. deploy_manifests.py renders the chart
+# with these and applies the result; helm is a renderer here, so there is no
+# release and no in-cluster Helm state.
 #
-# Committed and generated for the same reason the queues are - what the fleet is
-# configured to do should be readable in a diff. The chart's own output is not
-# committed, the way the Kueue and JobSet releases are not: it is upstream, it is
-# pinned by version, and helm is used here as a renderer and nothing more. There
-# is no release, no history and no in-cluster Helm state to reconcile against.
-#
-# Deliberately short. The chart writes the controller's config file by pasting
-# this block under three keys of its own - agent-token-secret, namespace and id -
-# and the controller parses that file with a YAML decoder that rejects a
-# duplicated key. So anything the chart already derives has to be left out and
-# set the way the chart derives it: the namespace from the render's --namespace,
-# the id from the release name.
+# Deliberately short. The chart pastes this block under three keys of its own -
+# agent-token-secret, namespace and id - and the controller parses the result
+# with a decoder that rejects a duplicated key, so anything the chart derives
+# must be left out.
 
-# Where the token comes from. The chart takes a Secret name, not a value, and
-# this one is written by the SecretSync in workload/ - so the token reaches the
-# cluster once, from Secret Manager, and the chart only refers to it.
-#
+# The chart takes a Secret name, not a value; workload/'s SecretSync writes it.
 # It becomes envFrom on the controller, so every key in that Secret is an
 # environment variable on it. Ours holds exactly one.
 agentStackSecret: ${AGENT_TOKEN_SECRET_NAME}
 
 config:
-  # One queue, and one controller behind it. A Buildkite queue no longer encodes
-  # a TPU shape: every TPU step goes through the launcher, which names a profile
-  # and submits the real workload to Kueue. Adding a shape is a regenerated
-  # profile registry, not another agent or another queue.
+  # One queue for the whole fleet. A queue does not encode a TPU shape: every
+  # TPU step goes through the launcher, so adding a shape is a regenerated
+  # profile registry rather than another queue.
   #
-  # The organization is not named anywhere here. The controller has not needed it
-  # since it stopped using the GraphQL API in 0.28.0; it now takes the org and
-  # the cluster from the agent token, which is why that token has to be a
+  # The organization is not named here. The controller takes the org and the
+  # cluster from the agent token, which is why that token has to be a
   # cluster's and not the organization's.
   queue: ${BUILDKITE_QUEUE}

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/cache_volumes.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/cache_volumes.yaml.tpl
@@ -1,19 +1,14 @@
 ---
 # The caches, as claims a pod can name without knowing where they live.
 #
-# Static PersistentVolumes rather than inline CSI volumes in the workload
-# manifest. The bucket is regional - a cache 10,000 km away costs 502ms per miss
-# against 36ms in-region - so its name differs per cluster, and putting it in
-# the workload would mean every manifest, pipeline and step carrying a bucket
-# name it has no business knowing. Here the claim names are identical in every
-# region and the binding is infrastructure, which also survives MultiKueue
-# placing a job somewhere other than where it was submitted: the claim resolves
-# at mount time, in whichever cluster the pod actually landed in.
-#
-# Created here rather than by the workload because MultiKueue copies only the
-# Job. A claim created where the launcher runs would not exist where the pod
-# does. These are static and shared, and gcsfuse serves ReadWriteMany, so every
-# pod mounts the same claim at once.
+# Static PersistentVolumes rather than inline CSI volumes in the workload. The
+# bucket is regional (see cache.tf), so its name differs per cluster, and in
+# the workload it would mean every manifest and step carrying a bucket name it
+# has no business knowing. Here the claim names are identical everywhere and
+# resolve at mount time, in whichever cluster MultiKueue actually landed the
+# pod in - which also has to be here rather than created by the workload,
+# because MultiKueue copies only the Job. gcsfuse serves ReadWriteMany, so
+# every pod mounts the same claim at once.
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -32,17 +27,15 @@ spec:
     name: jax-cache
   mountOptions:
     - implicit-dirs
-    # Scoped to this cache, not the whole bucket. The bucket is per purpose but
-    # will hold more than one kind of compilation cache, so this one lives under
-    # its own prefix and the mount says so - otherwise the metadata prefetch
-    # walks every other kind at mount time to reach this one. A second kind gets
+    # Scoped to this cache, not the whole bucket, so the metadata prefetch does
+    # not walk every other kind of cache in it at mount time. A second kind gets
     # its own PersistentVolume with its own only-dir.
     - only-dir=jax_cache
     # Thousands of small content-addressed files, read far more often than
-    # written. Never expire metadata: every access stats the object, the default
-    # TTL is 60s, and re-stating over the network is what a compile-heavy step
-    # would otherwise spend its time on. Safe to pin because an entry's name
-    # encodes its contents, so a name never changes meaning.
+    # written. Never expire metadata: every access stats the object, and at the
+    # default 60s TTL a compile-heavy step spends its time re-stating over the
+    # network. Safe to pin because an entry's name encodes its contents, so a
+    # name never changes meaning.
     - metadata-cache:ttl-secs:-1
     - metadata-cache:stat-cache-max-size-mb:-1
     - metadata-cache:type-cache-max-size-mb:-1
@@ -67,17 +60,14 @@ spec:
       # Redundant here: every pod uses the same service account against the same
       # bucket, and the check costs IAM and STS calls on the startup path.
       skipCSIBucketAccessCheck: "true"
-      # 8Gi against the model mount's 65Gi. Compilation entries are thousands of
-      # small files and a run reads a fraction of a namespace that is only ~34GB
-      # whole, so the rest of the node's cache is worth more to the models.
+      # 8Gi against the model mount's 65Gi: a run reads a fraction of a
+      # namespace that is only ~34GB whole, so the rest of the node's cache is
+      # worth more to the models. Explicit rather than -1, which fills the
+      # volume and then starts failing writes.
       #
-      # Explicit rather than -1: this is the threshold gcsfuse evicts against,
-      # and with -1 it fills the volume and then starts failing writes.
-      #
-      # One figure, not one per machine type: a PersistentVolume is a single
-      # object per cluster and every profile's pods bind the same claim, so it
-      # has to hold on the smallest shape we run. Sized for ct6e-standard-1t's
-      # 176 GB, and conservative above it.
+      # One figure, not one per machine type: a PersistentVolume is one object
+      # per cluster and every profile binds the same claim, so it has to hold on
+      # the smallest shape we run - ct6e-standard-1t's 176 GB.
       fileCacheCapacity: "8Gi"
       # Defaults to false, which sends random reads past the cache to GCS.
       fileCacheForRangeRead: "true"
@@ -107,10 +97,9 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  # Ignored, as above, and worth repeating here because this mount holds
-  # multi-gigabyte checkpoints and 1Gi reads like a limit. It is not one: the
-  # driver never enforces capacity on a bucket. What does bound anything is
-  # fileCacheCapacity below, which sizes the on-node cache.
+  # Ignored, as above - worth repeating because this mount holds multi-gigabyte
+  # checkpoints and 1Gi reads like a limit. It is not one. What bounds anything
+  # is fileCacheCapacity below, which sizes the on-node cache.
   capacity:
     storage: 1Gi
   storageClassName: ""
@@ -142,20 +131,16 @@ spec:
     volumeAttributes:
       gcsfuseMetadataPrefetchOnMount: "true"
       skipCSIBucketAccessCheck: "true"
-      # 65Gi. fileCacheForRangeRead below pulls a whole object into the cache on
-      # a partial read, and gcsfuse will not cache an object that does not fit
-      # the remaining capacity - so at 20Gi the larger checkpoints, read a few
-      # layers at a time, were refetched on every load and evicted the small
-      # models that would have fit. That was 84.6m of a 111.8m step; at 56Gi the
-      # same work took 23.8m and the step reached parity with bare metal. 73Gi
-      # was no better than 56Gi, so the working set already fits and the
-      # difference is ~25 GiB of node returned to the tests.
+      # 65Gi, which holds the whole working set. fileCacheForRangeRead below
+      # pulls an object into the cache on a partial read, and gcsfuse will not
+      # cache an object that does not fit the remaining capacity, so a capacity
+      # under the largest checkpoint refetches it on every load and evicts the
+      # small models that would have fit.
       #
       # The pod must back this with a gke-gcsfuse-cache volume at least this
       # large, or the sidecar falls back to 5GiB of ephemeral storage and the
-      # capacity is nominal. The launcher substitutes FUSE_CACHE_SIZE for that
-      # - half the machine type's memory, the volume being a RAM-backed
-      # emptyDir - and every shape this fleet runs clears 65Gi.
+      # capacity is nominal. The launcher sizes that volume at half the machine
+      # type's memory, and every shape this fleet runs clears 65Gi.
       fileCacheCapacity: "65Gi"
       # safetensors are memory-mapped, which is nothing but random reads. With
       # this false a 2.88 GiB checkpoint page-faulted over the network until the

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/queue_group.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/queue_group.yaml.tpl
@@ -21,10 +21,9 @@ spec:
     matchLabels:
       kubernetes.io/metadata.name: ${NAMESPACE}${ADMISSION_CHECKS}
   resourceGroups:
-    # google.com/tpu is the only resource under quota. The cpu and memory a
-    # workload, its gcsfuse sidecar and any helper containers request are
-    # ignored here (quotaCheckStrategy: IgnoreUndeclared) and enforced by the
-    # kube scheduler against node capacity.
+    # google.com/tpu is the only resource under quota; everything else a pod
+    # requests is left to the kube scheduler. See quotaCheckStrategy in
+    # common-config.yaml.
     - coveredResources:
         - google.com/tpu
       flavors:

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/resource_flavor.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/resource_flavor.yaml.tpl
@@ -1,15 +1,11 @@
 ---
 # One flavor per TPU generation, and deliberately no nodeLabels.
 #
-# The flavor, not the queue, is Kueue's quota partition: quota is counted per
-# flavor, cohort borrowing is per flavor, and Kueue skips a flavor whose
-# nodeLabels conflict with what a podSet already asks for. A flavor per shape
-# would therefore make it impossible for a 1-chip job to use idle 8-chip
-# capacity, whatever the numbers said. Bare and shared, the per-shape queues
-# above it can lend to each other.
-#
-# Placement is the workload's: it carries the gke-tpu-accelerator,
-# gke-tpu-topology and gke-accelerator-count nodeSelectors itself.
+# The flavor, not the queue, is Kueue's quota partition, and Kueue skips a
+# flavor whose nodeLabels conflict with what a podSet asks for. A flavor per
+# shape would therefore stop a 1-chip job borrowing idle 8-chip capacity,
+# whatever the numbers said. Placement is the workload's anyway: it carries the
+# TPU nodeSelectors itself.
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/secret_sync.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/secret_sync.yaml.tpl
@@ -2,47 +2,36 @@
 # The Buildkite agent token, pulled out of Secret Manager and into a Kubernetes
 # Secret the agent-stack-k8s chart can be pointed at.
 #
-# GKE's own SecretSync, not External Secrets. There is no controller to install
-# and none to run: the reconciler lives in the GKE control plane, so nothing
-# here appears in `kubectl get pods` and there is nothing for the deploy script
-# to wait on. Enabling it is a cluster field, `secret_sync_config` in manager.tf.
+# GKE's own SecretSync, not External Secrets: the reconciler runs in the control
+# plane, so there is no controller to install and nothing for the deploy script
+# to wait on. Enabling it is `secret_sync_config` in manager.tf.
 #
-# Manager only, and not because a worker does no Buildkite work - a TPU pod
-# uploads its own artifacts, writes meta-data and reports to Test Engine, since
-# it is the only thing that can see its own output files. It is that it does so
-# with a different credential.
-#
-# This one is the org registration token. It is what an agent presents to
-# Buildkite to register and claim a job, and the only things that register are
-# the agent-stack-k8s controller and the agent pods it creates, both here. What
-# a workload pod calls `buildkite-agent` with is BUILDKITE_AGENT_ACCESS_TOKEN,
-# which the agent is handed back after registering: it is scoped to the one job,
-# it dies with it, and the launcher forwards it as a plain environment variable.
-# Nothing syncs it and nothing needs to.
-#
-# So syncing this secret to a worker would put a long-lived org credential next
-# to pods running images named by a pull request, and buy nothing.
+# Manager only. This is the org registration token, and the only things that
+# register are the controller and the agent pods it creates, both here. A TPU
+# pod does call `buildkite-agent` - it is the only thing that can see its own
+# output files - but with BUILDKITE_AGENT_ACCESS_TOKEN, which is scoped to the
+# one job and forwarded as a plain environment variable. Syncing this one to a
+# worker would put a long-lived org credential next to pods running images
+# named by a pull request, and buy nothing.
 
 # The identity the sync reads Secret Manager as. Its own, not tpu-workload:
-# these are two different jobs - one may read the agent token, the other may
-# write to the caches - and a workload image named by a pull request runs as the
-# second. Nothing mounts this account, so nothing that runs here can use it.
+# one may read the agent token, the other may write to the caches, and a
+# workload image named by a pull request runs as the second. Nothing mounts
+# this account, so nothing that runs here can use it.
 #
 # No Google service account annotation: secrets.tf grants the accessor role
-# straight to the Workload Identity principal for this account, so there is
-# nothing to impersonate and no key to rotate.
+# straight to the Workload Identity principal, so there is nothing to
+# impersonate and no key to rotate.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: secret-sync
   namespace: ${NAMESPACE}
 ---
-# Which secret, and what to call it on the way through. The path is internal:
-# it names the value inside this class so the SecretSync below can refer to it,
-# and it is never a file anywhere - nothing mounts this class as a CSI volume.
-#
-# `versions/latest` rather than a pinned version, because rotation is the point.
-# A new version is picked up on the next poll.
+# Which secret, and what to call it on the way through. `path` is internal - it
+# names the value for the SecretSync below, and is never a file anywhere, since
+# nothing mounts this class as a CSI volume. `versions/latest` because rotation
+# is the point: a new version is picked up on the next poll.
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
@@ -57,18 +46,13 @@ spec:
 ---
 # The Secret itself, which takes this object's own name. The key is not ours to
 # choose - agent-stack-k8s reads BUILDKITE_AGENT_TOKEN out of whatever Secret it
-# is pointed at - but the name is, and it comes from the generator rather than
-# from here, because the chart's values have to name the same Secret.
+# is pointed at - but the name is, and it comes from the generator, because the
+# chart's values have to name the same Secret.
 #
-# Rotation updates this object in place - same name, new value, within about
-# five minutes of a new Secret Manager version. There is no watch, only a poll,
-# so treat five minutes as the bound. Pods that read the token at startup pick
-# it up on their next start; the controller holds its copy for the life of its
-# process, so rotating the token also means restarting that Deployment.
-#
-# The Secret lands in this namespace because there is nowhere else it could:
-# SecretSync has no target-namespace field and writes only beside itself. That
-# is where it is wanted anyway.
+# Rotation updates this object in place, within about five minutes of a new
+# Secret Manager version: there is no watch, only a poll. The controller holds
+# its copy for the life of its process, so rotating the token also means
+# restarting that Deployment.
 apiVersion: secret-sync.gke.io/v1
 kind: SecretSync
 metadata:

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/workload_sa.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/workload_sa.yaml.tpl
@@ -1,11 +1,9 @@
 ---
 # The identity a TPU workload runs as.
 #
-# Named rather than `default`, which is what every pod in the namespace gets
-# when none is set. The cache buckets grant object access to this principal, and
-# `default` would hand that to anything scheduled here - including a workload
-# image named by a pull request, since the launcher accepts any image it is
-# given.
+# Named rather than `default`: the cache buckets grant object access to this
+# principal, and `default` is what every pod in the namespace gets when none is
+# set - which would extend that access to anything scheduled here.
 #
 # No Google service account annotation: cache.tf grants the roles directly to
 # ${PROJECT_ID}.svc.id.goog[${NAMESPACE}/tpu-workload], so there is nothing to

--- a/terraform/gcp_old/tpu-inference/k8s/locals.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/locals.tf
@@ -14,26 +14,22 @@ locals {
     "/subject/ns/kueue-system/sa/kueue-controller-manager",
   ])
 
-  # The launcher's service account on the manager cluster, as IAM sees it. The
-  # older syntax, matching the rest of this fleet's namespaced grants; it names
-  # the same principal as the Kueue controller's above.
-  #
-  # The account name is fixed by kueue/templates/launcher.yaml.tpl, which is
-  # rendered rather than declared here, and the namespace is shared with
-  # Terraform for exactly this reason - see var.namespace.
+  # The launcher's service account on the manager cluster, in the older syntax
+  # the rest of this fleet's namespaced grants use. The account name is fixed by
+  # kueue/templates/launcher.yaml.tpl, which is rendered rather than declared
+  # here, and the namespace is shared with Terraform for exactly this reason -
+  # see var.namespace.
   launcher_principal = "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/tpu-launcher]"
 
-  # Worker clusters keyed by the pair that identifies one. The tfvars is a list
-  # so that nothing has to be invented to name a cluster, but for_each needs a
-  # key, and a positional index would renumber - and so destroy and rebuild -
-  # every cluster after one that was removed.
+  # Worker clusters keyed by the pair that identifies one, rather than by a
+  # positional index, which would renumber - and so rebuild - every cluster
+  # after one that was removed.
   #
   # Two names come out of that pair, because they have to be unique in two
-  # different places. A GKE cluster, a service account, a router, a NAT: each is
-  # scoped to a project, so the region alone names them and two projects may
-  # each hold a us-east5. The Terraform address, the rendered directory and the
-  # MultiKueueCluster are fleet-wide - every worker registers into the one
-  # manager, in the one namespace - so those carry the project as well.
+  # places. A cluster, a service account, a router, a NAT are all project
+  # scoped, so the region alone names them. The Terraform address, the rendered
+  # directory and the MultiKueueCluster are fleet-wide, so those carry the
+  # project too.
   workers = {
     for w in var.worker_clusters : "${w.project}/${w.location}" => merge(w, {
       short_name = w.location
@@ -81,22 +77,18 @@ locals {
   }
 
   # Both caches for every worker in one map, since one resource creates them all
-  # and one grants access to them all. What differs between the two entries is
-  # only retention and the purpose, so the rest is written once here.
+  # and one grants access to them all. Only retention and purpose differ.
   #
-  # The name is derived, and scripts/generate_manifests.py derives it the same
-  # way, because it has to put the same string into a PersistentVolume's
-  # volumeHandle. Keeping the two in step is a real hazard - a name computed
-  # twice is a name that can differ, and the failure is a volume pointing at a
-  # bucket that was never created - so deploy_manifests.py checks that every
-  # bucket a volume names exists before it applies anything.
+  # scripts/generate_manifests.py derives the same name, because it has to put
+  # it in a PersistentVolume's volumeHandle. A name computed twice is a name
+  # that can differ, and the failure is a volume pointing at a bucket that was
+  # never created, so deploy_manifests.py checks every bucket a volume names
+  # exists before applying.
   #
-  # The hash covers the project and the region, which is what identifies a
-  # cluster; the purpose is spelled out beside it rather than hashed in, so the
-  # two buckets of one cluster share a suffix and read as a pair. The project
-  # has to be in there because a bucket name is globally unique across the whole
-  # of GCP: without it, two organisations running this would ask for the same
-  # name and the second would be refused.
+  # The hash covers project and region, which is what identifies a cluster; the
+  # purpose is spelled out beside it so the two buckets of one cluster read as a
+  # pair. The project has to be in the hash because bucket names are globally
+  # unique, so two organisations running this would otherwise collide.
   workload_buckets = merge([
     for worker in var.worker_clusters : {
       for purpose, retention_days in {

--- a/terraform/gcp_old/tpu-inference/k8s/prod.auto.tfvars
+++ b/terraform/gcp_old/tpu-inference/k8s/prod.auto.tfvars
@@ -42,9 +42,8 @@ kueue_version       = "0.19.0"
 jobset_version      = "0.12.0"
 agent_stack_version = "0.49.0"
 
-# A queue of its own rather than one of the names the bare-metal agents already
-# answer to, so the two fleets can run side by side and a pipeline moves over one
-# step at a time.
+# A queue of its own, so this fleet and the bare-metal one run side by side and
+# a pipeline moves over one step at a time.
 buildkite_queue = "kube"
 
 auth_plugin_image       = "gcr.io/google.com/cloudsdktool/google-cloud-cli:584.0.0"
@@ -63,8 +62,8 @@ launcher_image = "us-central1-docker.pkg.dev/cloud-ullm-inference-ci-cd/tpu-ci/l
 
 # A test may hold chips for three hours and a step may take eight in total,
 # queueing included; the launcher waits for admission for the difference. Both
-# are the bare-metal timeouts, so a step that moves here does not quietly get a
-# different budget.
+# match the bare-metal budgets, so a step moving between the two lanes gets the
+# same allowance.
 tpu_test_max_seconds  = 10800
 tpu_total_max_seconds = 28800
 

--- a/terraform/gcp_old/tpu-inference/k8s/scripts/deploy_manifests.py
+++ b/terraform/gcp_old/tpu-inference/k8s/scripts/deploy_manifests.py
@@ -274,11 +274,9 @@ def plan(cluster: dict, index: dict) -> list[Step]:
     """The install order, written once.
 
     The preview walks this same list, in this same order, which is the point of
-    it being a list. Held as two sequences of calls instead, the two drifted:
-    the preview took the whole generated tree as one -R, kubectl diff walked it
-    alphabetically, queues was read first, its missing namespace and CRDs
-    aborted the run - and an overlay that would have deleted half the Kueue
-    Deployment previewed clean.
+    it being a list: a preview that walks the tree its own way reads objects
+    before the namespace and CRDs they need, aborts, and reports clean on an
+    overlay that would have deleted half a Deployment.
     """
     base = DEFAULT_OUT / cluster["dir"]
     steps: list[Step] = [

--- a/terraform/gcp_old/tpu-inference/k8s/scripts/generate_manifests.py
+++ b/terraform/gcp_old/tpu-inference/k8s/scripts/generate_manifests.py
@@ -48,9 +48,8 @@ DEFAULT_OUT = ROOT / "kueue" / "generated"
 AGENT_TOKEN_SECRET_NAME = "buildkite-agent-token"
 
 # The launcher's program, and the ConfigMap deploy_manifests.py builds out of
-# it. Not rendered into the generated tree: a second copy of a program as
-# indented YAML is not a diff anyone reads, and the two can disagree. Named
-# here because launcher.yaml.tpl's PodTemplate mounts that ConfigMap.
+# it. Not rendered into the generated tree: a program indented into YAML is not
+# a diff anyone reads. Named here because launcher.yaml.tpl mounts it.
 LAUNCHER_SCRIPT = ROOT / "kueue" / "launcher" / "launch.py"
 LAUNCHER_SCRIPT_CONFIGMAP = "tpu-launcher-scripts"
 # The key is the file name under the mount, and the step's command is that
@@ -58,8 +57,7 @@ LAUNCHER_SCRIPT_CONFIGMAP = "tpu-launcher-scripts"
 LAUNCHER_SCRIPT_KEY = "launch"
 
 # The Job a step gets when it names hardware and nothing else, deployed the
-# same way and for the same reason: it is a manifest, and a copy of it indented
-# into a ConfigMap is not one anyone can read a diff of.
+# same way and for the same reason.
 LAUNCHER_DEFAULT_JOB = ROOT / "kueue" / "launcher" / "job.yaml"
 LAUNCHER_MANIFEST_CONFIGMAP = "tpu-launcher-manifests"
 LAUNCHER_DEFAULT_JOB_KEY = "job.yaml"
@@ -87,14 +85,13 @@ MACHINE_MEMORY_GB = {
 }
 
 # How much of the host a workload's gcsfuse file cache may take. Memory, not
-# disk: the volume behind it is a `medium: Memory` emptyDir, which is why a
-# node's ephemeral storage does not bound it and too high shows up as an OOM.
+# disk: the volume behind it is a `medium: Memory` emptyDir, so a node's
+# ephemeral storage does not bound it and too high shows up as an OOM.
 #
 # Per machine type, since host memory runs from 176 GB to 1440 GB across the
-# shapes we run. Only the pod's volume can vary that way - the per-mount
-# fileCacheCapacity in cache_volumes.yaml.tpl cannot, a PersistentVolume being
-# one object per cluster that every shape's pods bind, so that one is sized for
-# the smallest shape.
+# shapes we run. Only the pod's volume can vary that way; the per-mount
+# fileCacheCapacity in cache_volumes.yaml.tpl is one object per cluster and so
+# is sized for the smallest shape.
 FUSE_VOLUME_RATIO = 0.50
 # Small enough to be safe on any host, for a machine type not listed above. Too
 # low only costs read speed.

--- a/terraform/gcp_old/tpu-inference/k8s/secrets.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/secrets.tf
@@ -1,29 +1,21 @@
 # Read access to the Buildkite agent token, for the sync that copies it onto the
 # manager. The objects that do the copying are generated YAML, not Terraform -
-# see kueue/templates/secret_sync.yaml.tpl - because GKE's SecretSync reconciler
-# runs in the control plane and there is nothing to install for it.
+# see kueue/templates/secret_sync.yaml.tpl.
 #
-# The secret itself is not declared here. It predates this fleet, the bare-metal
-# agents read the same one, and its value is not something Terraform should hold
-# or replace. A data source rather than a resource, so a name that is wrong
-# fails at plan time instead of quietly creating an empty second secret.
+# The secret itself predates this fleet and the bare-metal agents read the same
+# one, so a data source rather than a resource: a name that is wrong fails at
+# plan time instead of quietly creating an empty second secret.
 data "google_secret_manager_secret" "agent_token" {
   project   = var.project_id
   secret_id = var.agent_token_secret_id
 }
 
-# Scoped to this one secret. The project holds five others - REST API tokens, a
-# webhook signing key - and the bare-metal agents reach all of them through a
-# project-wide secretAccessor on the default compute account, which is the grant
-# this migration exists to stop inheriting.
+# Scoped to this one secret. The project holds others - REST API tokens, a
+# webhook signing key - that nothing here has any business reading.
 #
 # _member, so this manages one (secret, role, member) tuple and leaves any other
-# grant on the secret alone.
-#
-# The member is the Kubernetes service account, federated by Workload Identity
-# into a principal that can hold a role directly. No Google service account
-# stands behind it and no key exists to leak - which matters more here than for
-# the caches, since what is behind this one is a credential.
+# grant on the secret alone. The member is the Kubernetes service account,
+# federated by Workload Identity, so no key exists to leak.
 resource "google_secret_manager_secret_iam_member" "agent_token_sync" {
   project   = var.project_id
   secret_id = data.google_secret_manager_secret.agent_token.secret_id
@@ -31,20 +23,18 @@ resource "google_secret_manager_secret_iam_member" "agent_token_sync" {
   member    = "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/secret-sync]"
 }
 
-# The Buildkite Test Engine token, in the test suite's own project. A data
-# source for the same reason as above: it predates this fleet and the
-# bare-metal agents read it too, so both lanes report into one suite.
+# The Buildkite Test Engine token, in the test suite's own project. Also
+# pre-existing: the bare-metal agents read it too, so both lanes report into
+# one suite.
 data "google_secret_manager_secret" "analytics_token" {
   project   = var.analytics_token_secret_project
   secret_id = var.analytics_token_secret_id
 }
 
-# Read straight by the launcher pod, not synced: unlike the agent token there
-# is no consumer that has to be pointed at a Kubernetes Secret, and a Secret
-# would be a copy of a credential sitting in the namespace between runs.
-#
-# Scoped to the one secret, not its project: that project is the suite's and
-# holds other people's secrets.
+# Read straight by the launcher pod, not synced: nothing here has to be pointed
+# at a Kubernetes Secret, and a Secret would be a copy of a credential sitting
+# in the namespace between runs. Scoped to the one secret, not its project -
+# that project is the suite's and holds other people's secrets.
 resource "google_secret_manager_secret_iam_member" "launcher_analytics_token" {
   project   = var.analytics_token_secret_project
   secret_id = data.google_secret_manager_secret.analytics_token.secret_id

--- a/terraform/gcp_old/tpu-inference/k8s/variables.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/variables.tf
@@ -125,8 +125,7 @@ variable "analytics_token_secret_id" {
     Secret Manager secret holding the Buildkite Test Engine token.
 
     Read by the launcher pod and forwarded into the workload, since a TPU pod
-    is the only thing that can see its own test output. On bare metal it comes
-    from the agent environment on the VM, which a pod has no equivalent of.
+    is the only thing that can see its own test output.
 
     Named rather than defaulted because the grant is scoped to this one secret.
   EOT

--- a/terraform/gcp_old/tpu-inference/k8s/workers.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/workers.tf
@@ -36,12 +36,11 @@ resource "google_container_cluster" "worker" {
   for_each = local.workers
 
   # The region alone, because a cluster name is scoped to its project. It is
-  # also the Fleet membership ID, though, and every worker joins the manager's
-  # fleet whatever project it runs in - so two clusters in one region in
-  # different projects would ask for one membership and the second apply would
-  # be refused. Give one of them an explicit short name when that day comes:
-  # added as an optional field it renames nothing that already exists, which is
-  # why there is no such field yet.
+  # also the Fleet membership ID, and every worker joins the manager's fleet
+  # whatever project it runs in - so two clusters in one region in different
+  # projects would ask for one membership and the second apply would be
+  # refused. An optional short-name field would fix that without renaming
+  # anything that exists.
   name     = "${var.name_prefix}-${each.value.short_name}"
   project  = each.value.project
   location = each.value.location


### PR DESCRIPTION
The comments under `terraform/gcp_old/tpu-inference/k8s/` documented how the design was arrived at as well as the design. That history is worth a PR and not a file — it dates, and none of it was ever a feature anyone used.

Rule applied: a comment says why the code is the way it is, as a statement about the present. Not what it replaced, not what was measured on the way. Measurements stay only where the number is otherwise arbitrary (the 502ms vs 36ms behind regional cache buckets), as the constraint rather than the investigation.

Comments and docstrings only — no executable change. Proven by comparing the AST of every Python file with docstrings stripped, and every YAML/Terraform file with comment lines removed. `kueue/generated/` is regenerated because the comments live inside the rendered ConfigMaps; that diff is comment-only too.

1121 comment lines to 1013.