### PR TITLE
ci(kube): let a manifest state how long its workload runs

### DIFF
--- a/terraform/gcp_old/tpu-inference/k8s/README.md
+++ b/terraform/gcp_old/tpu-inference/k8s/README.md
@@ -86,9 +86,18 @@ at all is the exception and rides along — a benchmark client driving the serve
 over HTTP, say — because the queues put `google.com/tpu` alone under quota.
 
 A manifest must contain a container named `workload`: that is the one whose
-output is streamed back and which step environment is forwarded to. Everything
-that follows from the shape is the launcher's and is rejected in a manifest —
-the queue label, the `activeDeadlineSeconds` ceiling, the gcsfuse cache size.
+output is streamed back and which step environment is forwarded to. More than
+one may carry the name, and in a JobSet whose roles all want the log and the
+step's secrets, they all should. Everything that follows from the shape is the
+launcher's and is rejected in a manifest — the queue label, the gcsfuse cache
+size.
+
+How long the workload runs is not one of those. It defaults to
+`tpu_test_max_seconds`, which is right for a test, and a manifest that knows
+better states its own `activeDeadlineSeconds` — a serving benchmark runs for as
+long as its client sweeps, which no shape implies. The ceiling is
+`tpu_total_max_seconds`: past that the workload would outlive the launcher
+watching it, and the chips would be held by nothing.
 
 `kueue/launcher/launch.py` is the program. It is a file rather than YAML so it
 can be linted and run; `deploy_manifests.py` builds the ConfigMap from it.

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/workload/10-launcher.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/workload/10-launcher.yaml
@@ -77,7 +77,7 @@ data:
     workload_service_accounts:
     - default
     - tpu-workload
-    total_max_seconds: 28800
+    total_max_seconds: 39600
     workers:
       tpu-ci-us-central1:
         membership: tpu-ci-us-central1

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/launcher/launch.py
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/launcher/launch.py
@@ -236,14 +236,17 @@ def resolve_shape(doc, registry, where):
     )
 
 
-def admission_timeout(registry, profile):
-    """How long to wait for chips: the whole budget, less one full-length run.
+def admission_timeout(registry, doc):
+    """How long to wait for chips: the whole budget, less this run.
 
     Derived rather than configured, from the only two numbers worth choosing.
-    Longer leaves no room to run; shorter fails steps that were queueing.
+    Longer leaves no room to run; shorter fails steps that were queueing. Read
+    off the deadline cap_runtime settled on rather than the shape's default, so
+    a workload that asked to serve for ten hours is not also given eight to
+    queue in.
     """
-    return max(int(registry["total_max_seconds"])
-               - int(profile["max_runtime_seconds"]), 300)
+    runtime = max(int(spec["activeDeadlineSeconds"]) for spec in job_specs(doc))
+    return max(int(registry["total_max_seconds"]) - runtime, 300)
 
 
 def resolve_image(registry):
@@ -441,7 +444,7 @@ def render(path, image, name, shape):
     return coerce_ints(doc)
 
 
-def finalise(doc, profile, name, labels, owner, command, where):
+def finalise(doc, profile, registry, name, labels, owner, command, where):
     """Everything the launcher decides rather than the manifest."""
     meta = doc.setdefault("metadata", {})
     meta["name"] = name
@@ -474,24 +477,33 @@ def finalise(doc, profile, name, labels, owner, command, where):
         for container in workload:
             container["args"] = [command]
 
-    cap_runtime(doc, profile)
+    cap_runtime(doc, profile, registry)
     size_fuse_cache(doc, profile)
     state_node_affinity(doc)
     return doc
 
 
-def cap_runtime(doc, profile):
+def cap_runtime(doc, profile, registry):
     """Bound how long the workload may hold its chips.
 
-    A ceiling rather than a setting: a manifest that wants to fail sooner is
-    welcome to, but one that would outlast the step is holding a reservation
-    nothing is watching. Left to the manifest it is a number that has to be
-    right in every copy of it.
+    A default rather than a setting, because most steps have no opinion and the
+    number would otherwise have to be right in every copy of every manifest.
+    One that does have an opinion states activeDeadlineSeconds and is believed:
+    how long a workload runs is a property of the work, not of the hardware,
+    and a benchmark that serves for ten hours has no shape-derived number that
+    could know that.
+
+    The ceiling is the step's whole budget, which is the part that is always
+    true - a workload must not outlast the step watching it, or it is holding a
+    reservation nothing will clean up.
     """
-    limit = int(profile["max_runtime_seconds"])
+    default = int(profile["max_runtime_seconds"])
+    ceiling = int(registry["total_max_seconds"])
     for spec in job_specs(doc):
         current = spec.get("activeDeadlineSeconds")
-        spec["activeDeadlineSeconds"] = min(int(current), limit) if current else limit
+        spec["activeDeadlineSeconds"] = (
+            min(int(current), ceiling) if current else default
+        )
 
 
 def size_fuse_cache(doc, profile):
@@ -954,7 +966,7 @@ def main():
     # shell again, so joining plainly loses every quote the step wrote. `python
     # -c 'import jax; print(jax.devices())'` arrives as three arguments and
     # would go back out as an unquoted one-liner the second shell breaks on.
-    finalise(doc, profile, name, labels, owner_reference(),
+    finalise(doc, profile, registry, name, labels, owner_reference(),
              shlex.join(command) if command else None, manifest)
     kind = SUPPORTED_KINDS[doc["kind"]]
 
@@ -985,7 +997,7 @@ def main():
     )
 
     uid = kubectl_json("get", kind, name)["metadata"]["uid"]
-    admission_limit = admission_timeout(registry, profile)
+    admission_limit = admission_timeout(registry, doc)
     started = time.monotonic()
     admitted = False
     running = False

--- a/terraform/gcp_old/tpu-inference/k8s/prod.auto.tfvars
+++ b/terraform/gcp_old/tpu-inference/k8s/prod.auto.tfvars
@@ -60,12 +60,13 @@ auth_plugin_source_path = "/usr/lib/google-cloud-sdk/bin/gke-gcloud-auth-plugin"
 # bytes.
 launcher_image = "us-central1-docker.pkg.dev/cloud-ullm-inference-ci-cd/tpu-ci/launcher:584.0.0-1"
 
-# A test may hold chips for three hours and a step may take eight in total,
-# queueing included; the launcher waits for admission for the difference. Both
-# match the bare-metal budgets, so a step moving between the two lanes gets the
-# same allowance.
+# A test gets three hours with the chips unless its manifest says otherwise,
+# matching the bare-metal budget so a step moving between the two lanes gets the
+# same allowance. Eleven in total is the ceiling on both the queueing and on
+# what a manifest may ask for, set by the longest workload the fleet runs: the
+# nightly P/D disaggregation benchmark, which serves for ten.
 tpu_test_max_seconds  = 10800
-tpu_total_max_seconds = 28800
+tpu_total_max_seconds = 39600
 
 # Every CI image this fleet runs is built into the manager project's Artifact
 # Registry, and a step names its own tag, so the project is the boundary rather

--- a/terraform/gcp_old/tpu-inference/k8s/variables.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/variables.tf
@@ -213,7 +213,7 @@ variable "allowed_image_repos" {
 
 variable "tpu_test_max_seconds" {
   type        = number
-  description = "How long a TPU workload may run once it has chips. The launcher puts it on the submitted workload as activeDeadlineSeconds, so a hung test releases the chips rather than holding them until the Buildkite step times out."
+  description = "How long a TPU workload runs for when it says nothing. The launcher puts it on the submitted workload as activeDeadlineSeconds, so a hung test releases the chips rather than holding them until the Buildkite step times out. A manifest that knows better states its own, bounded by tpu_total_max_seconds."
 }
 
 variable "tpu_total_max_seconds" {
@@ -221,8 +221,10 @@ variable "tpu_total_max_seconds" {
   description = <<-EOT
     How long a TPU step may take in total, queueing included.
 
-    The launcher waits for admission for whatever this leaves once a
-    full-length run is allowed for, so this and tpu_test_max_seconds are the
+    Also the ceiling on any deadline a manifest asks for, since the one thing
+    that must hold is that a workload does not outlast the launcher watching
+    it. The launcher waits for admission for whatever this leaves once the
+    workload's own run is allowed for, so this and tpu_test_max_seconds are the
     only deadlines worth choosing and every other one follows from them.
   EOT
 }


### PR DESCRIPTION
`tpu_test_max_seconds` becomes a default rather than a ceiling, and `tpu_total_max_seconds` becomes the ceiling — on both the deadline a manifest may ask for and the time the launcher will wait for admission.

A test has no opinion about its runtime and should get the fleet's number. A serving benchmark runs for as long as its client sweeps, which no shape can imply; the P/D disagg benchmark serves for ten hours and was being killed at three.