### PR TITLE
ci(kube): let the launcher read the Hugging Face token

### DIFF
--- a/terraform/gcp_old/tpu-inference/k8s/prod.auto.tfvars
+++ b/terraform/gcp_old/tpu-inference/k8s/prod.auto.tfvars
@@ -17,6 +17,12 @@ agent_token_secret_id = "vllm_buildkite_agent_token"
 analytics_token_secret_project = "cloud-tpu-inference-test"
 analytics_token_secret_id      = "tpu_commons_buildkite_analytics_token"
 
+# The Hugging Face token, likewise the bare-metal agents' rather than one of
+# this fleet's: a gated model is gated per account, and the two lanes pull the
+# same weights into the same caches.
+hf_token_secret_project = "cloud-tpu-inference-test"
+hf_token_secret_id      = "bm-agent-hf-token"
+
 # us-central1 to sit with the rest of the CI control plane: the monitoring VM,
 # the cache buckets, and the Artifact Registry these nodes pull from. The
 # manager holds no TPUs, so it is not tied to a reservation's zone.

--- a/terraform/gcp_old/tpu-inference/k8s/secrets.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/secrets.tf
@@ -41,3 +41,22 @@ resource "google_secret_manager_secret_iam_member" "launcher_analytics_token" {
   role      = "roles/secretmanager.secretAccessor"
   member    = local.launcher_principal
 }
+
+# The Hugging Face token, in the bare-metal agents' project. A model behind a
+# gate cannot be fetched without it, and the fleet's model cache is shared, so
+# the first step to want a gated model pays for every later one.
+data "google_secret_manager_secret" "hf_token" {
+  project   = var.hf_token_secret_project
+  secret_id = var.hf_token_secret_id
+}
+
+# Read by the launcher and forwarded into the workload with --env, so the value
+# is never a Kubernetes object and never appears in a pipeline. Same shape as
+# the Test Engine grant above and for the same reason: one secret, not the
+# project it happens to live in.
+resource "google_secret_manager_secret_iam_member" "launcher_hf_token" {
+  project   = var.hf_token_secret_project
+  secret_id = data.google_secret_manager_secret.hf_token.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = local.launcher_principal
+}

--- a/terraform/gcp_old/tpu-inference/k8s/variables.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/variables.tf
@@ -119,6 +119,23 @@ variable "analytics_token_secret_project" {
   description = "Project holding the Buildkite Test Engine token. Not this one: it belongs to the suite, which predates this fleet and is shared with the bare-metal lane."
 }
 
+variable "hf_token_secret_project" {
+  type        = string
+  description = "Project holding the Hugging Face token. Not this one: it belongs to the bare-metal agents, and a gated model should be fetched under the same identity in both lanes."
+}
+
+variable "hf_token_secret_id" {
+  type        = string
+  description = <<-EOT
+    Secret Manager secret holding the Hugging Face token.
+
+    Read by the launcher pod and forwarded into the workload, since the pod
+    that downloads the weights is the only one that needs it.
+
+    Named rather than defaulted because the grant is scoped to this one secret.
+  EOT
+}
+
 variable "analytics_token_secret_id" {
   type        = string
   description = <<-EOT


### PR DESCRIPTION
Resource-scoped `secretAccessor` on `bm-agent-hf-token` in `cloud-tpu-inference-test` for the launcher's service account, plus the two variables naming it.

A gated model cannot be fetched without it, and the fleet's model cache is shared, so the first step to want one pays the download for every later step. The bare-metal agents' secret rather than a new one: a gate is per account and both lanes pull the same weights.