### PR TITLE
ci(kube): move the manager cluster off Autopilot

### DIFF
--- a/terraform/gcp_old/tpu-inference/k8s/README.md
+++ b/terraform/gcp_old/tpu-inference/k8s/README.md
@@ -7,7 +7,7 @@ dispatched to whichever worker cluster has the chips.
 
 Two clusters, and the split is the whole design:
 
-- **Manager** — `tpu-ci-manager`, Autopilot, `us-central1`. No TPUs. Runs the
+- **Manager** — `tpu-ci-manager`, Standard, `us-central1`. No TPUs. Runs the
   agent-stack-k8s controller, the Buildkite agent pods, and the Kueue that owns
   fleet-wide quota. This is where a step's agent lives and where its log goes.
 - **Worker** — `tpu-ci-us-east5`, Standard, `us-east5`. The chips. Reports to

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/workload/10-launcher.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/workload/10-launcher.yaml
@@ -193,14 +193,20 @@ template:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.uid
-        # Requests only: Autopilot mirrors them into limits, so a limit above
-        # the request would be a request at the limit's size and a bill to
-        # match. Not as small as it looks - the launcher polls kubectl and
-        # gcloud, both Python, and holds log lines in memory.
+        # Not as small as it looks - the launcher polls kubectl and gcloud, both
+        # Python, and holds a poll's worth of log lines in memory.
+        #
+        # A memory limit and no cpu limit. The launcher shares its nodes with
+        # the controllers that run the fleet, so a step whose workload floods
+        # the log must not be able to take the Kueue controller down with it;
+        # cpu is left unbounded because throttling a poller only makes it slower
+        # to notice its workload finished.
         resources:
           requests:
             cpu: "500m"
             memory: 1Gi
+          limits:
+            memory: 2Gi
         volumeMounts:
           - name: launcher-scripts
             mountPath: /opt/launcher

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/launcher.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/launcher.yaml.tpl
@@ -130,14 +130,20 @@ template:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.uid
-        # Requests only: Autopilot mirrors them into limits, so a limit above
-        # the request would be a request at the limit's size and a bill to
-        # match. Not as small as it looks - the launcher polls kubectl and
-        # gcloud, both Python, and holds log lines in memory.
+        # Not as small as it looks - the launcher polls kubectl and gcloud, both
+        # Python, and holds a poll's worth of log lines in memory.
+        #
+        # A memory limit and no cpu limit. The launcher shares its nodes with
+        # the controllers that run the fleet, so a step whose workload floods
+        # the log must not be able to take the Kueue controller down with it;
+        # cpu is left unbounded because throttling a poller only makes it slower
+        # to notice its workload finished.
         resources:
           requests:
             cpu: "500m"
             memory: 1Gi
+          limits:
+            memory: 2Gi
         volumeMounts:
           - name: launcher-scripts
             mountPath: /opt/launcher

--- a/terraform/gcp_old/tpu-inference/k8s/manager.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/manager.tf
@@ -3,8 +3,13 @@
 # that nothing running here competes with a test for chips. Worker clusters hold
 # the TPUs and attach to this one through Fleet.
 #
-# Autopilot is ForceNew: switching to Standard rebuilds the cluster and every
-# workload on it.
+# Standard, like the workers, because this is where every workload podspec is
+# born. Autopilot admission-mutates a podspec it considers underspecified - it
+# fills in a nodeAffinity on cloud.google.com/extended-duration-pods for any pod
+# that arrives without one - and MultiKueue copies the podspec to a worker
+# verbatim, where no node carries that label and the pod is unschedulable with
+# nothing reporting an error. A launcher that builds podspecs for another
+# cluster cannot share a cluster with something that rewrites them.
 
 # Nodes here are private, so egress - image pulls, Buildkite's API, Secret
 # Manager - goes through the Cloud NAT covering this region. It is created
@@ -17,7 +22,9 @@ resource "google_container_cluster" "manager" {
   network    = var.network
   subnetwork = var.manager_subnetwork
 
-  enable_autopilot    = true
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
   deletion_protection = var.deletion_protection
 
   release_channel {
@@ -39,18 +46,15 @@ resource "google_container_cluster" "manager" {
     role                                      = "manager"
   })
 
-  # Autopilot has no node pool to hang a service account on, so this is the only
-  # place to keep nodes off the project default compute account - which holds
-  # tpu.admin, storage.admin and project-wide secretmanager.secretAccessor,
-  # because the bare-metal agent VMs share it.
-  #
-  # `enabled` must stay unset: on Autopilot the autoscaler is always on and
-  # setting it is an error. Only auto_provisioning_defaults is honoured.
-  cluster_autoscaling {
-    auto_provisioning_defaults {
-      service_account = google_service_account.manager_nodes.email
-      oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
-    }
+  # Empty: GKE picks and creates the pod and service secondary ranges, as on the
+  # workers.
+  ip_allocation_policy {}
+
+  # How a pod here gets a Google identity without a key: the secret sync reads
+  # the agent token, and the launcher reads the Test Engine and Hugging Face
+  # tokens. Implicit under Autopilot, explicit here.
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
   }
 
   private_cluster_config {
@@ -78,6 +82,63 @@ resource "google_container_cluster" "manager" {
     rotation_config {
       enabled           = true
       rotation_interval = "300s"
+    }
+  }
+}
+
+# The only pool: the Kueue and JobSet controllers, the Buildkite controller, the
+# secret sync, and one launcher pod per TPU step in flight. No taint and no
+# label, because everything here is the fleet's own control plane and there is
+# nothing to keep apart.
+#
+# The floor is two nodes rather than one so that a node under repair does not
+# take the whole control plane with it. The ceiling follows the Buildkite
+# controller's in-flight limit: a launcher pod waiting on quota still occupies a
+# node, so the pods that can exist at once, not the chips, is what has to fit.
+resource "google_container_node_pool" "manager_system" {
+  name     = "system"
+  project  = var.project_id
+  cluster  = google_container_cluster.manager.name
+  location = var.manager_region
+
+  # total_, not the per-zone min_node_count/max_node_count: in a regional
+  # cluster those are multiplied by the number of zones, so a floor of 2 would
+  # quietly become two nodes per zone.
+  autoscaling {
+    total_min_node_count = var.manager_system_min_nodes
+    total_max_node_count = var.manager_system_max_nodes
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  node_config {
+    machine_type = var.manager_system_machine_type
+    image_type   = "COS_CONTAINERD"
+
+    # Off the project default compute account, which holds tpu.admin,
+    # storage.admin and project-wide secretmanager.secretAccessor because the
+    # bare-metal agent VMs share it.
+    service_account = google_service_account.manager_nodes.email
+    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+      enable_secure_boot          = true
+    }
+
+    labels = {
+      "tpu-ci.google.com/role" = "manager"
+    }
+
+    metadata = {
+      disable-legacy-endpoints = "true"
     }
   }
 }

--- a/terraform/gcp_old/tpu-inference/k8s/variables.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/variables.tf
@@ -29,6 +29,24 @@ variable "manager_master_ipv4_cidr_block" {
   description = "RFC1918 /28 for the manager control plane. Must not overlap any worker cluster's block, because the manager peers with all of them."
 }
 
+variable "manager_system_machine_type" {
+  type        = string
+  description = "Machine type for the manager's nodes. Sized for the controllers plus the launcher pods, which are a kubectl and a Python script and want cores rather than memory."
+  default     = "e2-standard-4"
+}
+
+variable "manager_system_min_nodes" {
+  type        = number
+  description = "Scale-down floor for the manager. Two, so a node under repair does not take the fleet's whole control plane with it."
+  default     = 2
+}
+
+variable "manager_system_max_nodes" {
+  type        = number
+  description = "Ceiling for the manager. Bounded by the Buildkite controller's in-flight limit rather than by any TPU quota: a launcher pod waiting for chips occupies a node without holding any."
+  default     = 8
+}
+
 variable "labels" {
   type        = map(string)
   description = "Labels applied to every resource that takes them."


### PR DESCRIPTION
Rebuilds `tpu-ci-manager` as a Standard cluster with its own node pool, so the cluster that builds workload podspecs is not one that rewrites them.

Autopilot fills in a `cloud.google.com/extended-duration-pods` nodeAffinity on any pod that lacks one; MultiKueue copies the podspec to a worker where no node carries that label, and the pod is silently unschedulable.

ForceNew, so the cluster is recreated. Everything on it is generated YAML that `deploy_manifests.py` reapplies.