### PR TITLE
Drop the affinity that kept Autopilot out of a podspec

### DIFF
--- a/terraform/gcp_old/tpu-inference/k8s/README.md
+++ b/terraform/gcp_old/tpu-inference/k8s/README.md
@@ -208,12 +208,12 @@ do not deploy into the middle of something that cannot tolerate it. JobSet's
 webhooks are also `Fail`, though those are narrowed to pods that already carry a
 JobSet label.
 
-**Autopilot writes a nodeAffinity into any podspec that lacks one** —
-`cloud.google.com/extended-duration-pods`. MultiKueue copies the podspec to the
-worker unchanged, no Standard node carries that label, and the pod is then
-unschedulable with nothing reporting an error: the step simply waits out its
-timeout. The launcher always states an affinity of its own to prevent it. If you
-write a podspec that reaches the worker by some other path, state one too.
+**No cluster in this fleet may be Autopilot.** Autopilot writes a nodeAffinity
+on `cloud.google.com/extended-duration-pods` into any podspec that arrives
+without one. MultiKueue copies the podspec to the worker unchanged, no Standard
+node carries that label, and the pod is then unschedulable with nothing
+reporting an error: the step simply waits out its timeout. The manager is where
+every workload podspec is born, so that is the one it would break.
 
 **A very short workload can lose its output.** MultiKueue deletes the remote Job
 when it completes and the pods go with it, so a workload that lives a few

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/launcher/launch.py
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/launcher/launch.py
@@ -197,8 +197,8 @@ def resolve_shape(doc, registry, where):
     """The profile the manifest's TPU pods describe.
 
     Read rather than passed in, so the hardware is written once. What follows
-    from it - the queue, the deadline, the file cache size, the affinity that
-    keeps Autopilot out - is cluster policy, and the manifest states none of it.
+    from it - the queue, the deadline, the file cache size - is cluster policy,
+    and the manifest states none of it.
 
     Only the roles holding chips decide it. A disaggregated workload is servers
     plus a client that drives them over HTTP, and the client wants no
@@ -512,7 +512,6 @@ def finalise(doc, profile, registry, name, labels, owner, command, where):
 
     cap_runtime(doc, profile, registry)
     size_fuse_cache(doc, profile)
-    state_node_affinity(doc)
     return doc
 
 
@@ -553,39 +552,6 @@ def size_fuse_cache(doc, profile):
                 volume["emptyDir"].setdefault(
                     "sizeLimit", profile["fuse_cache_size"]
                 )
-
-
-def state_node_affinity(doc):
-    """Say where the pod runs, so that Autopilot does not say it instead.
-
-    The manager is Autopilot, and Autopilot fills in a nodeAffinity for any pod
-    that arrives without one: cloud.google.com/extended-duration-pods. No node
-    in a Standard worker carries that label, and MultiKueue copies the podspec
-    across unchanged, so the pod is unschedulable there with nothing reporting
-    an error - the step just waits out its timeout.
-
-    Autopilot adds one only where there is none, and does not merge into one
-    that exists, so stating an affinity prevents it. This one restates the
-    manifest's nodeSelector rather than constraining anything further, which
-    also keeps to the keys Autopilot permits in an affinity at all.
-
-    Per pod, because that is how Autopilot fills them in: a role that holds no
-    chips has no nodeSelector to restate, so it says the one thing that is true
-    of it instead - it is not for a TPU node - which the taint it does not
-    tolerate already ensured.
-    """
-    for spec in pod_specs(doc):
-        accelerator = spec.get("nodeSelector", {}).get(ACCELERATOR_KEY)
-        term = (
-            {"key": ACCELERATOR_KEY, "operator": "In", "values": [accelerator]}
-            if accelerator
-            else {"key": ACCELERATOR_KEY, "operator": "DoesNotExist"}
-        )
-        affinity = spec.setdefault("affinity", {}).setdefault("nodeAffinity", {})
-        affinity.setdefault(
-            "requiredDuringSchedulingIgnoredDuringExecution",
-            {"nodeSelectorTerms": [{"matchExpressions": [term]}]},
-        )
 
 
 # Fields the Kubernetes API declares as integers. A manifest is text with


### PR DESCRIPTION
The launcher wrote a nodeAffinity into every pod it submitted, restating the manifest's own nodeSelector, so that Autopilot would not add `cloud.google.com/extended-duration-pods` — a label no Standard worker node carries, on a podspec MultiKueue copies across verbatim.

The manager is Standard now and every worker always was, so nothing in the fleet mutates a podspec. The affinity constrained nothing the nodeSelector and the TPU taint did not already. The README keeps the failure mode, restated as a constraint on what the fleet may be built from.