### PR TITLE
Add CI test-selection leak corpus

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,13 @@ repos:
       stages: [commit-msg]
 
     # Keep `suggestion` last
+    - id: validate-selection-leaks
+      name: Validate test-selection leak corpus
+      entry: python3 test-selection/validate_selection_leaks.py
+      language: system
+      files: ^test-selection/(selection-leaks\.json|selection-leaks\.schema\.json|README\.md|validate_selection_leaks\.py)$
+      pass_filenames: false
+
     - id: suggestion
       name: Suggestion
       entry: bash -c 'echo "To bypass all the pre-commit hooks, add --no-verify to git commit. To skip a specific hook, prefix the commit command with SKIP=<hook-id>."'

--- a/claude-skills/AUTOMATIONS.md
+++ b/claude-skills/AUTOMATIONS.md
@@ -143,6 +143,9 @@ These files guide an agent but do not install timers or send scheduled alerts:
   daily CI runs.
 - [`pytorch-bump-triage.md`](pytorch-bump-triage.md): distinguish PyTorch or
   Triton bump regressions from failures already present on main.
+- [`vllm-main-ci-triage/`](vllm-main-ci-triage/): diagnose hard main-CI
+  failures, prepare narrow fixes, audit exact pull-request job coverage, and
+  record confirmed test-selection leaks.
 
 ## Validate changes
 

--- a/claude-skills/vllm-main-ci-triage/SKILL.md
+++ b/claude-skills/vllm-main-ci-triage/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: vllm-main-ci-triage
+description: Diagnose hard vLLM main-CI failures, open narrow source-fix PRs when authorized, audit the culprit PR's exact job coverage, and record confirmed test-selection leaks. Use when monitoring the vLLM main-CI dashboard, investigating a failed Buildkite main or daily job, deciding whether a failure is source-related or environmental, or updating the ci-infra selection-leak corpus.
+---
+
+# vLLM Main CI Triage
+
+Triage hard failures from this filtered view:
+
+`https://vllm-ci-dashboard.vercel.app/alerts?tab=main-ci&window=1d&hide=softfail%2Coptional%2Camd`
+
+The dashboard is an index, not evidence. Open the exact Buildkite job and read
+the first causal error, relevant test summary, agent identity, retry history,
+and teardown output before classifying it.
+
+## Investigate
+
+1. Deduplicate against open dashboard alerts, recent Slack/Raft incidents,
+   GitHub issues, and fix or revert PRs.
+2. Compare the exact job with recent main and daily executions. Separate the
+   first causal error from cleanup, worker-loss, timeout, and cancellation
+   cascades.
+3. Classify the failure as source regression, test defect, infrastructure,
+   external dependency, known baseline, or unknown. State confidence and link
+   exact evidence.
+4. For a suspected source regression, establish the last-good/first-bad
+   boundary and inspect only relevant commits and diffs. Do not assign a
+   culprit from timing alone.
+5. Inspect the culprit PR's exact job state. Overall PR green is irrelevant:
+   record whether that precise job passed, failed, was blocked, was skipped,
+   or was not selected.
+
+Retry once only when evidence supports a transient failure. Do not use
+retries to hide a repeated signature or a deterministic source failure.
+
+## Fix and report
+
+When the current request authorizes external writes, search for duplicate
+work, create the smallest source or harness fix, run focused local validation,
+and open a PR with exact failure evidence. Never merge, revert, deploy, cancel
+jobs, change runner state, or resolve an incident unless that action is also
+authorized. Include a plain disclosure when AI materially assisted the patch.
+
+Post a brief lifecycle update on the authorized team surface only when there
+is actionable new evidence. Include the exact main job, normalized signature,
+classification, cause, fix PR, and validation state. Keep credentials and raw
+environment files out of chat and commits.
+
+## Record selection leaks
+
+Read [references/evidence-and-leaks.md](references/evidence-and-leaks.md) before
+adding a row. Update `test-selection/selection-leaks.json` only when the exact
+PR job did not run, the post-merge failure is source-related, and causality is
+confirmed. Then run:
+
+```bash
+python3 test-selection/validate_selection_leaks.py
+```
+
+Treat each affected job as a separate record. Do not record cases where the
+exact job ran in PR CI, even when its internal test sharding missed the failing
+case; those require a different corpus and label.

--- a/claude-skills/vllm-main-ci-triage/agents/openai.yaml
+++ b/claude-skills/vllm-main-ci-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "vLLM Main CI Triage"
+  short_description: "Diagnose hard vLLM main-CI failures"
+  default_prompt: "Use $vllm-main-ci-triage to inspect hard main-CI failures, identify the cause, and record confirmed selection leaks."

--- a/claude-skills/vllm-main-ci-triage/references/evidence-and-leaks.md
+++ b/claude-skills/vllm-main-ci-triage/references/evidence-and-leaks.md
@@ -1,0 +1,34 @@
+# Evidence and selection-leak contract
+
+## Minimum incident evidence
+
+- exact Buildkite build number, job ID, job key, URL, and terminal state;
+- first causal error plus the test summary or proof that tests never started;
+- retry and recent exact-job history;
+- relevant commit, pull request, diff, and last-good/first-bad boundary;
+- exact state of the same job on the suspected culprit pull request;
+- a narrow fix, revert, reproduction, or direct code path that confirms cause.
+
+Blocked is a valid non-running state only on a terminal PR build when the job
+has no start time or assigned agent. Absence from a PR build is `not_selected`,
+not success.
+
+## Positive corpus rule
+
+Add one record per `(culprit PR, exact job, main failure job)` only when:
+
+1. `pr_ci.ran` is false;
+2. the main failure is a source regression caused by that PR; and
+3. causality has evidence stronger than chronological proximity.
+
+Exclude infrastructure failures, external outages, known baselines, flaky
+tests without a source regression, and exact jobs that ran in PR CI. A test
+inside a passing job being omitted by an inner shard is a related but distinct
+selection problem and must not be mislabeled as an exact-job leak.
+
+## Data hygiene
+
+Use full immutable merge SHAs and exact Buildkite job anchors. Keep the concise
+failure signature semantic rather than copying volatile timestamps or ANSI
+logs. Preserve historical names. Sort records by main build and job name, run
+the validator, and use frozen temporal snapshots for evaluation.

--- a/test-selection/README.md
+++ b/test-selection/README.md
@@ -1,0 +1,41 @@
+# Test-selection leak corpus
+
+`selection-leaks.json` is the canonical, versioned set of confirmed vLLM CI
+selection leaks. Each row identifies an exact CI job that did not execute on a
+pull request and then exposed a source regression after that pull request
+merged.
+
+The corpus is job-granular: one pull request can contribute several rows when
+several exact jobs were missed. Keep the recorded Buildkite job IDs and URLs;
+an aggregate green pull-request build is not evidence that a particular job
+ran.
+
+## Inclusion gate
+
+Add a row only when all of these are true:
+
+1. The exact job was blocked, not selected, skipped, or canceled on the
+   culprit pull request. A terminal Buildkite job with no start time or agent
+   is acceptable proof that it did not execute.
+2. The corresponding post-merge main or daily job failed because of source
+   behavior, not mutable infrastructure or an external service.
+3. The cause is confirmed by a narrow fix, revert, reproduction, or direct
+   code-level analysis that connects the culprit diff to the failure.
+
+Do not add infrastructure flakes, baseline failures, external outages, or
+cases where the exact job executed in pull-request CI. Keep rejected
+candidates outside this positive corpus; they are useful negative examples
+for model evaluation but have a different label.
+
+## Update and validate
+
+Keep records sorted by main build number and then job name. Use stable IDs and
+never rewrite historical evidence because a job or pipeline is later renamed.
+
+```bash
+python3 test-selection/validate_selection_leaks.py
+```
+
+`selection-leaks.schema.json` documents the machine-readable contract. For
+evaluation, use a frozen temporal snapshot or holdout rather than randomly
+splitting rows from the same incident across train and test sets.

--- a/test-selection/selection-leaks.json
+++ b/test-selection/selection-leaks.json
@@ -1,0 +1,454 @@
+{
+  "$schema": "./selection-leaks.schema.json",
+  "schema_version": 1,
+  "records": [
+    {
+      "id": "pr-52131-main-84585-distributed-dp-tests-2-gpus",
+      "job_name": "L4 Distributed DP Tests (2 GPUs)",
+      "job_key": "distributed-dp-tests-2-gpus",
+      "culprit_pr": {
+        "number": 52131,
+        "url": "https://github.com/vllm-project/vllm/pull/52131",
+        "merge_commit": "eac636a7fa476983cdae34b45a984e9852aad375"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 84571,
+        "job_id": "01a01924-4d9a-43e7-8b8f-5942754ea911",
+        "url": "https://buildkite.com/vllm/ci/builds/84571#01a01924-4d9a-43e7-8b8f-5942754ea911"
+      },
+      "main_failure": {
+        "build_number": 84585,
+        "job_id": "01a0199c-2a3a-402c-a6e2-d9b9473af880",
+        "url": "https://buildkite.com/vllm/ci/builds/84585#01a0199c-2a3a-402c-a6e2-d9b9473af880",
+        "signature": "pytest exit 4: moved test_multi_api_servers.py path did not exist"
+      },
+      "causal_confirmation": {
+        "kind": "fix",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/52939",
+        "notes": "The fix updated the stale NVIDIA and AMD distributed test paths left by PR #52131."
+      }
+    },
+    {
+      "id": "pr-52131-main-84585-amd-distributed-dp-tests-2-gpus",
+      "job_name": "MI300 Distributed DP Tests (2 GPUs)",
+      "job_key": "amd-distributed-dp-tests-2-gpus",
+      "culprit_pr": {
+        "number": 52131,
+        "url": "https://github.com/vllm-project/vllm/pull/52131",
+        "merge_commit": "eac636a7fa476983cdae34b45a984e9852aad375"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 84571,
+        "job_id": "01a01924-4df6-496d-8412-3723bee439f9",
+        "url": "https://buildkite.com/vllm/ci/builds/84571#01a01924-4df6-496d-8412-3723bee439f9"
+      },
+      "main_failure": {
+        "build_number": 84585,
+        "job_id": "01a0199c-2a85-4548-bb98-a886e8630dad",
+        "url": "https://buildkite.com/vllm/ci/builds/84585#01a0199c-2a85-4548-bb98-a886e8630dad",
+        "signature": "pytest exit 4: moved test_multi_api_servers.py path did not exist"
+      },
+      "causal_confirmation": {
+        "kind": "fix",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/52939",
+        "notes": "The fix updated the stale NVIDIA and AMD distributed test paths left by PR #52131."
+      }
+    },
+    {
+      "id": "pr-51665-main-84882-quantized-models-test",
+      "job_name": "H200 Quantized Models",
+      "job_key": "quantized-models-test",
+      "culprit_pr": {
+        "number": 51665,
+        "url": "https://github.com/vllm-project/vllm/pull/51665",
+        "merge_commit": "f0c14b4f776bb976e654b430442067539fbdb2ea"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 84786,
+        "job_id": "01a01e6e-a5f8-40a5-bda0-be9160791f94",
+        "url": "https://buildkite.com/vllm/ci/builds/84786#01a01e6e-a5f8-40a5-bda0-be9160791f94"
+      },
+      "main_failure": {
+        "build_number": 84882,
+        "job_id": "01a02120-8ed5-41ee-bbe4-a10f5bf5e7e1",
+        "url": "https://buildkite.com/vllm/ci/builds/84882#01a02120-8ed5-41ee-bbe4-a10f5bf5e7e1",
+        "signature": "Gemma tied lm_head checkpoint weight was not recognized as an alias"
+      },
+      "causal_confirmation": {
+        "kind": "fix",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/53170",
+        "notes": "The fix restored loading for a physical lm_head key when the model exposes only tied embeddings."
+      }
+    },
+    {
+      "id": "pr-53106-main-84887-bitsandbytes-plugin",
+      "job_name": "H200 BitsAndBytes Plugin",
+      "job_key": "bitsandbytes-plugin",
+      "culprit_pr": {
+        "number": 53106,
+        "url": "https://github.com/vllm-project/vllm/pull/53106",
+        "merge_commit": "1fe3a1571ac67581478a11743e55a306de1d136f"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 84841,
+        "job_id": "01a01f90-6493-43bb-90d1-40135f82de53",
+        "url": "https://buildkite.com/vllm/ci/builds/84841#01a01f90-6493-43bb-90d1-40135f82de53"
+      },
+      "main_failure": {
+        "build_number": 84887,
+        "job_id": "01a020fa-8367-4346-8c8a-aa763ebaf8fa",
+        "url": "https://buildkite.com/vllm/ci/builds/84887#01a020fa-8367-4346-8c8a-aa763ebaf8fa",
+        "signature": "BitsAndBytes plugin called removed WeightsMapper.get_unstacked_mapper"
+      },
+      "causal_confirmation": {
+        "kind": "reproduction",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/53224",
+        "notes": "The proposed compatibility patch directly restored the method removed by PR #53106; the same exception repeated in later exact jobs."
+      }
+    },
+    {
+      "id": "pr-53106-main-84887-bitsandbytes-plugin-2-gpus",
+      "job_name": "L4 BitsAndBytes Plugin (2 GPUs)",
+      "job_key": "bitsandbytes-plugin-2-gpus",
+      "culprit_pr": {
+        "number": 53106,
+        "url": "https://github.com/vllm-project/vllm/pull/53106",
+        "merge_commit": "1fe3a1571ac67581478a11743e55a306de1d136f"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 84841,
+        "job_id": "01a01f90-6494-4f47-ad8d-68515555725f",
+        "url": "https://buildkite.com/vllm/ci/builds/84841#01a01f90-6494-4f47-ad8d-68515555725f"
+      },
+      "main_failure": {
+        "build_number": 84887,
+        "job_id": "01a020fa-8367-49cf-985a-0f229f663b1d",
+        "url": "https://buildkite.com/vllm/ci/builds/84887#01a020fa-8367-49cf-985a-0f229f663b1d",
+        "signature": "BitsAndBytes plugin called removed WeightsMapper.get_unstacked_mapper"
+      },
+      "causal_confirmation": {
+        "kind": "reproduction",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/53224",
+        "notes": "The proposed compatibility patch directly restored the method removed by PR #53106; the same exception repeated in later exact jobs."
+      }
+    },
+    {
+      "id": "pr-53093-main-85112-lm-eval-humming-f16-a100",
+      "job_name": "A100 LM Eval Humming F16 (Shard 2)",
+      "job_key": "lm-eval-humming-f16-a100",
+      "culprit_pr": {
+        "number": 53093,
+        "url": "https://github.com/vllm-project/vllm/pull/53093",
+        "merge_commit": "b00f475f09b7d54e811efc006cab2562d3b23893"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 84868,
+        "job_id": "01a02067-2edd-4ddd-9ba0-904042a9f1ff",
+        "url": "https://buildkite.com/vllm/ci/builds/84868#01a02067-2edd-4ddd-9ba0-904042a9f1ff"
+      },
+      "main_failure": {
+        "build_number": 85112,
+        "job_id": "01a02620-d87f-465d-a61c-bf18dc01cf53",
+        "url": "https://buildkite.com/vllm/ci/builds/85112#01a02620-d87f-465d-a61c-bf18dc01cf53",
+        "signature": "Qwen3-VL dummy processor inputs were truncated and no longer matched multimodal placeholders"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/53093",
+        "notes": "The culprit diff removed the processor-input truncation override reached by all three exact Humming jobs."
+      }
+    },
+    {
+      "id": "pr-53093-main-85112-lm-eval-humming-f16-b200",
+      "job_name": "B200 LM Eval Humming F16",
+      "job_key": "lm-eval-humming-f16-b200",
+      "culprit_pr": {
+        "number": 53093,
+        "url": "https://github.com/vllm-project/vllm/pull/53093",
+        "merge_commit": "b00f475f09b7d54e811efc006cab2562d3b23893"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 84868,
+        "job_id": "01a02067-2ede-4178-b48b-ca9cdad022d7",
+        "url": "https://buildkite.com/vllm/ci/builds/84868#01a02067-2ede-4178-b48b-ca9cdad022d7"
+      },
+      "main_failure": {
+        "build_number": 85112,
+        "job_id": "01a02620-d880-45cd-acb5-b0d50c9c2ccd",
+        "url": "https://buildkite.com/vllm/ci/builds/85112#01a02620-d880-45cd-acb5-b0d50c9c2ccd",
+        "signature": "Qwen3-VL dummy processor inputs were truncated and no longer matched multimodal placeholders"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/53093",
+        "notes": "The culprit diff removed the processor-input truncation override reached by all three exact Humming jobs."
+      }
+    },
+    {
+      "id": "pr-53093-main-85112-lm-eval-humming-f16-h100",
+      "job_name": "H100 LM Eval Humming F16 (Shard 2)",
+      "job_key": "lm-eval-humming-f16-h100",
+      "culprit_pr": {
+        "number": 53093,
+        "url": "https://github.com/vllm-project/vllm/pull/53093",
+        "merge_commit": "b00f475f09b7d54e811efc006cab2562d3b23893"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 84868,
+        "job_id": "01a02067-2ee4-45f9-8f59-55a527a553e5",
+        "url": "https://buildkite.com/vllm/ci/builds/84868#01a02067-2ee4-45f9-8f59-55a527a553e5"
+      },
+      "main_failure": {
+        "build_number": 85112,
+        "job_id": "01a02620-d884-4e7b-9c9b-a2aafe130807",
+        "url": "https://buildkite.com/vllm/ci/builds/85112#01a02620-d884-4e7b-9c9b-a2aafe130807",
+        "signature": "Qwen3-VL dummy processor inputs were truncated and no longer matched multimodal placeholders"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/53093",
+        "notes": "The culprit diff removed the processor-input truncation override reached by all three exact Humming jobs."
+      }
+    },
+    {
+      "id": "pr-53306-main-85298-basic-models-tests-extra-initialization",
+      "job_name": "H200 Basic Models - Extra Initialization (Shard 1)",
+      "job_key": "basic-models-tests-extra-initialization",
+      "culprit_pr": {
+        "number": 53306,
+        "url": "https://github.com/vllm-project/vllm/pull/53306",
+        "merge_commit": "a4d70bef3724edb068c8206804154065acaa4cd4"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 85254,
+        "job_id": "01a030bf-20d5-47cb-a33f-326ab6a8bcc0",
+        "url": "https://buildkite.com/vllm/ci/builds/85254#01a030bf-20d5-47cb-a33f-326ab6a8bcc0"
+      },
+      "main_failure": {
+        "build_number": 85298,
+        "job_id": "01a03290-1976-4ce2-ad50-22e62ba39776",
+        "url": "https://buildkite.com/vllm/ci/builds/85298#01a03290-1976-4ce2-ad50-22e62ba39776",
+        "signature": "Kimi-K3 model-runner-v2 startup raised KeyError for missing CUDA-graph profiling metadata"
+      },
+      "causal_confirmation": {
+        "kind": "fix",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/53581",
+        "notes": "The fix restored the missing profiling metadata and the exact post-fix job passed."
+      }
+    },
+    {
+      "id": "pr-53306-main-85388-moe-refactor-integration-test-b200-temporary",
+      "job_name": "B200 MoE Refactor Integration (Shard 1)",
+      "job_key": "moe-refactor-integration-test-b200-temporary",
+      "culprit_pr": {
+        "number": 53306,
+        "url": "https://github.com/vllm-project/vllm/pull/53306",
+        "merge_commit": "a4d70bef3724edb068c8206804154065acaa4cd4"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 85254,
+        "job_id": "01a030bf-20be-4fe4-b7dc-6a4e9d7ec9dc",
+        "url": "https://buildkite.com/vllm/ci/builds/85254#01a030bf-20be-4fe4-b7dc-6a4e9d7ec9dc"
+      },
+      "main_failure": {
+        "build_number": 85388,
+        "job_id": "01a035af-ab0f-49af-ae58-841411521cad",
+        "url": "https://buildkite.com/vllm/ci/builds/85388#01a035af-ab0f-49af-ae58-841411521cad",
+        "signature": "CachingHostAllocator use_count remained positive during CUDA-graph recapture"
+      },
+      "causal_confirmation": {
+        "kind": "revert",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/53644",
+        "notes": "The diagnostic revert passed all four exact B200 MoE shards and isolated the profiling-capture change."
+      }
+    },
+    {
+      "id": "pr-52388-main-85541-basic-models-tests-extra-initialization",
+      "job_name": "H200 Basic Models - Extra Initialization (Shard 1)",
+      "job_key": "basic-models-tests-extra-initialization",
+      "culprit_pr": {
+        "number": 52388,
+        "url": "https://github.com/vllm-project/vllm/pull/52388",
+        "merge_commit": "41729fc53b02cb09beda2a1ced690d021443be43"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 85384,
+        "job_id": "01a03555-17a3-474d-b71c-62aa2320559b",
+        "url": "https://buildkite.com/vllm/ci/builds/85384#01a03555-17a3-474d-b71c-62aa2320559b"
+      },
+      "main_failure": {
+        "build_number": 85541,
+        "job_id": "01a03a23-80cf-4c73-8040-7336c53622df",
+        "url": "https://buildkite.com/vllm/ci/builds/85541#01a03a23-80cf-4c73-8040-7336c53622df",
+        "signature": "Kimi-K3 CUDA illegal memory access from stale raw block-table pointers"
+      },
+      "causal_confirmation": {
+        "kind": "fix",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/53773",
+        "notes": "The fix stopped caching raw block-table pointers across graph-capture lifetimes; the exact post-merge job passed."
+      }
+    },
+    {
+      "id": "pr-51332-main-85561-lm-eval-humming-act-h100",
+      "job_name": "H100 LM Eval Humming Act",
+      "job_key": "lm-eval-humming-act-h100",
+      "culprit_pr": {
+        "number": 51332,
+        "url": "https://github.com/vllm-project/vllm/pull/51332",
+        "merge_commit": "ca29cd48ba05ac9ae1c9fa29271e9f899bc4ce56"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 85460,
+        "job_id": "01a037c6-7f27-4717-bd9b-e54ecda7fae6",
+        "url": "https://buildkite.com/vllm/ci/builds/85460#01a037c6-7f27-4717-bd9b-e54ecda7fae6"
+      },
+      "main_failure": {
+        "build_number": 85561,
+        "job_id": "01a03aba-6c3e-4b98-a0f5-40d420e14882",
+        "url": "https://buildkite.com/vllm/ci/builds/85561#01a03aba-6c3e-4b98-a0f5-40d420e14882",
+        "signature": "H100 Humming MXFP4 correctness score was zero with 99.4 percent invalid outputs"
+      },
+      "causal_confirmation": {
+        "kind": "revert",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/53805",
+        "notes": "The H100-only failure began at the block-FP8/MXFP4 change while the B200 control passed; the narrow revert targets that change."
+      }
+    },
+    {
+      "id": "pr-50611-main-86170-lm-eval-spec-decode-4xb200",
+      "job_name": "B200 LM Eval Spec Decode (4xB200)",
+      "job_key": "lm-eval-spec-decode-4xb200",
+      "culprit_pr": {
+        "number": 50611,
+        "url": "https://github.com/vllm-project/vllm/pull/50611",
+        "merge_commit": "7f4793eaa335a3667927a0191868d01f36b170af"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 86145,
+        "job_id": "01a04ddc-3e0d-465c-b35f-e9ece2858957",
+        "url": "https://buildkite.com/vllm/ci/builds/86145#01a04ddc-3e0d-465c-b35f-e9ece2858957"
+      },
+      "main_failure": {
+        "build_number": 86170,
+        "job_id": "01a04f53-ac9e-4549-92a2-859958908fbf",
+        "url": "https://buildkite.com/vllm/ci/builds/86170#01a04f53-ac9e-4549-92a2-859958908fbf",
+        "signature": "lazy interleave property called get_current_vllm_config outside the configuration context"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/50611",
+        "notes": "The culprit diff replaced a constructor-cached value with the failing lazy property; the same assertion appeared in four exact jobs."
+      }
+    },
+    {
+      "id": "pr-50611-main-86170-moe-refactor-integration-test-b200-temporary",
+      "job_name": "B200 MoE Refactor Integration (Shard 1)",
+      "job_key": "moe-refactor-integration-test-b200-temporary",
+      "culprit_pr": {
+        "number": 50611,
+        "url": "https://github.com/vllm-project/vllm/pull/50611",
+        "merge_commit": "7f4793eaa335a3667927a0191868d01f36b170af"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 86145,
+        "job_id": "01a04ddc-3e0e-4a4f-978b-511fc41fa502",
+        "url": "https://buildkite.com/vllm/ci/builds/86145#01a04ddc-3e0e-4a4f-978b-511fc41fa502"
+      },
+      "main_failure": {
+        "build_number": 86170,
+        "job_id": "01a04f53-ac9e-41d2-b97b-a2ce9b155b63",
+        "url": "https://buildkite.com/vllm/ci/builds/86170#01a04f53-ac9e-41d2-b97b-a2ce9b155b63",
+        "signature": "lazy interleave property called get_current_vllm_config outside the configuration context"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/50611",
+        "notes": "The culprit diff replaced a constructor-cached value with the failing lazy property; the same assertion appeared in four exact jobs."
+      }
+    },
+    {
+      "id": "pr-50611-main-86170-kv-offload-large",
+      "job_name": "H100 KV Offload Large",
+      "job_key": "kv-offload-large",
+      "culprit_pr": {
+        "number": 50611,
+        "url": "https://github.com/vllm-project/vllm/pull/50611",
+        "merge_commit": "7f4793eaa335a3667927a0191868d01f36b170af"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 86145,
+        "job_id": "01a04ddc-3e12-4e05-bae6-114ff35a21e2",
+        "url": "https://buildkite.com/vllm/ci/builds/86145#01a04ddc-3e12-4e05-bae6-114ff35a21e2"
+      },
+      "main_failure": {
+        "build_number": 86170,
+        "job_id": "01a04f53-aca0-412c-aaf6-5c15639e7607",
+        "url": "https://buildkite.com/vllm/ci/builds/86170#01a04f53-aca0-412c-aaf6-5c15639e7607",
+        "signature": "lazy interleave property called get_current_vllm_config outside the configuration context"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/50611",
+        "notes": "The culprit diff replaced a constructor-cached value with the failing lazy property; the same assertion appeared in four exact jobs."
+      }
+    },
+    {
+      "id": "pr-50611-main-86170-dsv4-flash-disaggregated",
+      "job_name": "H200 DeepSeek-V4 Flash Disaggregated",
+      "job_key": "dsv4-flash-disaggregated",
+      "culprit_pr": {
+        "number": 50611,
+        "url": "https://github.com/vllm-project/vllm/pull/50611",
+        "merge_commit": "7f4793eaa335a3667927a0191868d01f36b170af"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 86145,
+        "job_id": "01a04ddc-3d89-47ef-8dea-2f9a4f5d12d3",
+        "url": "https://buildkite.com/vllm/ci/builds/86145#01a04ddc-3d89-47ef-8dea-2f9a4f5d12d3"
+      },
+      "main_failure": {
+        "build_number": 86170,
+        "job_id": "01a04f53-ac2a-45bf-b593-b9abc1e42323",
+        "url": "https://buildkite.com/vllm/ci/builds/86170#01a04f53-ac2a-45bf-b593-b9abc1e42323",
+        "signature": "lazy interleave property called get_current_vllm_config outside the configuration context"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/50611",
+        "notes": "The culprit diff replaced a constructor-cached value with the failing lazy property; the same assertion appeared in four exact jobs."
+      }
+    }
+  ]
+}

--- a/test-selection/selection-leaks.schema.json
+++ b/test-selection/selection-leaks.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/vllm-project/ci-infra/test-selection/selection-leaks.schema.json",
+  "title": "vLLM CI test-selection leaks",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schema_version", "records"],
+  "properties": {
+    "$schema": {"const": "./selection-leaks.schema.json"},
+    "schema_version": {"const": 1},
+    "records": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/record"}
+    }
+  },
+  "$defs": {
+    "positiveInteger": {"type": "integer", "minimum": 1},
+    "jobId": {
+      "oneOf": [
+        {"type": "null"},
+        {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+        }
+      ]
+    },
+    "buildkiteUrl": {
+      "type": "string",
+      "pattern": "^https://buildkite\\.com/vllm/ci/builds/[1-9][0-9]*(#[0-9a-f-]+)?$"
+    },
+    "record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "job_name",
+        "job_key",
+        "culprit_pr",
+        "pr_ci",
+        "main_failure",
+        "causal_confirmation"
+      ],
+      "properties": {
+        "id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$"},
+        "job_name": {"type": "string", "minLength": 1},
+        "job_key": {"type": "string", "minLength": 1},
+        "culprit_pr": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["number", "url", "merge_commit"],
+          "properties": {
+            "number": {"$ref": "#/$defs/positiveInteger"},
+            "url": {
+              "type": "string",
+              "pattern": "^https://github\\.com/vllm-project/vllm/pull/[1-9][0-9]*$"
+            },
+            "merge_commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}
+          }
+        },
+        "pr_ci": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["ran", "state", "build_number", "job_id", "url"],
+          "properties": {
+            "ran": {"const": false},
+            "state": {
+              "enum": ["blocked", "not_selected", "skipped", "canceled"]
+            },
+            "build_number": {"$ref": "#/$defs/positiveInteger"},
+            "job_id": {"$ref": "#/$defs/jobId"},
+            "url": {"$ref": "#/$defs/buildkiteUrl"}
+          }
+        },
+        "main_failure": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["build_number", "job_id", "url", "signature"],
+          "properties": {
+            "build_number": {"$ref": "#/$defs/positiveInteger"},
+            "job_id": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+            },
+            "url": {"$ref": "#/$defs/buildkiteUrl"},
+            "signature": {"type": "string", "minLength": 1}
+          }
+        },
+        "causal_confirmation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "reference_url", "notes"],
+          "properties": {
+            "kind": {
+              "enum": ["fix", "revert", "reproduction", "code_analysis"]
+            },
+            "reference_url": {"type": "string", "pattern": "^https://"},
+            "notes": {"type": "string", "minLength": 1}
+          }
+        }
+      }
+    }
+  }
+}

--- a/test-selection/validate_selection_leaks.py
+++ b/test-selection/validate_selection_leaks.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Validate the canonical vLLM CI test-selection leak corpus."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent
+DATA_PATH = ROOT / "selection-leaks.json"
+SCHEMA_PATH = ROOT / "selection-leaks.schema.json"
+
+JOB_ID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]+$")
+PR_URL_RE = re.compile(r"^https://github\.com/vllm-project/vllm/pull/([1-9][0-9]*)$")
+BUILDKITE_URL_RE = re.compile(
+    r"^https://buildkite\.com/vllm/ci/builds/([1-9][0-9]*)(?:#([0-9a-f-]+))?$"
+)
+PR_STATES = {"blocked", "not_selected", "skipped", "canceled"}
+CONFIRMATION_KINDS = {"fix", "revert", "reproduction", "code_analysis"}
+
+
+class ValidationError(Exception):
+    """A user-correctable corpus validation failure."""
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"{path}: {exc}") from exc
+
+
+def require_keys(value: Any, expected: set[str], context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValidationError(f"{context}: expected an object")
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise ValidationError(
+            f"{context}: key mismatch (missing={missing}, extra={extra})"
+        )
+    return value
+
+
+def positive_int(value: Any, context: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValidationError(f"{context}: expected a positive integer")
+    return value
+
+
+def nonempty(value: Any, context: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{context}: expected a non-empty string")
+    return value
+
+
+def validate_buildkite_job(value: Any, context: str) -> tuple[int, str]:
+    obj = require_keys(value, {"build_number", "job_id", "url"}, context)
+    build = positive_int(obj["build_number"], f"{context}.build_number")
+    job_id = nonempty(obj["job_id"], f"{context}.job_id")
+    if not JOB_ID_RE.fullmatch(job_id):
+        raise ValidationError(f"{context}.job_id: invalid Buildkite job UUID")
+    match = BUILDKITE_URL_RE.fullmatch(nonempty(obj["url"], f"{context}.url"))
+    if match is None or int(match.group(1)) != build or match.group(2) != job_id:
+        raise ValidationError(f"{context}.url: must point to its exact build and job")
+    return build, job_id
+
+
+def validate_pr_ci(value: Any, context: str) -> None:
+    obj = require_keys(
+        value, {"ran", "state", "build_number", "job_id", "url"}, context
+    )
+    if obj["ran"] is not False:
+        raise ValidationError(f"{context}.ran: positive leaks require false")
+    if obj["state"] not in PR_STATES:
+        raise ValidationError(f"{context}.state: unsupported non-running state")
+
+    build = positive_int(obj["build_number"], f"{context}.build_number")
+    match = BUILDKITE_URL_RE.fullmatch(nonempty(obj["url"], f"{context}.url"))
+    if match is None or int(match.group(1)) != build:
+        raise ValidationError(f"{context}.url: must point to the PR build")
+
+    job_id = obj["job_id"]
+    if obj["state"] == "not_selected":
+        if job_id is not None or match.group(2) is not None:
+            raise ValidationError(
+                f"{context}: not_selected requires a null job_id and build-level URL"
+            )
+        return
+    if not isinstance(job_id, str) or not JOB_ID_RE.fullmatch(job_id):
+        raise ValidationError(f"{context}.job_id: invalid Buildkite job UUID")
+    if match.group(2) != job_id:
+        raise ValidationError(f"{context}.url: must point to its exact job")
+
+
+def validate_record(
+    record: Any, index: int
+) -> tuple[str, tuple[int, str], tuple[int, str, int]]:
+    context = f"records[{index}]"
+    obj = require_keys(
+        record,
+        {
+            "id",
+            "job_name",
+            "job_key",
+            "culprit_pr",
+            "pr_ci",
+            "main_failure",
+            "causal_confirmation",
+        },
+        context,
+    )
+    record_id = nonempty(obj["id"], f"{context}.id")
+    if not ID_RE.fullmatch(record_id):
+        raise ValidationError(
+            f"{context}.id: use lowercase letters, digits, and hyphens"
+        )
+    job_name = nonempty(obj["job_name"], f"{context}.job_name")
+    job_key = nonempty(obj["job_key"], f"{context}.job_key")
+
+    culprit = require_keys(
+        obj["culprit_pr"], {"number", "url", "merge_commit"}, f"{context}.culprit_pr"
+    )
+    pr_number = positive_int(culprit["number"], f"{context}.culprit_pr.number")
+    pr_url = nonempty(culprit["url"], f"{context}.culprit_pr.url")
+    pr_match = PR_URL_RE.fullmatch(pr_url)
+    if pr_match is None or int(pr_match.group(1)) != pr_number:
+        raise ValidationError(f"{context}.culprit_pr.url: must point to the culprit PR")
+    if not SHA_RE.fullmatch(
+        nonempty(culprit["merge_commit"], f"{context}.culprit_pr.merge_commit")
+    ):
+        raise ValidationError(f"{context}.culprit_pr.merge_commit: expected a full SHA")
+
+    validate_pr_ci(obj["pr_ci"], f"{context}.pr_ci")
+
+    main_failure = require_keys(
+        obj["main_failure"],
+        {"build_number", "job_id", "url", "signature"},
+        f"{context}.main_failure",
+    )
+    main_build, main_job_id = validate_buildkite_job(
+        {key: main_failure[key] for key in ("build_number", "job_id", "url")},
+        f"{context}.main_failure",
+    )
+    nonempty(main_failure["signature"], f"{context}.main_failure.signature")
+
+    confirmation = require_keys(
+        obj["causal_confirmation"],
+        {"kind", "reference_url", "notes"},
+        f"{context}.causal_confirmation",
+    )
+    if confirmation["kind"] not in CONFIRMATION_KINDS:
+        raise ValidationError(f"{context}.causal_confirmation.kind: unsupported kind")
+    reference = nonempty(
+        confirmation["reference_url"], f"{context}.causal_confirmation.reference_url"
+    )
+    if not reference.startswith("https://"):
+        raise ValidationError(
+            f"{context}.causal_confirmation.reference_url: require HTTPS"
+        )
+    nonempty(confirmation["notes"], f"{context}.causal_confirmation.notes")
+
+    return (
+        record_id,
+        (main_build, job_name.casefold()),
+        (pr_number, job_key, main_job_id),
+    )
+
+
+def main() -> int:
+    try:
+        schema = load_json(SCHEMA_PATH)
+        if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+            raise ValidationError(f"{SCHEMA_PATH}: expected JSON Schema draft 2020-12")
+
+        data = require_keys(
+            load_json(DATA_PATH),
+            {"$schema", "schema_version", "records"},
+            str(DATA_PATH),
+        )
+        if data["$schema"] != "./selection-leaks.schema.json":
+            raise ValidationError(f"{DATA_PATH}: unexpected $schema path")
+        if data["schema_version"] != 1:
+            raise ValidationError(f"{DATA_PATH}: unsupported schema_version")
+        if not isinstance(data["records"], list) or not data["records"]:
+            raise ValidationError(f"{DATA_PATH}: records must be a non-empty array")
+
+        ids: set[str] = set()
+        incident_keys: set[tuple[int, str, int]] = set()
+        sort_keys: list[tuple[int, str]] = []
+        for index, record in enumerate(data["records"]):
+            record_id, sort_key, incident_key = validate_record(record, index)
+            if record_id in ids:
+                raise ValidationError(f"records[{index}].id: duplicate {record_id}")
+            if incident_key in incident_keys:
+                raise ValidationError(
+                    f"records[{index}]: duplicate culprit PR/job/main-failure tuple"
+                )
+            ids.add(record_id)
+            incident_keys.add(incident_key)
+            sort_keys.append(sort_key)
+
+        if sort_keys != sorted(sort_keys):
+            raise ValidationError("records: sort by main build number, then job_name")
+    except ValidationError as exc:
+        print(f"selection-leaks validation failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"selection-leaks validation passed: {len(ids)} records")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a canonical JSON corpus with 16 confirmed exact-job selection leaks across eight culprit PRs
- add a machine-readable schema and stdlib validator with deterministic ordering and evidence consistency checks
- add an interactive `vllm-main-ci-triage` skill for hard-failure diagnosis, source-fix workflow, exact PR coverage audits, and corpus updates

## Validation

- `python3 test-selection/validate_selection_leaks.py`
- JSON Schema Draft 2020-12 validation with `jsonschema`
- skill `quick_validate.py`
- `pre-commit run --files ...` (all applicable hooks passed)
- `git diff --check`

This change was prepared with AI assistance. The evidence links, schema contract, and generated diff were reviewed before submission.
