### PR TITLE
ci(kube): pin a workload's image to one digest

### DIFF
--- a/terraform/gcp_old/tpu-inference/k8s/README.md
+++ b/terraform/gcp_old/tpu-inference/k8s/README.md
@@ -82,6 +82,12 @@ of its pods runs, which no pair of flags can express. Not the command either —
 JobSet has one per role. A manifest passed together with a command is refused
 rather than one role being silently chosen.
 
+The image is `WORKLOAD_IMAGE` in the step's environment, checked against
+`allowed_image_repos` — a CI image is built per commit, so which one runs is the
+pipeline's choice, which in a public repo means a PR's. A tag is resolved to the
+digest it points at when the step submits, so every pod in the workload and
+every restart pull the same bytes even if the tag is republished mid-run.
+
 Every role that holds chips must ask for the same shape: a workload is admitted
 against one queue and a queue is one shape. A role that asks for no accelerator
 at all is the exception and rides along — a benchmark client driving the servers

--- a/terraform/gcp_old/tpu-inference/k8s/iam.tf
+++ b/terraform/gcp_old/tpu-inference/k8s/iam.tf
@@ -97,3 +97,17 @@ resource "google_project_iam_member" "launcher_gateway" {
   role    = each.value
   member  = local.launcher_principal
 }
+
+# Read of the registry metadata, not of the layers: the launcher never pulls an
+# image, it asks which digest a tag currently points at so that every pod in a
+# workload is pinned to one set of bytes. The pull itself is the node service
+# accounts' above.
+resource "google_artifact_registry_repository_iam_member" "launcher" {
+  for_each = local.manager_repository_bindings
+
+  project    = var.project_id
+  location   = each.value.location
+  repository = each.value.repository
+  role       = "roles/artifactregistry.reader"
+  member     = local.launcher_principal
+}

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/launcher/launch.py
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/launcher/launch.py
@@ -270,7 +270,39 @@ def resolve_image(registry):
             f"image {image!r} is not from an allowed registry. Allowed prefixes: "
             + ", ".join(allowed)
         )
-    return image
+    return pin_digest(image)
+
+
+def pin_digest(image):
+    """Resolve a tag to the digest it points at right now.
+
+    A run is many pulls - a pod per role, and another on every restart - spread
+    over hours. A moving tag can be republished between two of them, which puts
+    two builds in one benchmark and invalidates a compile cache keyed on the
+    image. Resolving once, here, is what makes every pod in a workload the same
+    bytes.
+
+    Best effort: a tag that cannot be resolved is passed through, because the
+    registry being briefly unreachable is a worse reason to fail a step than an
+    unpinned pull is to run one.
+    """
+    if "@" in image:
+        return image
+    proc = subprocess.run(
+        ["gcloud", "artifacts", "docker", "images", "describe", image,
+         "--format=value(image_summary.digest)"],
+        capture_output=True, text=True,
+    )
+    digest = proc.stdout.strip()
+    if proc.returncode != 0 or not digest:
+        log(f"warning: could not resolve {image} to a digest; using the tag")
+        return image
+    # Strip the tag off the last path segment only: a colon earlier in the
+    # string is a registry port, not a tag separator.
+    head, sep, tail = image.rpartition("/")
+    pinned = f"{head}{sep}{tail.split(':', 1)[0]}@{digest}"
+    log(f"image {image} -> {pinned}")
+    return pinned
 
 
 def workload_name():


### PR DESCRIPTION
Re-lands #542, whose squash merge went into `launcher-env-forwarding-doc` rather than `main` and so never reached the trunk. Same commit, cherry-picked onto current main; no content change.

The launcher resolves a step's image tag to a digest at submission, so every pod in a run uses the bytes that existed when the run started, even if the tag moves under it.

This is already what the deployed launcher does — the manifests were applied from a branch that had it — so this closes a gap between the cluster and the trunk.