### PR TITLE
tpu-inference/k8s: let the launcher supply the Test Engine token

### DIFF
--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/workload/10-launcher.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/workload/10-launcher.yaml
@@ -81,6 +81,9 @@ data:
       HF_TOKEN:
         project: cloud-tpu-inference-test
         secret: bm-agent-hf-token
+      BUILDKITE_ANALYTICS_TOKEN:
+        project: cloud-tpu-inference-test
+        secret: tpu_commons_buildkite_analytics_token
     total_max_seconds: 39600
     workers:
       tpu-ci-us-central1:

--- a/terraform/gcp_old/tpu-inference/k8s/scripts/generate_manifests.py
+++ b/terraform/gcp_old/tpu-inference/k8s/scripts/generate_manifests.py
@@ -319,6 +319,14 @@ def launcher_profiles(fleet: dict, workers: list[str], tfvars: dict) -> str:
                     "project": tfvars["hf_token_secret_project"],
                     "secret": tfvars["hf_token_secret_id"],
                 },
+                # Test Engine. The collector runs inside the workload, not in
+                # the agent, so the token has to reach the pod; without it a
+                # suite still passes and reports nothing, which is the failure
+                # mode worth designing against.
+                "BUILDKITE_ANALYTICS_TOKEN": {
+                    "project": tfvars["analytics_token_secret_project"],
+                    "secret": tfvars["analytics_token_secret_id"],
+                },
             },
             "total_max_seconds": int(tfvars["tpu_total_max_seconds"]),
             # How the launcher gets from an admitted workload to the pod logs.


### PR DESCRIPTION
The Test Engine collector runs inside the workload container, so `BUILDKITE_ANALYTICS_TOKEN` has to reach the pod, not the agent. A bare-metal agent gets it from an env hook on the VM; a kube agent has nothing, and it fails silently — the suite passes and reports no tests.

The IAM grant on the secret already exists, so this only adds it to the launcher's `env_secrets` registry: a step naming `--env BUILDKITE_ANALYTICS_TOKEN` now gets it the same way it gets `HF_TOKEN`.

Applied and deployed to `tpu-ci-manager`.
