### PR TITLE
tpu-inference/k8s: expire the model cache's metadata

### DIFF
--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/workers/cloud-ullm-inference-ci-cd/us-central1/workload/10-cache-volumes.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/workers/cloud-ullm-inference-ci-cd/us-central1/workload/10-cache-volumes.yaml
@@ -114,15 +114,28 @@ spec:
     name: hf-cache
   mountOptions:
     - implicit-dirs
-    - metadata-cache:ttl-secs:-1
+    # A minute, where the compilation cache pins its metadata forever. This
+    # mount is not read-only: a model nothing has fetched yet is downloaded by
+    # the first workload that wants it, through this mount, and the same
+    # process then lists the directory it just filled. Pinned metadata makes
+    # that listing the one taken before the download - vLLM reports "Cannot
+    # find any model weights" for a snapshot whose safetensors are sitting in
+    # the bucket - and a handle opened across the change comes back as
+    # OSError: [Errno 116] Stale file handle.
+    #
+    # The size caps stay unbounded. What has to expire is an entry's age, not
+    # how many of them are kept, and a checkpoint directory is a few dozen
+    # names.
+    - metadata-cache:ttl-secs:60
     - metadata-cache:stat-cache-max-size-mb:-1
     - metadata-cache:type-cache-max-size-mb:-1
-    - file-system:kernel-list-cache-ttl-secs:-1
-    # An hour, against the compilation cache's minute. Hugging Face probes
-    # several optional files per model - adapter_config.json and friends - that
-    # legitimately do not exist, and a model that is absent stays absent until
-    # something downloads it, which writes through this same mount.
-    - metadata-cache:negative-ttl-secs:3600
+    - file-system:kernel-list-cache-ttl-secs:60
+    # Hugging Face probes several optional files per model -
+    # adapter_config.json and friends - that legitimately do not exist, so a
+    # negative entry is worth keeping. The same minute as above, and for the
+    # same reason: what does not exist at the start of a download does by the
+    # end of it.
+    - metadata-cache:negative-ttl-secs:60
     # 128MiB, GKE's own serving-profile value. Large sequential reads want each
     # round trip to carry as much as possible.
     - read_ahead_kb=131072

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/workers/cloud-ullm-inference-ci-cd/us-east5/workload/10-cache-volumes.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/workers/cloud-ullm-inference-ci-cd/us-east5/workload/10-cache-volumes.yaml
@@ -114,15 +114,28 @@ spec:
     name: hf-cache
   mountOptions:
     - implicit-dirs
-    - metadata-cache:ttl-secs:-1
+    # A minute, where the compilation cache pins its metadata forever. This
+    # mount is not read-only: a model nothing has fetched yet is downloaded by
+    # the first workload that wants it, through this mount, and the same
+    # process then lists the directory it just filled. Pinned metadata makes
+    # that listing the one taken before the download - vLLM reports "Cannot
+    # find any model weights" for a snapshot whose safetensors are sitting in
+    # the bucket - and a handle opened across the change comes back as
+    # OSError: [Errno 116] Stale file handle.
+    #
+    # The size caps stay unbounded. What has to expire is an entry's age, not
+    # how many of them are kept, and a checkpoint directory is a few dozen
+    # names.
+    - metadata-cache:ttl-secs:60
     - metadata-cache:stat-cache-max-size-mb:-1
     - metadata-cache:type-cache-max-size-mb:-1
-    - file-system:kernel-list-cache-ttl-secs:-1
-    # An hour, against the compilation cache's minute. Hugging Face probes
-    # several optional files per model - adapter_config.json and friends - that
-    # legitimately do not exist, and a model that is absent stays absent until
-    # something downloads it, which writes through this same mount.
-    - metadata-cache:negative-ttl-secs:3600
+    - file-system:kernel-list-cache-ttl-secs:60
+    # Hugging Face probes several optional files per model -
+    # adapter_config.json and friends - that legitimately do not exist, so a
+    # negative entry is worth keeping. The same minute as above, and for the
+    # same reason: what does not exist at the start of a download does by the
+    # end of it.
+    - metadata-cache:negative-ttl-secs:60
     # 128MiB, GKE's own serving-profile value. Large sequential reads want each
     # round trip to carry as much as possible.
     - read_ahead_kb=131072

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/cache_volumes.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/cache_volumes.yaml.tpl
@@ -109,15 +109,28 @@ spec:
     name: hf-cache
   mountOptions:
     - implicit-dirs
-    - metadata-cache:ttl-secs:-1
+    # A minute, where the compilation cache pins its metadata forever. This
+    # mount is not read-only: a model nothing has fetched yet is downloaded by
+    # the first workload that wants it, through this mount, and the same
+    # process then lists the directory it just filled. Pinned metadata makes
+    # that listing the one taken before the download - vLLM reports "Cannot
+    # find any model weights" for a snapshot whose safetensors are sitting in
+    # the bucket - and a handle opened across the change comes back as
+    # OSError: [Errno 116] Stale file handle.
+    #
+    # The size caps stay unbounded. What has to expire is an entry's age, not
+    # how many of them are kept, and a checkpoint directory is a few dozen
+    # names.
+    - metadata-cache:ttl-secs:60
     - metadata-cache:stat-cache-max-size-mb:-1
     - metadata-cache:type-cache-max-size-mb:-1
-    - file-system:kernel-list-cache-ttl-secs:-1
-    # An hour, against the compilation cache's minute. Hugging Face probes
-    # several optional files per model - adapter_config.json and friends - that
-    # legitimately do not exist, and a model that is absent stays absent until
-    # something downloads it, which writes through this same mount.
-    - metadata-cache:negative-ttl-secs:3600
+    - file-system:kernel-list-cache-ttl-secs:60
+    # Hugging Face probes several optional files per model -
+    # adapter_config.json and friends - that legitimately do not exist, so a
+    # negative entry is worth keeping. The same minute as above, and for the
+    # same reason: what does not exist at the start of a download does by the
+    # end of it.
+    - metadata-cache:negative-ttl-secs:60
     # 128MiB, GKE's own serving-profile value. Large sequential reads want each
     # round trip to carry as much as possible.
     - read_ahead_kb=131072


### PR DESCRIPTION
The model mount was tuned as if it were read-only — metadata and kernel list cache pinned forever — but the first workload to want a model downloads it through this mount and then lists the directory it just filled.

Pinned metadata makes that listing the one taken *before* the download: vLLM reports `Cannot find any model weights` for a snapshot whose safetensors are in the bucket, and a handle held across the change gives `OSError: [Errno 116] Stale file handle` out of the tokenizer load.

One minute TTL for positive, negative and list entries. Size caps stay unbounded — what has to expire is an entry's age, not how many are kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)