### PR TITLE
Add reusable Buildkite agent templates for H200 MIG machines

### DIFF
--- a/scripts/AGENT.md
+++ b/scripts/AGENT.md
@@ -130,9 +130,64 @@ docker run --rm --gpus all nvidia/cuda:12.8.0-base-ubuntu22.04 nvidia-smi
 
 For H200 MIG setup, see [`setup_mig_h200.sh`](setup_mig_h200.sh) and [`teardown_mig_h200.sh`](teardown_mig_h200.sh).
 
-## 6. Configure and Start the Buildkite Agent
+## 6. Point HF_HOME at Large Storage
+
+Model weights downloaded during CI jobs go to Hugging Face's cache. By default that is `~/.cache/huggingface` on the root disk, which fills up fast on GPU machines. Point `HF_HOME` at a big disk instead:
+
+- If the machine has a mounted shared filesystem with **4+ TB** of space (FSx, NFS, a large NVMe array), use that — a shared cache stays warm across jobs.
+- Otherwise use the **largest local filesystem** (e.g. a RAID or NVMe mount).
+
+This snippet picks the target automatically and prints what it chose:
+
+```bash
+# Prefer a mounted share with >= 4TB, else the largest non-root filesystem.
+HF_TARGET=$(
+  df -B1G --output=target,size,avail | tail -n +2 | \
+  awk '
+    $1 != "/" && $1 !~ "^/boot" {
+      if ($2 >= 4096) { big[++n] = $1; sz[n] = $2 }
+      if ($2 > max) { max = $2; largest = $1 }
+    }
+    END {
+      if (n > 0) {
+        # among >= 4TB mounts, pick the largest
+        best = 0
+        for (i = 1; i <= n; i++) if (sz[i] > best) { best = sz[i]; pick = i }
+        print big[pick]
+      } else {
+        print largest
+      }
+    }'
+)
+echo "HF cache target: $HF_TARGET"
+sudo mkdir -p "$HF_TARGET/hf_cache"
+```
+
+Then set `HF_HOME` for the buildkite-agent user via the agent's environment hook so every job inherits it (the pipeline's docker plugin passes `HF_HOME` through into containers):
+
+```bash
+sudo tee -a /etc/buildkite-agent/hooks/environment > /dev/null <<EOF
+export HF_HOME="$HF_TARGET/hf_cache"
+EOF
+sudo chown buildkite-agent:buildkite-agent /etc/buildkite-agent/hooks/environment
+```
+
+Make sure the directory is writable by the agent:
+
+```bash
+sudo chown -R buildkite-agent:buildkite-agent "$HF_TARGET/hf_cache"
+```
+
+> If your pipeline mounts a specific path into containers (e.g. `/fsx/hf_cache` or `/raid`), set `HF_HOME` to that same path so the container and host agree on the cache location.
+
+## 7. Configure and Start the Buildkite Agent
 
 Now that the machine is fully prepared, configure the agent and bring it online.
+
+> **H200 MIG machines:** ready-made config + hook templates (including MIG
+> slice pinning, ECR login, and secrets) live in
+> [`buildkite-agent/`](buildkite-agent/README.md). Copy those instead of writing
+> the config from scratch.
 
 ### Determine your token and queue
 
@@ -180,5 +235,6 @@ The agent should appear in your Buildkite dashboard under Agents within a few se
 - [ ] `buildkite-agent` user is in the `docker` group
 - [ ] Docker/containerd data roots moved if needed (step 4)
 - [ ] NVIDIA driver + container toolkit installed (GPU machines only)
-- [ ] Agent configured with correct token and queue tags (step 6)
+- [ ] `HF_HOME` pointed at large storage (step 6)
+- [ ] Agent configured with correct token and queue tags (step 7)
 - [ ] Agent started and visible in Buildkite dashboard

--- a/scripts/buildkite-agent/README.md
+++ b/scripts/buildkite-agent/README.md
@@ -1,0 +1,54 @@
+# Buildkite Agent Templates (H200 MIG)
+
+Reusable, working copies of the Buildkite agent config and hooks from a live
+`h200_18gb` MIG agent. Use these when onboarding a new H200 MIG machine so you
+don't have to reverse-engineer a running agent each time.
+
+Secrets are replaced with `<placeholders>` — fill them in on the target machine.
+Nothing secret is committed here.
+
+## Files
+
+| File | Install to | Purpose |
+|------|-----------|---------|
+| `buildkite-agent.cfg` | `/etc/buildkite-agent/buildkite-agent.cfg` | Agent config: queue tag, `spawn=56` (8 GPUs × 7 MIG slices), build/git-mirror paths. |
+| `environment` | `/etc/buildkite-agent/hooks/environment` | Exports secrets, logs into ECR, maps agent spawn # → MIG slice UUID, serializes the first docker pull, sets shallow git flags. |
+| `buildkite-gpu-cdi-env.sh` | `/usr/local/libexec/buildkite-gpu-cdi-env.sh` | Converts the MIG GPU selection into a CDI device (`nvidia.com/gpu=...`) and validates it exists. Sourced by `environment`. |
+| `pre-checkout` | `/etc/buildkite-agent/hooks/pre-checkout` | Injects a GitHub read-only PAT (from the agent secret store) as a git HTTP header for the vllm / perf-eval repos. |
+| `post-checkout` | `/etc/buildkite-agent/hooks/post-checkout` | Removes the injected git header after fetch. |
+
+## Secrets to fill in
+
+In `environment`:
+- `HF_TOKEN` — Hugging Face token (required for gated models / rate limits).
+- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` — for ECR image pulls.
+- `BUILDKITE_ANALYTICS_TOKEN` — optional, Buildkite Test Analytics.
+
+In `buildkite-agent.cfg`:
+- `token` — the Buildkite agent registration token for the target cluster.
+
+The GitHub PAT is **not** in a file — `pre-checkout` fetches it at runtime via
+`buildkite-agent secret get GITHUB_READONLY_PAT`, so it must exist in the
+cluster's secret store.
+
+## Quick install
+
+```bash
+# On the target machine, after scripts/AGENT.md steps 1-5 are done:
+sudo install -m 0755 environment            /etc/buildkite-agent/hooks/environment
+sudo install -m 0755 pre-checkout           /etc/buildkite-agent/hooks/pre-checkout
+sudo install -m 0755 post-checkout          /etc/buildkite-agent/hooks/post-checkout
+sudo install -m 0755 buildkite-gpu-cdi-env.sh /usr/local/libexec/buildkite-gpu-cdi-env.sh
+sudo install -m 0644 buildkite-agent.cfg    /etc/buildkite-agent/buildkite-agent.cfg
+
+# Edit the two files to fill in secrets / token / hostname, then:
+sudo systemctl enable --now buildkite-agent
+```
+
+## Notes
+
+- `HF_HOME=/mnt/vllm-ci` matches the `h200_18gb` docker plugin, which mounts
+  `/mnt/vllm-ci` into containers. Keep them in sync.
+- `spawn` must equal `num_gpus × 7` for the MIG-slice mapping to line up with
+  the agent names (`<host>-1` … `<host>-56`).
+- See [`../AGENT.md`](../AGENT.md) for the full machine-onboarding runbook.

--- a/scripts/buildkite-agent/README.md
+++ b/scripts/buildkite-agent/README.md
@@ -1,17 +1,31 @@
 # Buildkite Agent Templates (H200 MIG)
 
-Reusable, working copies of the Buildkite agent config and hooks from a live
-`h200_18gb` MIG agent. Use these when onboarding a new H200 MIG machine so you
-don't have to reverse-engineer a running agent each time.
+Reusable, working copies of the Buildkite agent config and hooks from live
+H200 MIG agents (`h200_18gb` and `h200_35gb`). Use these when onboarding a new
+H200 MIG machine so you don't have to reverse-engineer a running agent each time.
 
 Secrets are replaced with `<placeholders>` — fill them in on the target machine.
 Nothing secret is committed here.
+
+## MIG profiles and agent counts (8-GPU H200)
+
+One Buildkite agent is spawned per MIG slice, so `spawn` = slices per GPU × 8:
+
+| Profile | Slices/GPU | Agents (spawn) | Queue | `SLICES_PER_GPU` |
+|---------|-----------:|---------------:|-------|------------------|
+| `1g.18gb` | 7 | 56 | `h200_18gb` | 7 |
+| `1g.35gb` | 4 | 32 | `h200_35gb` | 4 |
+
+The `environment` hook maps each agent's spawn number to a MIG slice UUID using
+`SLICES_PER_GPU` (set near the top of that file). Keep three things in sync:
+the MIG profile created on the GPUs, `spawn` in `buildkite-agent.cfg`, and
+`SLICES_PER_GPU` in `environment`.
 
 ## Files
 
 | File | Install to | Purpose |
 |------|-----------|---------|
-| `buildkite-agent.cfg` | `/etc/buildkite-agent/buildkite-agent.cfg` | Agent config: queue tag, `spawn=56` (8 GPUs × 7 MIG slices), build/git-mirror paths. |
+| `buildkite-agent.cfg` | `/etc/buildkite-agent/buildkite-agent.cfg` | Agent config: queue tag, `spawn` (see table above), build/git-mirror paths. |
 | `environment` | `/etc/buildkite-agent/hooks/environment` | Exports secrets, logs into ECR, maps agent spawn # → MIG slice UUID, serializes the first docker pull, sets shallow git flags. |
 | `buildkite-gpu-cdi-env.sh` | `/usr/local/libexec/buildkite-gpu-cdi-env.sh` | Converts the MIG GPU selection into a CDI device (`nvidia.com/gpu=...`) and validates it exists. Sourced by `environment`. |
 | `pre-checkout` | `/etc/buildkite-agent/hooks/pre-checkout` | Injects a GitHub read-only PAT (from the agent secret store) as a git HTTP header for the vllm / perf-eval repos. |
@@ -41,14 +55,17 @@ sudo install -m 0755 post-checkout          /etc/buildkite-agent/hooks/post-chec
 sudo install -m 0755 buildkite-gpu-cdi-env.sh /usr/local/libexec/buildkite-gpu-cdi-env.sh
 sudo install -m 0644 buildkite-agent.cfg    /etc/buildkite-agent/buildkite-agent.cfg
 
-# Edit the two files to fill in secrets / token / hostname, then:
+# Edit the two files to fill in secrets / token / hostname, set spawn and
+# SLICES_PER_GPU for your MIG profile, then:
 sudo systemctl enable --now buildkite-agent
 ```
 
 ## Notes
 
-- `HF_HOME=/mnt/vllm-ci` matches the `h200_18gb` docker plugin, which mounts
-  `/mnt/vllm-ci` into containers. Keep them in sync.
-- `spawn` must equal `num_gpus × 7` for the MIG-slice mapping to line up with
-  the agent names (`<host>-1` … `<host>-56`).
+- `HF_HOME=/mnt/vllm-ci` matches the `h200_18gb` / `h200_35gb` docker plugins,
+  which mount `/mnt/vllm-ci` into containers. Keep them in sync: if the host's
+  HF cache lives elsewhere, either mount it at `/mnt/vllm-ci` or update the
+  plugin's volume list.
+- `spawn` must equal `num_gpus × slices_per_gpu` for the MIG-slice mapping to
+  line up with the agent names (`<host>-1` … `<host>-N`).
 - See [`../AGENT.md`](../AGENT.md) for the full machine-onboarding runbook.

--- a/scripts/buildkite-agent/buildkite-agent.cfg
+++ b/scripts/buildkite-agent/buildkite-agent.cfg
@@ -1,0 +1,17 @@
+# Buildkite agent config for an H200 MIG machine (queue=h200_18gb).
+#
+# Install at: /etc/buildkite-agent/buildkite-agent.cfg
+#
+# spawn=56 matches the MIG layout from scripts/setup_mig_h200.sh on an 8-GPU
+# H200: 8 GPUs x 7 slices = 56 agents, one per slice. The environment hook maps
+# each spawn number to a MIG UUID. Adjust spawn to (num_gpus * 7) for your box.
+
+token="<agent-token>"
+name="<hostname>-%spawn"
+tags="queue=h200_18gb"
+spawn=56
+build-path="/raid0/buildkite-agent/builds"
+hooks-path="/etc/buildkite-agent/hooks"
+plugins-path="/etc/buildkite-agent/plugins"
+git-mirrors-path=/var/lib/buildkite-agent/git-mirrors
+git-mirror-checkout-mode=dissociate

--- a/scripts/buildkite-agent/buildkite-agent.cfg
+++ b/scripts/buildkite-agent/buildkite-agent.cfg
@@ -1,10 +1,12 @@
-# Buildkite agent config for an H200 MIG machine (queue=h200_18gb).
+# Buildkite agent config for an H200 MIG machine.
 #
 # Install at: /etc/buildkite-agent/buildkite-agent.cfg
 #
-# spawn=56 matches the MIG layout from scripts/setup_mig_h200.sh on an 8-GPU
-# H200: 8 GPUs x 7 slices = 56 agents, one per slice. The environment hook maps
-# each spawn number to a MIG UUID. Adjust spawn to (num_gpus * 7) for your box.
+# One agent is spawned per MIG slice, so spawn = num_gpus * slices_per_gpu:
+#   - 1g.18gb (queue=h200_18gb): 7 slices/GPU -> spawn=56 on 8 GPUs
+#   - 1g.35gb (queue=h200_35gb): 4 slices/GPU -> spawn=32 on 8 GPUs
+# The environment hook maps each spawn number to a MIG UUID (SLICES_PER_GPU
+# there must match). Set tags/spawn for your profile.
 
 token="<agent-token>"
 name="<hostname>-%spawn"

--- a/scripts/buildkite-agent/buildkite-gpu-cdi-env.sh
+++ b/scripts/buildkite-agent/buildkite-gpu-cdi-env.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Use Docker's native CDI device injection instead of the legacy --gpus hook.
+# The legacy hook can lose GPU cgroup access after `systemctl daemon-reload`.
+#
+# Install at: /usr/local/libexec/buildkite-gpu-cdi-env.sh
+# Sourced by the agent environment hook after BUILDKITE_PLUGIN_DOCKER_GPUS/UUID
+# are set. Converts the selection into a CDI device and validates it exists.
+
+cdi_selector="${BUILDKITE_PLUGIN_DOCKER_GPUS:-all}"
+cdi_selector="${cdi_selector#device=}"
+
+if [[ -n "${UUID:-}" ]]; then
+  cdi_selector="${UUID}"
+fi
+
+cdi_device="nvidia.com/gpu=${cdi_selector}"
+if ! nvidia-ctk cdi list 2>/dev/null | grep -Fqx "${cdi_device}"; then
+  echo "ERROR: CDI device ${cdi_device} is absent from the NVIDIA CDI spec" >&2
+  exit 1
+fi
+
+unset BUILDKITE_PLUGIN_DOCKER_GPUS
+export BUILDKITE_PLUGIN_DOCKER_DEVICES_0="${cdi_device}"

--- a/scripts/buildkite-agent/environment
+++ b/scripts/buildkite-agent/environment
@@ -12,10 +12,18 @@
 #   4. Serializes the first docker pull of the job image across the many agents
 #      on the host (flock), so 56 agents don't all pull at once.
 #
-# This template assumes the H200 MIG layout from scripts/setup_mig_h200.sh:
-# 7 slices per GPU, agents spawned with names ending in -<N> (N = 1..56).
+# This template assumes the H200 MIG layout from scripts/setup_mig_h200.sh,
+# with agents spawned with names ending in -<N> (N = 1..num_slices).
+#
+# MIG profiles (8-GPU H200):
+#   - 1g.18gb: 7 slices/GPU -> 56 agents (queue=h200_18gb), SLICES_PER_GPU=7
+#   - 1g.35gb: 4 slices/GPU -> 32 agents (queue=h200_35gb), SLICES_PER_GPU=4
+# Set SLICES_PER_GPU to match the MIG profile and the agent cfg `spawn` value.
 
 set -e
+
+# Number of MIG slices per GPU (7 for 1g.18gb, 4 for 1g.35gb).
+SLICES_PER_GPU=7
 
 # ── Secrets (FILL THESE IN) ───────────────────────────────────────────────────
 export HF_TOKEN="<hf-token>"
@@ -50,8 +58,8 @@ fi
 
 IDX=$(( AGENT_NUMBER - 1 ))
 UUID="${UUIDS[$IDX]}"
-GPU=$(( IDX / 7 ))
-SLOT=$(( IDX % 7 ))
+GPU=$(( IDX / SLICES_PER_GPU ))
+SLOT=$(( IDX % SLICES_PER_GPU ))
 echo "Agent $BUILDKITE_AGENT_NAME (#$AGENT_NUMBER) → GPU $GPU slot $SLOT → $UUID"
 export BUILDKITE_PLUGIN_DOCKER_GPUS="device=${UUID}"
 

--- a/scripts/buildkite-agent/environment
+++ b/scripts/buildkite-agent/environment
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Buildkite agent environment hook for an H200 MIG machine.
+#
+# Install at: /etc/buildkite-agent/hooks/environment
+# Owner: root, mode 0755. Sourced by every job before it runs.
+#
+# What it does:
+#   1. Exports secrets (HF_TOKEN, AWS creds, analytics token) — fill these in.
+#   2. Logs Docker into ECR (public + the pull-through cache).
+#   3. Maps this agent's spawn number to a specific MIG slice UUID and pins the
+#      job to it via BUILDKITE_PLUGIN_DOCKER_GPUS.
+#   4. Serializes the first docker pull of the job image across the many agents
+#      on the host (flock), so 56 agents don't all pull at once.
+#
+# This template assumes the H200 MIG layout from scripts/setup_mig_h200.sh:
+# 7 slices per GPU, agents spawned with names ending in -<N> (N = 1..56).
+
+set -e
+
+# ── Secrets (FILL THESE IN) ───────────────────────────────────────────────────
+export HF_TOKEN="<hf-token>"
+export AWS_ACCESS_KEY_ID="<aws-access-key-id>"
+export AWS_SECRET_ACCESS_KEY="<aws-secret-access-key>"
+export BUILDKITE_ANALYTICS_TOKEN="<analytics-token>"   # optional
+
+# ── Hugging Face cache ────────────────────────────────────────────────────────
+# Point at large shared/local storage. The h200_18gb docker plugin mounts
+# /mnt/vllm-ci into containers, so keep HF_HOME on that path.
+export HF_HOME=/mnt/vllm-ci
+
+# ── ECR login ─────────────────────────────────────────────────────────────────
+aws ecr-public get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin public.ecr.aws
+aws ecr get-login-password --region us-west-2 \
+  | docker login --username AWS --password-stdin 936637512419.dkr.ecr.us-west-2.amazonaws.com
+
+# ── Pin this agent to one MIG slice ───────────────────────────────────────────
+# Agent names look like "<host>-<N>"; N selects the MIG device.
+AGENT_NUMBER="${BUILDKITE_AGENT_NAME##*-}"
+if [[ -z "$AGENT_NUMBER" ]]; then
+  echo "ERROR: Could not extract agent number from BUILDKITE_AGENT_NAME=$BUILDKITE_AGENT_NAME"
+  exit 1
+fi
+
+mapfile -t UUIDS < <(nvidia-smi -L | grep -oP 'UUID: \KMIG-[^\)]+')
+if (( AGENT_NUMBER < 1 || AGENT_NUMBER > ${#UUIDS[@]} )); then
+  echo "ERROR: Agent number $AGENT_NUMBER exceeds available MIG devices (${#UUIDS[@]})"
+  exit 1
+fi
+
+IDX=$(( AGENT_NUMBER - 1 ))
+UUID="${UUIDS[$IDX]}"
+GPU=$(( IDX / 7 ))
+SLOT=$(( IDX % 7 ))
+echo "Agent $BUILDKITE_AGENT_NAME (#$AGENT_NUMBER) → GPU $GPU slot $SLOT → $UUID"
+export BUILDKITE_PLUGIN_DOCKER_GPUS="device=${UUID}"
+
+# ── Serialize the first image pull across agents on this host ─────────────────
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_IMAGE:-}" ]]; then
+  IMAGE="$BUILDKITE_PLUGIN_DOCKER_IMAGE"
+elif [[ -n "${BUILDKITE_COMMIT:-}" ]]; then
+  if [[ "${BUILDKITE_BRANCH:-}" == "main" ]]; then
+    IMAGE="<main-image>"        # e.g. the postmerge CI image
+  else
+    IMAGE="<branch-image>"      # e.g. the premerge CI image
+  fi
+else
+  IMAGE=""
+fi
+
+if [[ -n "$IMAGE" ]]; then
+  LOCK_DIR="/tmp/docker-pull-locks"
+  mkdir -p "$LOCK_DIR"
+  LOCK_FILE="${LOCK_DIR}/$(echo "$IMAGE" | tr '/:' '__').lock"
+  DONE_FILE="${LOCK_FILE}.done"
+  if [[ -f "$DONE_FILE" ]]; then
+    echo "Image $IMAGE already pulled (done marker exists), skipping pull."
+  else
+    exec 9>"$LOCK_FILE"
+    if flock -n 9; then
+      echo "Pulling image $IMAGE (this agent won the lock)..."
+      docker pull "$IMAGE"
+      touch "$DONE_FILE"
+      echo "Image pull complete."
+    else
+      echo "Waiting for another agent to finish pulling $IMAGE..."
+      flock 9
+      echo "Image $IMAGE is now available."
+    fi
+    exec 9>&-
+  fi
+fi
+
+# ── CDI device injection + shallow git clones ─────────────────────────────────
+source /usr/local/libexec/buildkite-gpu-cdi-env.sh
+export BUILDKITE_GIT_CLONE_FLAGS="-v --depth=1 --filter=blob:none"
+export BUILDKITE_GIT_FETCH_FLAGS="-v --prune --depth=1"

--- a/scripts/buildkite-agent/post-checkout
+++ b/scripts/buildkite-agent/post-checkout
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Removes the git extraHeader config injected by pre-checkout, restoring the
+# previous GIT_CONFIG_COUNT so later steps don't carry the credential.
+#
+# Install at: /etc/buildkite-agent/hooks/post-checkout
+
+set -e
+
+config_index=${BUILDKITE_GITHUB_AUTH_CONFIG_INDEX:-}
+previous_count=${BUILDKITE_GITHUB_AUTH_PREVIOUS_CONFIG_COUNT:-}
+
+if [ -z "$config_index" ] || [ -z "$previous_count" ]; then
+    exit 0
+fi
+
+unset "GIT_CONFIG_KEY_${config_index}"
+unset "GIT_CONFIG_VALUE_${config_index}"
+
+if [ "$previous_count" -eq 0 ]; then
+    unset GIT_CONFIG_COUNT
+else
+    export GIT_CONFIG_COUNT=$previous_count
+fi
+
+unset BUILDKITE_GITHUB_AUTH_CONFIG_INDEX
+unset BUILDKITE_GITHUB_AUTH_PREVIOUS_CONFIG_COUNT
+unset config_index previous_count

--- a/scripts/buildkite-agent/pre-checkout
+++ b/scripts/buildkite-agent/pre-checkout
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Injects a GitHub read-only PAT as an HTTP extraHeader for git fetches on the
+# two canonical repos (vllm and perf-eval). The PAT comes from the Buildkite
+# agent secret store, never from disk.
+#
+# Install at: /etc/buildkite-agent/hooks/pre-checkout
+# Pair with post-checkout, which unsets the injected config after the fetch.
+
+set -e
+
+# Authenticate only the two canonical repositories.
+case "${BUILDKITE_PIPELINE_ID:-}:${BUILDKITE_REPO:-}" in
+    018cdabc-d930-49f6-9085-634c4cb582ed:https://github.com/vllm-project/vllm.git|\
+    019dd151-0969-469a-a03e-43dfc10f204f:https://github.com/vllm-project/perf-eval.git)
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+
+github_pat=$(/usr/bin/buildkite-agent secret get GITHUB_READONLY_PAT)
+github_basic=$(printf 'x-access-token:%s' "$github_pat" | base64 -w0)
+
+# The secret command redacts the raw PAT. Register the derived Basic payload and
+# complete header before exporting them so hook environment-diff logs are safe.
+printf '%s' "$github_basic" | /usr/bin/buildkite-agent redactor add
+printf '%s' "AUTHORIZATION: basic ${github_basic}" | /usr/bin/buildkite-agent redactor add
+
+git_config_index=${GIT_CONFIG_COUNT:-0}
+case "$git_config_index" in
+    ''|*[!0-9]*)
+        echo "Invalid GIT_CONFIG_COUNT: expected a non-negative integer" >&2
+        exit 1
+        ;;
+esac
+
+export BUILDKITE_GITHUB_AUTH_PREVIOUS_CONFIG_COUNT=$git_config_index
+export BUILDKITE_GITHUB_AUTH_CONFIG_INDEX=$git_config_index
+export "GIT_CONFIG_KEY_${git_config_index}=http.https://github.com/.extraHeader"
+export "GIT_CONFIG_VALUE_${git_config_index}=AUTHORIZATION: basic ${github_basic}"
+export GIT_CONFIG_COUNT=$((git_config_index + 1))
+
+unset github_pat github_basic git_config_index


### PR DESCRIPTION
## Summary

Captures the working Buildkite agent config + hooks from a live `h200_18gb` MIG agent as reusable templates, so onboarding a new H200 MIG machine no longer requires reverse-engineering a running agent.

## What is included

New `scripts/buildkite-agent/` directory:

- **`buildkite-agent.cfg`** — agent config template (`queue=h200_18gb`, `spawn=56` for 8 GPUs × 7 MIG slices, build/git-mirror paths)
- **`environment`** — environment hook: secrets placeholders, ECR login, MIG spawn#→UUID pinning, serialized first docker pull (flock), shallow git flags
- **`buildkite-gpu-cdi-env.sh`** — CDI device-injection helper sourced by the environment hook
- **`pre-checkout` / `post-checkout`** — GitHub PAT injection/removal (PAT fetched at runtime from the Buildkite secret store, not stored on disk)
- **`README.md`** — install table, secrets to fill in, quick-install commands, and notes

Also updates `scripts/AGENT.md`:
- New step 6 "Point HF_HOME at Large Storage" — auto-detects a ≥4 TB shared mount, else the largest local disk, and exports `HF_HOME` via the agent environment hook
- Links the new templates from the agent-config step

All secret values are `<placeholders>` — nothing sensitive is committed.
