### PR TITLE
Mount /mnt/hf-cache-af-south1-a in h200_35gb docker plugin

### DIFF
--- a/buildkite/pipeline_generator/plugin/docker_plugin.py
+++ b/buildkite/pipeline_generator/plugin/docker_plugin.py
@@ -62,6 +62,7 @@ h200_35gb_plugin_template = {
     "volumes": [
         "/dev/shm:/dev/shm",
         "/mnt/vllm-ci:/mnt/vllm-ci",
+        "/mnt/hf-cache-af-south1-a:/mnt/hf-cache-af-south1-a",
         "/dev/nvidiactl:/dev/nvidiactl",
     ],
 }


### PR DESCRIPTION
## Summary

Adds `/mnt/hf-cache-af-south1-a` to the `h200_35gb` docker plugin's volume mounts.

The `h200_35gb` agents keep their Hugging Face cache on the `/mnt/hf-cache-af-south1-a` share and set `HF_HOME` there via the agent environment hook. `HF_HOME` stays machine-configured (passed through from the agent env), not hardcoded in the plugin — this change only makes the path reachable inside containers.

## Test plan

- `python3 -m pytest buildkite/tests/pipeline_generator/test_plugins.py` — 12 passed
