### PR TITLE
Add confirmed vLLM CI selection leaks

### DIFF
--- a/test-selection/selection-leaks.json
+++ b/test-selection/selection-leaks.json
@@ -923,7 +923,7 @@
       "causal_confirmation": {
         "kind": "code_analysis",
         "reference_url": "https://github.com/vllm-project/vllm/pull/56323",
-        "notes": "The preceding selected main completed the exact lane in 41m05s; after the culprit registered four native sampler warmups per engine, two consecutive main builds timed out while another engine was compiling without a failed test."
+        "notes": "The preceding selected main completed the exact lane in 41m05s; after the culprit registered four native sampler warmups per engine, two consecutive main builds timed out while another engine was compiling without a failed test. The only unchanged retry of build 88593 repeated the 60-minute timeout on h200-ci-4 after 32 completed warmups totaling 897.12 seconds, with 721 passing tests and no test failure."
       }
     },
     {

--- a/test-selection/selection-leaks.json
+++ b/test-selection/selection-leaks.json
@@ -955,6 +955,62 @@
       }
     },
     {
+      "id": "pr-56323-main-88589-basic-correctness",
+      "job_name": "H200 MIG 18GB Basic Correctness",
+      "job_key": "basic-correctness",
+      "culprit_pr": {
+        "number": 56323,
+        "url": "https://github.com/vllm-project/vllm/pull/56323",
+        "merge_commit": "aed894c190aa3db74c502d521b3bc3935ad85de1"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "not_selected",
+        "build_number": 88574,
+        "job_id": null,
+        "url": "https://buildkite.com/vllm/ci/builds/88574"
+      },
+      "main_failure": {
+        "build_number": 88589,
+        "job_id": "01a098c5-c44a-42eb-93b3-2f6364d7dab3",
+        "url": "https://buildkite.com/vllm/ci/builds/88589#01a098c5-c44a-42eb-93b3-2f6364d7dab3",
+        "signature": "the lane timed out after 33 sampler JIT warmups added 2024 seconds while its tests continued passing"
+      },
+      "causal_confirmation": {
+        "kind": "fix",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56654",
+        "notes": "The preceding full main completed the exact lane in 37m13s; after PR #56323 it ran for 68 minutes without a failed test. The exact lane passed in 33m47s on rollback PR #56654 build 88588."
+      }
+    },
+    {
+      "id": "pr-56323-main-88593-v1-sample",
+      "job_name": "H200 MIG 18GB V1 Sample",
+      "job_key": "v1-sample",
+      "culprit_pr": {
+        "number": 56323,
+        "url": "https://github.com/vllm-project/vllm/pull/56323",
+        "merge_commit": "aed894c190aa3db74c502d521b3bc3935ad85de1"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "not_selected",
+        "build_number": 88574,
+        "job_id": null,
+        "url": "https://buildkite.com/vllm/ci/builds/88574"
+      },
+      "main_failure": {
+        "build_number": 88593,
+        "job_id": "01a098cf-26d1-47f1-9ed4-dd3654d42b24",
+        "url": "https://buildkite.com/vllm/ci/builds/88593#01a098cf-26d1-47f1-9ed4-dd3654d42b24",
+        "signature": "the lane timed out after 17 sampler JIT warmups added 215 seconds while 192 tests passed; its hot-cache retry then passed"
+      },
+      "causal_confirmation": {
+        "kind": "fix",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56654",
+        "notes": "The preceding full main completed the exact lane in 27m06s; the post-PR #56323 cold run exceeded its 35-minute budget. The exact lane passed in 20m07s on rollback PR #56654 build 88588."
+      }
+    },
+    {
       "id": "pr-56323-main-88593-cudagraph",
       "job_name": "H200 MIG 35GB CUDAGraph",
       "job_key": "cudagraph",
@@ -974,12 +1030,12 @@
         "build_number": 88593,
         "job_id": "01a098cf-2623-49ef-b655-b628195bf1af",
         "url": "https://buildkite.com/vllm/ci/builds/88593#01a098cf-2623-49ef-b655-b628195bf1af",
-        "signature": "the lane timed out after 13 sampler JIT warmups added 804 seconds while 28 tests passed"
+        "signature": "the lane timed out after 13 sampler JIT warmups added 804 seconds while 28 tests passed, and its only unchanged retry also timed out"
       },
       "causal_confirmation": {
         "kind": "code_analysis",
         "reference_url": "https://github.com/vllm-project/vllm/pull/56654",
-        "notes": "The preceding full main completed the exact lane in 22m17s; after PR #56323 registered about 120 sampler keys per engine, this job exceeded its 30-minute budget during the second test command. Merged PR #56654 reverts that registration."
+        "notes": "The preceding full main completed the exact lane in 22m17s; after PR #56323 registered about 120 sampler keys per engine, two different hosts exceeded the 30-minute budget during the second test command. Merged PR #56654 reverts that registration."
       }
     },
     {

--- a/test-selection/selection-leaks.json
+++ b/test-selection/selection-leaks.json
@@ -1002,7 +1002,7 @@
         "build_number": 88593,
         "job_id": "01a098cf-26d1-47f1-9ed4-dd3654d42b24",
         "url": "https://buildkite.com/vllm/ci/builds/88593#01a098cf-26d1-47f1-9ed4-dd3654d42b24",
-        "signature": "the lane timed out after 17 sampler JIT warmups added 215 seconds while 192 tests passed; its hot-cache retry then passed"
+        "signature": "the lane timed out after 17 sampler JIT warmups added 215 seconds while 192 tests passed, and its only unchanged retry also timed out"
       },
       "causal_confirmation": {
         "kind": "fix",
@@ -1039,6 +1039,34 @@
       }
     },
     {
+      "id": "pr-56323-main-88593-examples",
+      "job_name": "H200 MIG 35GB Examples",
+      "job_key": "examples",
+      "culprit_pr": {
+        "number": 56323,
+        "url": "https://github.com/vllm-project/vllm/pull/56323",
+        "merge_commit": "aed894c190aa3db74c502d521b3bc3935ad85de1"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "not_selected",
+        "build_number": 88574,
+        "job_id": null,
+        "url": "https://buildkite.com/vllm/ci/builds/88574"
+      },
+      "main_failure": {
+        "build_number": 88593,
+        "job_id": "01a098cf-26d3-4fbd-9701-7b2da1e36bcf",
+        "url": "https://buildkite.com/vllm/ci/builds/88593#01a098cf-26d3-4fbd-9701-7b2da1e36bcf",
+        "signature": "the lane timed out after 16 sampler JIT warmups added 1083 seconds while 15 of 17 example commands completed"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56323",
+        "notes": "The preceding full main completed the exact lane in 27m17s. After PR #56323 registered about 120 sampler keys per engine, the job exceeded its 40-minute budget without a failed command; exact rollback coverage is pending."
+      }
+    },
+    {
       "id": "pr-56323-main-88593-extract-hidden-states-integration",
       "job_name": "L4 Extract Hidden States Integration",
       "job_key": "extract-hidden-states-integration-2-gpus",
@@ -1064,6 +1092,34 @@
         "kind": "code_analysis",
         "reference_url": "https://github.com/vllm-project/vllm/pull/56654",
         "notes": "The preceding full main completed the exact job in 2m10s. Both post-PR #56323 attempts failed after 122.34s while the two TP workers were still warming sampler kernels; merged PR #56654 removes that registration."
+      }
+    },
+    {
+      "id": "pr-56323-main-88593-pipeline-context-parallelism-4-gpus",
+      "job_name": "L4 Pipeline + Context Parallelism",
+      "job_key": "pipeline-context-parallelism-4-gpus",
+      "culprit_pr": {
+        "number": 56323,
+        "url": "https://github.com/vllm-project/vllm/pull/56323",
+        "merge_commit": "aed894c190aa3db74c502d521b3bc3935ad85de1"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "not_selected",
+        "build_number": 88574,
+        "job_id": null,
+        "url": "https://buildkite.com/vllm/ci/builds/88574"
+      },
+      "main_failure": {
+        "build_number": 88593,
+        "job_id": "01a098cf-2643-446f-8662-3236f98c94fb",
+        "url": "https://buildkite.com/vllm/ci/builds/88593#01a098cf-2643-446f-8662-3236f98c94fb",
+        "signature": "the lane timed out after 78 worker sampler JIT warmups added 1186 seconds while 31 tests passed"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56323",
+        "notes": "The preceding full main completed the exact lane in 42m32s. After PR #56323 registered sampler kernels across parallel workers, the job exceeded its 55-minute budget without a failed test; exact rollback coverage is pending."
       }
     }
   ]

--- a/test-selection/selection-leaks.json
+++ b/test-selection/selection-leaks.json
@@ -1121,6 +1121,90 @@
         "reference_url": "https://github.com/vllm-project/vllm/pull/56323",
         "notes": "The preceding full main completed the exact lane in 42m32s. After PR #56323 registered sampler kernels across parallel workers, both attempts exceeded the 55-minute budget after 31 passing tests; the retry logged the same 78 warmups totaling 1188 seconds. Exact rollback coverage is pending."
       }
+    },
+    {
+      "id": "pr-56323-main-88612-arm-cpu-shard-2",
+      "job_name": "Arm CPU Test Shard 2",
+      "job_key": "arm-cpu-test",
+      "culprit_pr": {
+        "number": 56323,
+        "url": "https://github.com/vllm-project/vllm/pull/56323",
+        "merge_commit": "aed894c190aa3db74c502d521b3bc3935ad85de1"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "not_selected",
+        "build_number": 88574,
+        "job_id": null,
+        "url": "https://buildkite.com/vllm/ci/builds/88574"
+      },
+      "main_failure": {
+        "build_number": 88612,
+        "job_id": "01a0995b-7d09-414a-9448-99777c1de60e",
+        "url": "https://buildkite.com/vllm/ci/builds/88612#01a0995b-7d09-414a-9448-99777c1de60e",
+        "signature": "Arm CPU engine startup failed at import time because the warmup decorator dereferenced triton.runtime on the runtime-less Triton placeholder"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56676",
+        "notes": "The preceding daily build passed the exact shard. PR #56323 added the module-level spec-decode warmup decorator, but its PR build did not select any Arm CPU shard; the partial warmup rollback left this decorator in place. Draft PR #56676 adds the missing HAS_TRITON guard and a runtime-less placeholder regression test."
+      }
+    },
+    {
+      "id": "pr-56323-main-88612-arm-cpu-shard-3",
+      "job_name": "Arm CPU Test Shard 3",
+      "job_key": "arm-cpu-test",
+      "culprit_pr": {
+        "number": 56323,
+        "url": "https://github.com/vllm-project/vllm/pull/56323",
+        "merge_commit": "aed894c190aa3db74c502d521b3bc3935ad85de1"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "not_selected",
+        "build_number": 88574,
+        "job_id": null,
+        "url": "https://buildkite.com/vllm/ci/builds/88574"
+      },
+      "main_failure": {
+        "build_number": 88612,
+        "job_id": "01a0995b-7d0a-44d9-831b-87282c91863a",
+        "url": "https://buildkite.com/vllm/ci/builds/88612#01a0995b-7d0a-44d9-831b-87282c91863a",
+        "signature": "Arm CPU serving startup failed at import time because the warmup decorator dereferenced triton.runtime on the runtime-less Triton placeholder"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56676",
+        "notes": "The preceding daily build passed the exact shard. This independent shard reproduced the same deterministic import path from PR #56323, whose PR build selected no Arm CPU shard; draft PR #56676 guards autotune inspection when Triton is disabled."
+      }
+    },
+    {
+      "id": "pr-56157-main-88612-b200-lm-eval-pcp",
+      "job_name": "B200 LM Eval PCP",
+      "job_key": "lm-eval-pcp-4xb200",
+      "culprit_pr": {
+        "number": 56157,
+        "url": "https://github.com/vllm-project/vllm/pull/56157",
+        "merge_commit": "ebe1dec2da16ac559e40446a4c6e06a73c9efe00"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 88566,
+        "job_id": "01a09775-8294-4650-847c-daf7c477f5f1",
+        "url": "https://buildkite.com/vllm/ci/builds/88566#01a09775-8294-4650-847c-daf7c477f5f1"
+      },
+      "main_failure": {
+        "build_number": 88612,
+        "job_id": "01a0995b-7d98-4db4-8647-8bcabd2a7ab1",
+        "url": "https://buildkite.com/vllm/ci/builds/88612#01a0995b-7d98-4db4-8647-8bcabd2a7ab1",
+        "signature": "the new GLM-5.2 PCP4+DCP4 evaluation failed every worker at startup because it defaulted to the unsupported a2a DCP backend"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56677",
+        "notes": "PR #56157 both added the PCP4+DCP4 config without a DCP backend flag and added validation requiring ag_rs, while its exact optional B200 evaluation stayed blocked in PR CI. Draft PR #56677 supplies the single missing --dcp-comm-backend ag_rs argument."
+      }
     }
   ]
 }

--- a/test-selection/selection-leaks.json
+++ b/test-selection/selection-leaks.json
@@ -1114,12 +1114,12 @@
         "build_number": 88593,
         "job_id": "01a098cf-2643-446f-8662-3236f98c94fb",
         "url": "https://buildkite.com/vllm/ci/builds/88593#01a098cf-2643-446f-8662-3236f98c94fb",
-        "signature": "the lane timed out after 78 worker sampler JIT warmups added 1186 seconds while 31 tests passed"
+        "signature": "the lane timed out after 78 worker sampler JIT warmups added 1186 seconds while 31 tests passed, and its only unchanged retry repeated"
       },
       "causal_confirmation": {
         "kind": "code_analysis",
         "reference_url": "https://github.com/vllm-project/vllm/pull/56323",
-        "notes": "The preceding full main completed the exact lane in 42m32s. After PR #56323 registered sampler kernels across parallel workers, the job exceeded its 55-minute budget without a failed test; exact rollback coverage is pending."
+        "notes": "The preceding full main completed the exact lane in 42m32s. After PR #56323 registered sampler kernels across parallel workers, both attempts exceeded the 55-minute budget after 31 passing tests; the retry logged the same 78 warmups totaling 1188 seconds. Exact rollback coverage is pending."
       }
     }
   ]

--- a/test-selection/selection-leaks.json
+++ b/test-selection/selection-leaks.json
@@ -953,6 +953,62 @@
         "reference_url": "https://github.com/vllm-project/vllm/pull/56323",
         "notes": "The preceding main build needed 40m35s within a 45-minute budget; the culprit then added 712 seconds across 12 measured sampler warmups before this exact job was canceled."
       }
+    },
+    {
+      "id": "pr-56323-main-88593-cudagraph",
+      "job_name": "H200 MIG 35GB CUDAGraph",
+      "job_key": "cudagraph",
+      "culprit_pr": {
+        "number": 56323,
+        "url": "https://github.com/vllm-project/vllm/pull/56323",
+        "merge_commit": "aed894c190aa3db74c502d521b3bc3935ad85de1"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "not_selected",
+        "build_number": 88574,
+        "job_id": null,
+        "url": "https://buildkite.com/vllm/ci/builds/88574"
+      },
+      "main_failure": {
+        "build_number": 88593,
+        "job_id": "01a098cf-2623-49ef-b655-b628195bf1af",
+        "url": "https://buildkite.com/vllm/ci/builds/88593#01a098cf-2623-49ef-b655-b628195bf1af",
+        "signature": "the lane timed out after 13 sampler JIT warmups added 804 seconds while 28 tests passed"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56654",
+        "notes": "The preceding full main completed the exact lane in 22m17s; after PR #56323 registered about 120 sampler keys per engine, this job exceeded its 30-minute budget during the second test command. Merged PR #56654 reverts that registration."
+      }
+    },
+    {
+      "id": "pr-56323-main-88593-extract-hidden-states-integration",
+      "job_name": "L4 Extract Hidden States Integration",
+      "job_key": "extract-hidden-states-integration-2-gpus",
+      "culprit_pr": {
+        "number": 56323,
+        "url": "https://github.com/vllm-project/vllm/pull/56323",
+        "merge_commit": "aed894c190aa3db74c502d521b3bc3935ad85de1"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "not_selected",
+        "build_number": 88574,
+        "job_id": null,
+        "url": "https://buildkite.com/vllm/ci/builds/88574"
+      },
+      "main_failure": {
+        "build_number": 88593,
+        "job_id": "01a098cf-26d4-47b5-828d-79e2e45a8252",
+        "url": "https://buildkite.com/vllm/ci/builds/88593#01a098cf-26d4-47b5-828d-79e2e45a8252",
+        "signature": "the TP2 test hit its fixed 120-second process timeout during a 140-key sampler JIT warmup, and its only unchanged retry repeated exactly"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56654",
+        "notes": "The preceding full main completed the exact job in 2m10s. Both post-PR #56323 attempts failed after 122.34s while the two TP workers were still warming sampler kernels; merged PR #56654 removes that registration."
+      }
     }
   ]
 }

--- a/test-selection/selection-leaks.json
+++ b/test-selection/selection-leaks.json
@@ -673,6 +673,62 @@
         "reference_url": "https://github.com/vllm-project/vllm/pull/56423",
         "notes": "The FlashInfer post-release bump introduced module-scope CUDA initialization before the fork-based test; spawning isolated tests passed all three exact L4 shards in build #88281."
       }
+    },
+    {
+      "id": "pr-54416-main-88492-model-executor",
+      "job_name": "H200 MIG 35GB Model Executor",
+      "job_key": "model-executor",
+      "culprit_pr": {
+        "number": 54416,
+        "url": "https://github.com/vllm-project/vllm/pull/54416",
+        "merge_commit": "dca96bf97b350204937a72c4d386b79b425f3989"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 88369,
+        "job_id": "01a0914a-5c07-4f0e-a224-a79cf2de9d09",
+        "url": "https://buildkite.com/vllm/ci/builds/88369#01a0914a-5c07-4f0e-a224-a79cf2de9d09"
+      },
+      "main_failure": {
+        "build_number": 88492,
+        "job_id": "01a094a7-396e-4d7a-85b8-76af06ee9d44",
+        "url": "https://buildkite.com/vllm/ci/builds/88492#01a094a7-396e-4d7a-85b8-76af06ee9d44",
+        "signature": "Qwen3 Omni DSpark test mock lacked load_config after the draft-model loader contract changed"
+      },
+      "causal_confirmation": {
+        "kind": "fix",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56600",
+        "notes": "The fix supplies the missing LoadConfig and pipeline-group stubs; the focused Qwen3 Omni DSpark test passes."
+      }
+    },
+    {
+      "id": "pr-54416-main-88492-amd-model-executor",
+      "job_name": "MI300 Model Executor",
+      "job_key": "amd-model-executor",
+      "culprit_pr": {
+        "number": 54416,
+        "url": "https://github.com/vllm-project/vllm/pull/54416",
+        "merge_commit": "dca96bf97b350204937a72c4d386b79b425f3989"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "blocked",
+        "build_number": 88369,
+        "job_id": "01a0914a-5bb3-4346-a9a0-7c8d8138847c",
+        "url": "https://buildkite.com/vllm/ci/builds/88369#01a0914a-5bb3-4346-a9a0-7c8d8138847c"
+      },
+      "main_failure": {
+        "build_number": 88492,
+        "job_id": "01a094a7-3934-45db-bf7f-0d60008816d2",
+        "url": "https://buildkite.com/vllm/ci/builds/88492#01a094a7-3934-45db-bf7f-0d60008816d2",
+        "signature": "Qwen3 Omni DSpark test mock lacked load_config after the draft-model loader contract changed"
+      },
+      "causal_confirmation": {
+        "kind": "fix",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56600",
+        "notes": "The fix supplies the missing LoadConfig and pipeline-group stubs; the focused Qwen3 Omni DSpark test passes."
+      }
     }
   ]
 }

--- a/test-selection/selection-leaks.json
+++ b/test-selection/selection-leaks.json
@@ -729,6 +729,230 @@
         "reference_url": "https://github.com/vllm-project/vllm/pull/56600",
         "notes": "The fix supplies the missing LoadConfig and pipeline-group stubs; the focused Qwen3 Omni DSpark test passes."
       }
+    },
+    {
+      "id": "pr-56323-main-88580-spec-decode-draft-model",
+      "job_name": "H200 MIG 18GB Spec Decode Draft Model",
+      "job_key": "spec-decode-draft-model",
+      "culprit_pr": {
+        "number": 56323,
+        "url": "https://github.com/vllm-project/vllm/pull/56323",
+        "merge_commit": "aed894c190aa3db74c502d521b3bc3935ad85de1"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "not_selected",
+        "build_number": 88574,
+        "job_id": null,
+        "url": "https://buildkite.com/vllm/ci/builds/88574"
+      },
+      "main_failure": {
+        "build_number": 88580,
+        "job_id": "01a09827-e5f0-49f8-a44b-31af2433df26",
+        "url": "https://buildkite.com/vllm/ci/builds/88580#01a09827-e5f0-49f8-a44b-31af2433df26",
+        "signature": "the lane timed out after repeated sampler JIT warmups added 884 seconds across 15 engine starts"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56323",
+        "notes": "The culprit registered about 120 sampler compile keys on every accelerator engine; the exact job had no failed test and was externally canceled at its timeout after 15 measured warmups."
+      }
+    },
+    {
+      "id": "pr-56323-main-88580-e2e-core",
+      "job_name": "H200 MIG 35GB E2E Core",
+      "job_key": "e2e-core-1-gpu",
+      "culprit_pr": {
+        "number": 56323,
+        "url": "https://github.com/vllm-project/vllm/pull/56323",
+        "merge_commit": "aed894c190aa3db74c502d521b3bc3935ad85de1"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "not_selected",
+        "build_number": 88574,
+        "job_id": null,
+        "url": "https://buildkite.com/vllm/ci/builds/88574"
+      },
+      "main_failure": {
+        "build_number": 88580,
+        "job_id": "01a09827-e555-49aa-bd53-028b3d6d5252",
+        "url": "https://buildkite.com/vllm/ci/builds/88580#01a09827-e555-49aa-bd53-028b3d6d5252",
+        "signature": "the lane timed out while repeated sampler JIT warmups were compiling about 120 keys per engine"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56323",
+        "notes": "The culprit registered four native sampler warmups on every accelerator engine; this job spent 1011 seconds in 21 warmups before timeout, while its tests were still progressing without failures."
+      }
+    },
+    {
+      "id": "pr-56323-main-88580-multimodal-models-standard-4",
+      "job_name": "H200 MIG 35GB Multimodal Models (Standard) 4: other + whisper",
+      "job_key": "multi-modal-models-standard-4-other-whisper",
+      "culprit_pr": {
+        "number": 56323,
+        "url": "https://github.com/vllm-project/vllm/pull/56323",
+        "merge_commit": "aed894c190aa3db74c502d521b3bc3935ad85de1"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "not_selected",
+        "build_number": 88574,
+        "job_id": null,
+        "url": "https://buildkite.com/vllm/ci/builds/88574"
+      },
+      "main_failure": {
+        "build_number": 88580,
+        "job_id": "01a09827-e5e0-4891-a8ce-b08e7d4c8784",
+        "url": "https://buildkite.com/vllm/ci/builds/88580#01a09827-e5e0-4891-a8ce-b08e7d4c8784",
+        "signature": "the lane timed out after repeated sampler JIT warmups added 1415 seconds across 34 engine starts"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56323",
+        "notes": "The preceding main completed the exact lane in 46m19s; after the culprit registered about 120 sampler keys per engine, this build was canceled during the final Whisper tests while the follow-on main barely passed in 71m20s."
+      }
+    },
+    {
+      "id": "pr-56323-main-88580-spec-decode-speculators-mtp",
+      "job_name": "H200 MIG 35GB Spec Decode Speculators + MTP",
+      "job_key": "spec-decode-speculators-mtp",
+      "culprit_pr": {
+        "number": 56323,
+        "url": "https://github.com/vllm-project/vllm/pull/56323",
+        "merge_commit": "aed894c190aa3db74c502d521b3bc3935ad85de1"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "not_selected",
+        "build_number": 88574,
+        "job_id": null,
+        "url": "https://buildkite.com/vllm/ci/builds/88574"
+      },
+      "main_failure": {
+        "build_number": 88580,
+        "job_id": "01a09827-e5f2-4af5-8930-50d36e9fa00b",
+        "url": "https://buildkite.com/vllm/ci/builds/88580#01a09827-e5f2-4af5-8930-50d36e9fa00b",
+        "signature": "the lane timed out after repeated sampler JIT warmups added 1039 seconds across 14 engine starts"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56323",
+        "notes": "The culprit registered about 120 sampler compile keys on every accelerator engine; the exact job was canceled only after its final GSM8K evaluation had begun and was progressing normally."
+      }
+    },
+    {
+      "id": "pr-56323-main-88581-basic-models-tests-other",
+      "job_name": "H200 MIG 35GB Basic Models (Other)",
+      "job_key": "basic-models-tests-other",
+      "culprit_pr": {
+        "number": 56323,
+        "url": "https://github.com/vllm-project/vllm/pull/56323",
+        "merge_commit": "aed894c190aa3db74c502d521b3bc3935ad85de1"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "not_selected",
+        "build_number": 88574,
+        "job_id": null,
+        "url": "https://buildkite.com/vllm/ci/builds/88574"
+      },
+      "main_failure": {
+        "build_number": 88581,
+        "job_id": "01a09829-48b5-49aa-af83-3b25ae5d5669",
+        "url": "https://buildkite.com/vllm/ci/builds/88581#01a09829-48b5-49aa-af83-3b25ae5d5669",
+        "signature": "the lane timed out after sampler JIT warmup grew from under one second to 1185 seconds across 18 engine starts"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56323",
+        "notes": "The immediately preceding main build completed the exact lane in 23m45s with 18 warmups totaling under one second; after the culprit registered about 120 sampler keys per engine, two consecutive main builds timed out."
+      }
+    },
+    {
+      "id": "pr-56323-main-88581-language-models-hybrid-shard-2",
+      "job_name": "H200 MIG 35GB Language Models (Hybrid) Shard 2",
+      "job_key": "language-models-tests-hybrid",
+      "culprit_pr": {
+        "number": 56323,
+        "url": "https://github.com/vllm-project/vllm/pull/56323",
+        "merge_commit": "aed894c190aa3db74c502d521b3bc3935ad85de1"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "not_selected",
+        "build_number": 88574,
+        "job_id": null,
+        "url": "https://buildkite.com/vllm/ci/builds/88574"
+      },
+      "main_failure": {
+        "build_number": 88581,
+        "job_id": "01a09829-48bb-4f91-9cfe-ecba26fbaad6",
+        "url": "https://buildkite.com/vllm/ci/builds/88581#01a09829-48bb-4f91-9cfe-ecba26fbaad6",
+        "signature": "the lane timed out after repeated sampler JIT warmups added 1274 seconds across 22 engine starts"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56323",
+        "notes": "The preceding main build completed this exact shard in 48m15s; after the culprit registered about 120 sampler keys per engine, two consecutive main builds timed out while tests were still progressing without failures."
+      }
+    },
+    {
+      "id": "pr-56323-main-88581-model-executor",
+      "job_name": "H200 MIG 35GB Model Executor",
+      "job_key": "model-executor",
+      "culprit_pr": {
+        "number": 56323,
+        "url": "https://github.com/vllm-project/vllm/pull/56323",
+        "merge_commit": "aed894c190aa3db74c502d521b3bc3935ad85de1"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "not_selected",
+        "build_number": 88574,
+        "job_id": null,
+        "url": "https://buildkite.com/vllm/ci/builds/88574"
+      },
+      "main_failure": {
+        "build_number": 88581,
+        "job_id": "01a09829-48b0-49d2-887b-6912048aee7e",
+        "url": "https://buildkite.com/vllm/ci/builds/88581#01a09829-48b0-49d2-887b-6912048aee7e",
+        "signature": "the lane timed out after repeated sampler JIT warmups added 818 seconds across 31 engine starts"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56323",
+        "notes": "The preceding selected main completed the exact lane in 41m05s; after the culprit registered four native sampler warmups per engine, two consecutive main builds timed out while another engine was compiling without a failed test."
+      }
+    },
+    {
+      "id": "pr-56323-main-88581-v1-kv-connectors",
+      "job_name": "H200 MIG 35GB V1 KV Connectors",
+      "job_key": "v1-kv-connectors",
+      "culprit_pr": {
+        "number": 56323,
+        "url": "https://github.com/vllm-project/vllm/pull/56323",
+        "merge_commit": "aed894c190aa3db74c502d521b3bc3935ad85de1"
+      },
+      "pr_ci": {
+        "ran": false,
+        "state": "not_selected",
+        "build_number": 88574,
+        "job_id": null,
+        "url": "https://buildkite.com/vllm/ci/builds/88574"
+      },
+      "main_failure": {
+        "build_number": 88581,
+        "job_id": "01a09829-48ae-4a6d-8948-5d01a444b1d8",
+        "url": "https://buildkite.com/vllm/ci/builds/88581#01a09829-48ae-4a6d-8948-5d01a444b1d8",
+        "signature": "the lane timed out while its twelfth repeated sampler JIT warmup was still compiling"
+      },
+      "causal_confirmation": {
+        "kind": "code_analysis",
+        "reference_url": "https://github.com/vllm-project/vllm/pull/56323",
+        "notes": "The preceding main build needed 40m35s within a 45-minute budget; the culprit then added 712 seconds across 12 measured sampler warmups before this exact job was canceled."
+      }
     }
   ]
 }

--- a/test-selection/selection-leaks.json
+++ b/test-selection/selection-leaks.json
@@ -1058,12 +1058,12 @@
         "build_number": 88593,
         "job_id": "01a098cf-26d3-4fbd-9701-7b2da1e36bcf",
         "url": "https://buildkite.com/vllm/ci/builds/88593#01a098cf-26d3-4fbd-9701-7b2da1e36bcf",
-        "signature": "the lane timed out after 16 sampler JIT warmups added 1083 seconds while 15 of 17 example commands completed"
+        "signature": "the lane timed out after 16 sampler JIT warmups added 1083 seconds while 15 of 17 example commands completed, and its only unchanged retry repeated"
       },
       "causal_confirmation": {
         "kind": "code_analysis",
         "reference_url": "https://github.com/vllm-project/vllm/pull/56323",
-        "notes": "The preceding full main completed the exact lane in 27m17s. After PR #56323 registered about 120 sampler keys per engine, the job exceeded its 40-minute budget without a failed command; exact rollback coverage is pending."
+        "notes": "The preceding full main completed the exact lane in 27m17s. After PR #56323 registered about 120 sampler keys per engine, both attempts exceeded the 40-minute budget without a failed command; the retry logged 16 warmups totaling 1068 seconds. Exact rollback coverage is pending."
       }
     },
     {


### PR DESCRIPTION
## Summary

Add twenty-three confirmed exact-job selection-leak records from seven vLLM incidents.

PR #54416 / main #88492:

- H200 MIG 35GB Model Executor
- MI300 Model Executor

PR #56323 / main #88580-#88581, #88589, #88593, and nightly #88612:

- H200 MIG 35GB E2E Core
- H200 MIG 18GB Spec Decode Draft Model
- H200 MIG 35GB Spec Decode Speculators + MTP
- H200 MIG 35GB Basic Models (Other)
- H200 MIG 35GB Language Models (Hybrid) Shard 2
- H200 MIG 35GB Model Executor
- H200 MIG 35GB Multimodal Models (Standard) 4
- H200 MIG 35GB V1 KV Connectors
- H200 MIG 18GB Basic Correctness
- H200 MIG 18GB V1 Sample
- H200 MIG 35GB CUDAGraph
- H200 MIG 35GB Examples
- L4 Extract Hidden States Integration
- L4 Pipeline + Context Parallelism
- Arm CPU Test Shard 2
- Arm CPU Test Shard 3

For #56323, PR Buildkite #88574 did not select any of these exact jobs. Fourteen accelerator jobs accumulated repeated cold sampler warmups and hit either their job budget or the Extract Hidden States test's fixed process timeout. The only unchanged retries for CUDAGraph, Examples, Extract Hidden States, Model Executor, and Pipeline + Context Parallelism all repeated. Merged vLLM PR #56654 reverts that sampler registration; its full PR build #88588 passed the directly affected H200 lanes it selected under their original budgets. Exact post-revert coverage remains pending for CUDAGraph, Examples, Extract Hidden States, and Pipeline + Context Parallelism because they were not selected in #88588 or post-revert main #88599. The same culprit also added a module-level spec-decode warmup decorator that makes both Arm CPU serving shards dereference `triton.runtime` on the runtime-less placeholder; nightly #88612 exposed both deterministic failures after the partial rollback, and draft vLLM PR #56676 supplies the missing guard.

PR #56157 / main nightly #88612:

- B200 LM Eval PCP

PR Buildkite #88566 left the exact optional lane blocked. The PR both added a GLM-5.2 PCP4+DCP4 config without choosing a DCP communication backend and added runtime validation requiring `ag_rs`; the first post-merge exact run rejected all four workers because the config defaulted to `a2a`. Draft vLLM PR #56677 adds the missing one-line argument.

PR #56305 / main #88651:

- H200 MIG 35GB Model Executor

PR Buildkite #88637 and immediate post-main #88647 both left the exact lane blocked. PR #56305 added an unconditional `model_config.rswa_window` read in the attention selector; the next selected main run failed all 12 applicable FSE model-construction cases because their minimal `SimpleNamespace` fixture lacked that field. Draft vLLM PR #56710 adds the non-R-SWA default to the fixture contract.

PR #51700 / main nightly #88743:

- H200 MIG 35GB CUDAGraph

PR Buildkite #88703 left the exact H200 CUDAGraph job blocked. PR #51700 added the `CudaGraphManager.ubatch_runner` constructor dependency and made `capture()` read it, but the existing breakable-cudagraph unit test bypasses `__init__` and did not initialize the new attribute. The next nightly exact job failed deterministically with `AttributeError`; draft vLLM PR #56808 initializes the test double to the non-DBO default.

PR #55176 / main #88790:

- L4 Scale-out EC Connector E2E

PR Buildkite #88768 selected only thirteen setup and multimodal jobs; the exact L4 Scale-out EC lane was absent. PR #55176 removed `VLLM_ENABLE_SCALE_OUT_ENDPOINTS` in favor of `vllm serve --enable-scale-out`, but did not migrate the exact E2E launcher. Main #88790 and its automatic retry both started healthy encode and prefill servers without `/inference/v1/generate`, then failed the first encode request with HTTP 404. Draft vLLM PR #56819 passes the new CLI flag to both affected serve processes and changes a direct source dependency so the exact job is selected for validation.

PR #51167 / daily main #88920:

- H200 MIG 35GB Multimodal Models (Extended Generation 1)

PR Buildkite #88857 and post-merge main #88899 both left the exact optional lane blocked. PR #51167 added full-graph `FULL_DECODE_ONLY` support and its Voxtral test, but daily #88920 was the first exact run and Dynamo failed on `ContextVar.get()` inside the GPU sync debug `Tensor.to` wrapper. Later failures in the same process were leaked-engine-memory fallout. Draft vLLM PR #56904 checks compile state before touching either `ContextVar` and adds a full-graph regression test; exact H200 validation is running in Buildkite #88941.

## Scope decisions

- PR #53566 is not recorded: B200 Miscellaneous Kernels ran and passed in its PR build, so its missed inner test case is not an exact-job selection leak under this corpus contract.
- PR #56554 is not recorded: it had no Buildkite PR build, so there is no exact PR-job selection record that fits the current evidence schema.
- H200 Entrypoints Unit from main #88593 is held out pending post-revert evidence: both attempts timed out after six passing launcher tests, but each log contains only five negligible JIT warmups totaling about 0.77 seconds, so the #56323 causal link is not yet established.

## Validation

- `test-selection/validate_selection_leaks.py` — passed, 47 records
- `pre-commit run --files test-selection/selection-leaks.json` — passed
- `git diff --check` — passed

## AI assistance

OpenAI Codex assisted with the evidence audit and preparing this dataset update. Human review is required before this draft is marked ready.