### PR TITLE
tpu-inference/k8s: give a cold image pull longer than thirty seconds

### DIFF
--- a/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/charts/agent-stack-k8s.yaml
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/generated/manager/charts/agent-stack-k8s.yaml
@@ -27,6 +27,17 @@ config:
   # cluster's and not the organization's.
   queue: kube
 
+  # How long a container may sit unable to start before the controller gives
+  # up on the step. The chart's thirty seconds assumes a warm node and a small
+  # image; a fleet node is often brand new, and the pull is a CI image built
+  # per commit, so nothing about it is cached anywhere. Steps were failing with
+  # exit -1, no agent and an empty log - the controller had failed them before
+  # a pod ever ran, which reads as a Buildkite fault rather than a slow pull.
+  #
+  # Five minutes, not longer: this is also what catches an image that does not
+  # exist, and that should not cost a step its whole timeout.
+  image-pull-backoff-grace-period: 5m
+
   # The git SSH key, on every agent pod's checkout container. Controller-wide
   # rather than per-pipeline `gitEnvFrom`, because which repositories are
   # private is not something a pipeline should have to know: a public one

--- a/terraform/gcp_old/tpu-inference/k8s/kueue/templates/agent_stack_values.yaml.tpl
+++ b/terraform/gcp_old/tpu-inference/k8s/kueue/templates/agent_stack_values.yaml.tpl
@@ -22,6 +22,17 @@ config:
   # cluster's and not the organization's.
   queue: ${BUILDKITE_QUEUE}
 
+  # How long a container may sit unable to start before the controller gives
+  # up on the step. The chart's thirty seconds assumes a warm node and a small
+  # image; a fleet node is often brand new, and the pull is a CI image built
+  # per commit, so nothing about it is cached anywhere. Steps were failing with
+  # exit -1, no agent and an empty log - the controller had failed them before
+  # a pod ever ran, which reads as a Buildkite fault rather than a slow pull.
+  #
+  # Five minutes, not longer: this is also what catches an image that does not
+  # exist, and that should not cost a step its whole timeout.
+  image-pull-backoff-grace-period: 5m
+
   # The git SSH key, on every agent pod's checkout container. Controller-wide
   # rather than per-pipeline `gitEnvFrom`, because which repositories are
   # private is not something a pipeline should have to know: a public one


### PR DESCRIPTION
Raises the agent-stack-k8s controller's `image-pull-backoff-grace-period` from
the chart default of 30s to 5m, in both the template and its generated output.

The default assumes a warm node and a small image. A fleet node is usually
brand new and the image is a CI build from the commit under test, so the pull
is always cold. Steps were failing with exit -1, no agent and an empty log:
the controller had given up before a pod ever ran, which presents as a
Buildkite fault rather than a slow pull.

Already applied and deployed to the manager cluster.
