### PR TITLE
Add vLLM release notes skill

### DIFF
--- a/claude-skills/AUTOMATIONS.md
+++ b/claude-skills/AUTOMATIONS.md
@@ -148,6 +148,9 @@ These files guide an agent but do not install timers or send scheduled alerts:
 - [`vllm-main-ci-triage/`](vllm-main-ci-triage/): diagnose hard main-CI
   failures, prepare narrow fixes, audit exact pull-request job coverage, and
   record confirmed test-selection leaks.
+- [`vllm-release-notes/`](vllm-release-notes/): write the GitHub release
+  body and Slack announcement for a new vLLM release from the commit range
+  between two tags, with finished examples for every release since v0.22.0.
 
 ## Validate changes
 

--- a/claude-skills/vllm-release-notes/SKILL.md
+++ b/claude-skills/vllm-release-notes/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: vllm-release-notes
+description: Write the GitHub release notes and the Slack announcement for a new vLLM release. Use when the user asks to "make release notes for vX.Y.Z", "draft the vX.Y.Z release", or wants the Slack promotion message and install instructions for a release.
+---
+
+# vLLM Release Notes
+
+Turn the commit range between two vLLM tags into the GitHub release body
+(`3-highlights-note-edit.md`) and the Slack announcement
+(`4-slack-announcement.md`). Finished examples for every release since v0.22.0
+live in [examples/](examples/); read the newest one first for structure and
+tone, and use [ref-past-release-notes-highlight.md](ref-past-release-notes-highlight.md)
+for the older style and category reference.
+
+## Prerequisites
+
+- GitHub CLI (`gh`) authenticated as a person with read access to
+  `vllm-project/vllm`. Run `unset GITHUB_TOKEN` first if a bot token is exported
+  in the shell so `gh` uses the personal login.
+- `uv` (the fetch script declares its own dependencies).
+- Both tags pushed to `vllm-project/vllm`. Use the previous final release as the
+  base tag, not a release candidate.
+
+## Workspace layout
+
+Work in a scratch directory (the maintainer uses a private `release-notes`
+folder). Every release produces these files; archive them under `v<ver>/` when
+the release is published so the next release starts clean:
+
+| File | Purpose |
+| --- | --- |
+| `0-current-raw-commits.md` | Raw commit titles with PR numbers, one per line |
+| `0-contributor-stats.md` | Commit and contributor counts, top and new contributors |
+| `1-commit-analysis-draft.csv` | Per-commit classification: `title`, `pr number`, `user facing impact/summary`, `category`, `decision`, `reason` |
+| `2-highlights-note-draft.md` | First full draft |
+| `3-highlights-note-edit.md` | Final release body pasted into the GitHub release |
+| `4-slack-announcement.md` | Slack main message and thread replies |
+| `tmp/` | Helper scripts and fetched PR descriptions |
+
+## Steps
+
+1. **Fetch the commits and contributor stats.**
+
+   ```bash
+   uv run fetch_commits.py --base-tag v0.28.0 --head-tag v0.29.0 --output 0-current-raw-commits.md --stats
+   ```
+
+   The script reads `GITHUB_TOKEN` or `GH_TOKEN`; pass
+   `GITHUB_TOKEN=$(gh auth token)` when neither is set. It writes both `0-*`
+   files and prints the summary line.
+
+2. **Read every commit title**, then fetch PR descriptions for anything that
+   might reach the notes (new models, defaults, perf claims, breaking changes,
+   security fixes). `gh api repos/vllm-project/vllm/pulls/<N> --jq .body` is
+   enough; a loop over 300 to 400 PRs takes a few minutes. Take performance
+   numbers only from PR descriptions, never from titles alone.
+
+3. **Classify every commit** into `1-commit-analysis-draft.csv`. A rule-based
+   first pass (title regexes for CI, docs, reverts, refactors, hardware
+   vendors, spec decode, quantization, and so on) followed by hand-curated
+   overrides works well; keep the overrides in `tmp/` so the CSV can be
+   regenerated. Drop merged-then-reverted pairs entirely. Ignore CI, docs,
+   tests, mypy, refactors, and benchmark-script-only changes unless they change
+   user-visible behavior.
+
+4. **Draft `2-highlights-note-draft.md`** with these sections, in this order:
+   `## Highlights`, `## Release Artifacts`, `## Model Support`,
+   `## Engine Core`, `## Hardware & Performance`, `## Large Scale Serving`,
+   `## Quantization`, `## API & Frontend`, `## Security`, `## Dependencies`,
+   `## Breaking Changes & Deprecations`, `## New Contributors`,
+   `## Contributors`. Each section is a bulleted list; each bullet opens with a
+   bold topic and cites PR numbers as `(#NNNNN)`. Highlights get 6 to 9 bullets:
+   the biggest themes, new models, new defaults, and breaking changes.
+
+5. **Edit into `3-highlights-note-edit.md`.** Re-check every claim against the
+   PR descriptions and the CSV, then verify that every cited PR number appears
+   in `0-current-raw-commits.md`. Do not leave open questions or uncertainties
+   in the file; resolve them or drop the item.
+
+6. **Summary line.** The first line under Highlights is
+   `This release features X commits from Y contributors (Z new)!`, using the
+   numbers from `0-contributor-stats.md`.
+
+7. **Contributors.** Append `## New Contributors` (one line per person:
+   `* @user made their first contribution in https://github.com/vllm-project/vllm/pull/N`)
+   when there are any, then `## Contributors` as a single line of `@handle`
+   mentions separated by `, ` covering everyone in the "All Contributors" table.
+
+8. **Release Artifacts section**, placed right after Highlights. Copy it from
+   the previous release's example and bump every version string. Three
+   subsections:
+   - `### Python Wheels` table (Platform | Install): PyPI `pip install vllm`,
+     uv `uv pip install vllm --torch-backend=auto`, ROCm
+     `pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/<ver>/<rocmNNN>`,
+     XPU `uv pip install vllm --extra-index-url https://wheels.vllm.ai/<ver>/xpu --extra-index-url https://download.pytorch.org/whl/xpu --index-strategy unsafe-best-match`.
+   - `### Docker Images` table (Platform | Docker Image): `vllm/vllm-openai:v<ver>`
+     (default CUDA 13.0, `-cu130` alias), `-cu129`, `-ubuntu2404`,
+     `-cu129-ubuntu2404`, `vllm/vllm-openai-rocm`, `vllm/vllm-openai-cpu`,
+     `vllm/vllm-openai-xpu`.
+   - `### Other Artifacts`: pointer to the release Assets (sdist, CUDA 12.9 and
+     13.0 wheels for x86_64 and arm64, CPU wheels for x86_64, arm64 and macOS,
+     XPU wheel).
+
+   Verify every URL and tag; they change per release:
+   - ROCm subdir: list `https://wheels.vllm.ai/rocm/<ver>/` (v0.28.0 was
+     `rocm722`, v0.29.0 was `rocm723`).
+   - XPU index: `https://wheels.vllm.ai/<ver>/` should list `xpu/`.
+   - Docker tags: `https://hub.docker.com/v2/repositories/vllm/<repo>/tags?name=v<ver>`.
+   - Assets: `gh api repos/vllm-project/vllm/releases/tags/v<ver> --jq '.assets[].name'`.
+
+9. **No tildes.** GitHub renders paired `~` as strikethrough. Write "about 5%"
+   and "6.6-7.6x", never "~5%" or "6.6~7.6x". Run `grep -n '~' 3-highlights-note-edit.md`
+   and fix every hit before finishing.
+
+10. **Slack announcement** in `4-slack-announcement.md`, and paste both messages
+    into the final reply to the user.
+    - Main message, exact template (3 to 5 highlights):
+
+      ```
+      Hi all,
+      We just finished vLLM v<ver> release today. :rocket: This release features <X> commits from <Y> contributors. We also welcomed <Z> new contributors to vLLM!
+      A few highlights of this release: <highlight 1>, <highlight 2>, <highlight 3>, and more!
+      More details and install instructions in :thread:
+
+      Thank you everyone for your contributions to the new version of :vllm: :pray:
+      ```
+
+    - Thread reply with install instructions: Python wheels (PyPI `pip`,
+      "(Preferred)" uv `--torch-backend=auto`, ROCm index, XPU index), Docker
+      images (say that `latest` also works in place of the version tag; list
+      default, cu129, ubuntu2404, cu129-ubuntu2404, rocm, cpu, xpu), and the
+      GitHub release URL followed by the asset types. Use exactly the URLs and
+      tags verified in step 8. Use literal bullet glyphs so Slack shows dots:
+      `•` at level 1, `◦` at level 2 with a 4-space indent, `▪` at level 3 with
+      an 8-space indent. Slack counts indentation in units of 4 spaces when
+      parsing a paste, so 3-space indents flatten the list.
+    - Optionally a short thread reply listing notable breaking changes.
+
+See [examples/v0.29.0/](examples/v0.29.0/) for a complete release body and
+Slack announcement produced with these steps.
+
+## Judgment
+
+The goal is to miss no important change without listing every commit. Perf
+claims need a number and a source PR. New defaults and anything that changes
+behavior for existing deployments go in both Highlights and Breaking Changes.
+When a feature landed and was reverted inside the range, it did not ship; leave
+it out.

--- a/claude-skills/vllm-release-notes/examples/v0.22.0/release-notes.md
+++ b/claude-skills/vllm-release-notes/examples/v0.22.0/release-notes.md
@@ -1,0 +1,145 @@
+## Highlights
+
+This release features 459 commits from 230 contributors (63 new)!
+
+* **DeepSeek V4 maturity**: DeepSeek V4 received a major hardening pass this cycle — the model was reorganized into a dedicated `vllm/models/deepseek_v4/` package (#43004, #43039, #43073, #43077, #43149), gained NVFP4 fused MoE support (#42209), full + piecewise CUDA graph (#42604), and MTP speculative decoding (#43385). A large set of fused kernels (MegaMoE, `mhc`, Q-norm, indexer, sparse MLA) and ROCm parity fixes landed alongside accuracy fixes (#42810, #43710).
+* **Model Runner V2 advances toward default**: MRv2 added an oracle that selects MRv2 for Qwen3 dense models by default (#39337), sleep-mode weight reload (#42673), `update_config` (#42783), and shared KV-cache layers (#35045), plus many correctness fixes. It now falls back to MRv1 automatically when a KV connector is present (#42955).
+* **Experimental Rust frontend**: A new Rust front-end integration landed (#40848), with the implementation moved into the tree (#43283) and a DP Supervisor for data-parallel serving (#40841).
+* **Batch invariance, faster**: Batch-invariant inference gained Cutlass FP8 support for a **28.9% end-to-end latency improvement** (#40408), compile-mode support on SM80 (#42456), and an NVFP4 Cutlass linear path (#39912).
+* **Multi-tier KV cache offloading**: A new multi-tier KV cache offloading framework (#40020) with a Python filesystem secondary tier (#41735), DSv4 support (#43142), and Mooncake disk offloading (#42689) extends offloading beyond CPU memory.
+
+### Model Support
+* New architectures: MiniCPM-V 4.6 (#41254), InternS2 Preview (#42705), OpenVLA (#42654), MolmoWeb `hf_overrides` docs (#42163); EXAONE-4.5 aligned with Transformers update (#42246).
+* Speculative decoding: custom callable proposer backend (#39487), post-norm EAGLE-3 speculators (#42764), peagle speculators (#41826), hybrid-attention models in `extract_hidden_states` (#39949), non-MTP speculation for NemotronH (#43130), shared MTP weights in MRv2 (#42538).
+* DeepSeek V4: NVFP4 MoE (#42209), CUDA graph full/piecewise (#42604), MTP (#43385), model package refactor (#43004, #43039, #43073, #43077), sparse MLA + compressor refactor (#43149, #43710), MegaMoE input-prep kernel move (#43632).
+* Qwen3.5/3.6: GDN output-projection flatten (#42311), GatedDeltaNet Marlin TP≥2 fix (#36329), ViT full CUDA graph (#42151), runai-streamer weight loading for Qwen3.5/MTP/Qwen3-VL (#42521, #42716), KDA chunk-prefill exp2 semantics (#43195).
+* Gemma3/Gemma4: mixed-resolution image co-batching crash fix (#42217), MoE routing closure fix (#42250), tool-parser float-corruption fix (#42128), batched vision encoder for image/video (#43169), multi-GPU fix (#42630).
+* Kimi-K2.5: skip vision-tower dtype conversion under quantization (#42869), `mm_projector` dtype fix (#42081).
+* Cohere: enable Cohere MoE (#43143), pipeline parallelism for Cohere vision (#42819).
+* Tool calling: Apertus tool parser (#41154), Qwen3Coder `anyOf`/`oneOf`/`$ref` resolution re-land (#37831), shared `coerce_to_schema_type` across MiniMax-M2 / DeepSeek-V3.2 / Seed-OSS parsers (#43006, #43019, #43140).
+* ViT CUDA graph: Qwen2-VL (#41736), Step3-VL encoder (#42224), Qwen3.5 (#42151), FlashInfer metadata for Qwen2.5-VL vision attention (#42787).
+
+### Engine Core
+* Model Runner V2: Qwen3-dense-by-default oracle (#39337), sleep-mode reload weights (#42673), `update_config` (#42783), shared KV-cache layers (#35045), FP32 gumbel sampling (#41775), auto-fallback to MRv1 with connectors (#42955), `logprob_token_ids` correctness (#43125, #41761), prompt-logprobs size fix (#42778).
+* KV offloading: multi-tier framework (#40020), Python filesystem secondary tier (#41735), DSv4 support (#43142), tier-offload follow-up (#42529), prefer HND layout (#41928), `reset_cache()` (#41956), per-request tracking (#42507), store-deferral fix (#41945).
+* MoE refactor: `ExpertMapManager` (#41046), experts moved to `experts/` (#42334), `RoutedExperts` alias for FusedMoE (#40735), EPLB refactoring for FusedMoE (#41055).
+* Mamba: attention module refactor (#41126), Mamba2 SSD kernel warmup (#39822), bf16 SSM cache (#41680), GPU-side state postprocessing fused kernel (#40172), run single-token extends as decodes (#42430).
+* KV events: emit KV cache metadata (#40984).
+* Allocator: manual cumem allocator enable (#33648), stream-aware free callback (#43020).
+* elastic-EP: stage/commit MoE quant method on reconfigure (#40881).
+
+### Hardware & Performance
+* **NVIDIA Blackwell / SM12x**: FlashInfer b12x MoE + FP4 GEMM for SM120/121 (#40082), per-tensor FP8 CUTLASS on SM12.1 (#41215), `head_dim=512` for FlashInfer TRTLLM attention (#38822), FlashInfer Blackwell GDN prefill (#40717), GDN prefill kernel for SM100 (#43273).
+* **Performance**: batch-invariant Cutlass FP8 (+28.9% E2E) (#40408), CutlassFP8 padding pre-processing (+13.5% TTFT) (#42651), padded NVFP4 quant kernel (+2.4–5.7% E2E) (#42774), GPU<->CPU sync elimination 1/n (#41429) and 4/n (#42347), fused RoPE+KVCache+q_concat for MLA (#40392), MLA `compute_prefill_context` / `_v_up_proj` optimizations (#42460, #42561), penalties Triton kernel (#40657), `do_not_specialize` in fused FP8 RoPE (#42849), FULL CUDA graph capture for TRITON_MLA decode (#42885).
+* **AMD ROCm**: DSV4 functionality + accuracy fixes (#42810, #43679 Tilelang MHC), flash sparse MLA Triton kernels (#41812), gluon paged MQA logits on gfx950/MI355X (#42062), RMSNorm+Quant fusion for gfx950 (#41825), AITER FA backend cleanup (#41942), XGMI backend for MoRI connector (#41753), QuickReduce min-size override (#41675), DSV4 MTP (#43385).
+* **CPU / RISC-V**: RVV-optimized attention kernels for RISC-V Vector Extension (#40119) with VLEN=256 (#42943), fused GDN for AMX CPU (#42707), MXFP4 W4A16 MoE (#41922), experimental Triton + MRv2 on CPU (#43225), improved CPU thread utilization (#42666), `--cpu-distributed-timeout-seconds` (#42968).
+* **Intel XPU**: GPTQ int4 support (#37844), mxfp8 MoE (#41918), FP8 block-scaled quantization (#42952), custom-op collective behavior (#41354), multiple sparse-attention kernels (#37888), MoE topk routing + MXFP4 fallback (#42951), CT W4A4 MXFP4 path (#38896), reduced XPU MoE host overhead (#42915).
+* **Kernel ABI**: continued migration to libtorch stable ABI — 5/n (#42339), 6/n (#42663), 7/n (#43209).
+* **Experimental**: breakable CUDA graph (#42304).
+
+### Large Scale Serving
+* Disaggregated serving (NIXL): lease-renewal TTL for KV blocks on P (#41383), handshake-failure policy honoring (#40364), GDN support for PD with NIXL (#41869), multi-node TP>8 fix (#39907), side-channel host-selection fix (#41806).
+* Mooncake: disk offloading in MooncakeStoreConnector (#42689), HMA support for DSV4 (#42828), operation metrics (#43392), load-failure propagation (#42788), block-aligned full hits (#43494), finish-after-preemption handling (#43281).
+* Data parallel: DP Supervisor (#40841), publish request counts at engine-step start (#41626), forward `X-data-parallel-rank` header (#42330).
+* EPLB: change default EPLB communicator (#43110), VLM-wrapper init fix (#39805), remove dead `torch.accelerator.synchronize()` (#40733).
+* LoRA: one-shot Triton kernel for MoE LoRA (#42290), simultaneous 2D & 3D MoE LoRA adapters (#42242), reduced 2D-weight memory under EP (#42737), MoE LoRA align-kernel grid fix (#40131).
+
+### Quantization
+* **MXFP4**: linear layers + compressed-tensors integration (#41664), CPU W4A16 MoE (#41922), XPU mxfp8 MoE (#41918).
+* **NVFP4**: DeepSeek V4 fused MoE (#42209), ModelOpt W4A16 NVFP4 fused MoE + mixed-precision dispatch (#42566), batch-invariant NVFP4 Cutlass linear (#39912), FlashInfer TRTLLM NvFP4 monolithic MoE routing fix (#43223), TRTLLM NVFP4 MoE chunking fix (#43599).
+* **Quark**: load Quark NVFP4 checkpoints (#35859), W8A8 INT8 garbage-output fix on Step-3.5-Flash (#41892), W4A4 oracle refactor (#41436).
+* **AutoRound**: W4A16 support (#39778).
+* **ModelOpt**: Qwen3.5/3.6 VLM quantized prefix mapping (#42546).
+* **Framework**: rework `quantization_config` to use `QuantKey` with activation override (#41566), MoE W4A8 CT migrated to oracle (#42680), AWQ Marlin MoE onto modular WNA16 oracle (#42483), GPTQ consolidation (`gptq_marlin` → `auto_gptq`) (#38288).
+
+### API & Frontend
+* **Rust frontend**: integration (#40848), in-tree code move (#43283), utility call-ID newtype (#43405), simplified `AuthenticationMiddleware` path extraction (#43426).
+* **Responses API**: `chat_template_kwargs` support (#42272), message-merging fix (#42189), empty channel/recipient harmony fix (#35540).
+* **Completions**: `thinking_token_budget` support (#42116) with inverted-condition fix (#41674); map `reasoning_effort` to `enable_thinking` (#43401).
+* **Frontend**: truncation side for OpenAI endpoints (#43260), normalize `reasoning_content` → `reasoning` (#42664), reworked fastokens integration (#43168), consolidated Speech-to-Text entrypoints (#42370, #42274), beam-search consolidation via `BeamSearchMixin` (#42946), score/rerank chat-template instructions (#42412).
+* **Auth**: API-key authorization for `/v2` endpoints (#42594).
+* **Offline API**: pooling offline API split into `PoolingOfflineMixin` (#42267), split offline inference APIs/utils (#43553).
+
+### Build & Dependencies
+* CUDA 12.9 wheel builds switched to PyTorch `manylinux_2_28` base (#41668).
+* FlashInfer bumped to v0.6.11.post2 (#41711); `nvidia-cutlass-dsl` to 4.5.2 (#42991, #43230, #43745); llguidance to 1.7 (#42150); `triton_kernels` downgraded to v3.5.1 for gpt-oss (#43135).
+* Rust frontend build: `setuptools-rust` dependency (#43287, #43377), pinned `protoc` in rust-build stages (#43292).
+* Docker: non-root `vllm-openai` target (#40275), build `mooncake-transfer-engine` from source (#42114), AINIC & Thor NIC support (#40453); Python-only installation made optional (#42293).
+* vllm-tpu: disable build isolation for CUDA deps (#43038), tpu-inference docker build fix (#43360).
+* `humming` MoE backend dependency added, reverted, then restored with CuPy runtime fix (#42540, #43492, #43530).
+
+### Deprecations & Removals
+* Removed old locations of `get_tokenizer` and `resolve_hf_chat_template` (#35024).
+* Marked env vars now covered by `--moe-backend` / `--linear-backend` (#43148).
+* Removed deprecated MLA prefill arguments (#42555).
+* Removed dead CUDA kernels and dead code (#42767, #42889, #43144).
+
+## Contributors
+
+@yewentao256, @haosdent, @njhill, @mgoin, @jeejeelee, @AndreasKaratzas, @NickLucche, @sfeng33, @noooop, @WoosukKwon, @khluu, @taneem-ibrahim, @Dao007forever, @vadiklyutiy, @bnellnm, @ivanium, @tjtanaa, @mmangkad, @hmellor, @DarkLight1337, @hickeyma, @zhenwei-intel, @jikunshang, @ronensc, @benchislett, @hao-aaron, @arpera, @zyongye, @gau-nernst, @frida-andersson, @ZhanqiuHu, @cleonard530, @akii96, @bedeks, @Isotr0py, @JasonKeyiL, @bigPYJ1151, @zhewenl, @weizhoublue, @zxd1997066, @gnovack, @chaojun-zhang, @majian4work, @chaunceyjiang, @pschlan-amd, @amitz-nv, @yma11, @dsikka, @tc-mb, @shanjiaz, @jperezdealgaba, @yzong-rh, @viktorpusTT, @TheEpicDolphin, @MatthewBonanni, @shen-shanshan, @hallerite, @zufangzhu, @bbrowning, @divakar-amd, @ianliuy, @esmeetu, @rasmith, @louie-tsai, @pmaybank, @liulanze, @ZJY0516, @TheDuyIT, @wzhao18, @jinzhen-lin, @BugenZhao, @ashwing, @fuergaosi233, @hqhq1025, @shaharmor98, @pisceskkk, @lkm2835, @noa-neria, @Rohan138, @whx-sjtu, @vrdn-23, @alexagriffith, @Flink-ddd, @jeffreywang-anyscale, @skyloevil, @ymoslem, @Lucaskabela, @kg6-sleipnir, @woernfl, @tdoublep, @GOavi101, @jmamou, @PeaBrane, @KaivalyaMDabhadkar, @BWAAEEEK, @MrZ20, @afierka-intel, @JoursBleu, @hissu-hyvarinen, @mwawrzos, @CynicDora, @NoeliaBentancor, @johncalesp, @fynnsu, @fxmarty-amd, @walterbm, @liangel-02, @lgeiger, @he-yufeng, @abinggo, @KrxGu, @hks-9697-v2, @Sarah-Salah, @rebklee, @aoshen02, @haic0, @libinta, @Zhenzhong1, @xhx1022, @b-mu, @WindChimeRan, @tpopp, @charlifu, @chengyinie, @ricky-chaoju, @lyd1992, @daniel-devlab, @paulyu12, @bobofang11235, @laudney, @BadrBasowid, @maeehart, @PatchouliTIS, @chunxiaozheng, @blake-snc, @southfreebird, @rbrugaro-amd, @rasdani, @dusthunter, @qizzzh, @ProExpertProg, @qianlihuang, @alec-flowers, @JisoLya, @gaozihao-shy, @rishaps, @xyang16, @wendyliu235, @hlin99, @tianmu-li, @yuwenzho, @inisis, @kfirtoledo, @roikoren755, @liranschour, @vllm-agent, @blancsw, @netanel-haber, @BowenBao, @czhu-cohere, @amitport, @tuukkjs, @revit13, @ofirzaf, @qyYue1389, @junyanxu, @gracie-guo, @sagearc, @xinyu-intel, @yiwen101, @DomBrown, @tomeras91, @Dogacel, @maxdebayser, @fadara01, @Terrencezzj, @izikgo, @wangrui6, @kebe7jun, @rishitdholakia13, @j9smith, @meena-at-work, @dllehr-amd, @alexeldeib, @sonusflow, @lucianommartins, @AAISSJ, @DaoyuanLi2816, @zexplorerhj, @zhangxin81, @velonica0, @fuscof-ibm, @anishesg, @zhengluo-nv, @ylangtsou, @fangyuchu, @zx3xyy, @simondanielsson, @ruizhang99, @zixi-qi, @xwu-intel, @yufufi, @wdhongtw, @mrjunwan-lang, @wangxiyuan, @wasnertobias, @ilmarkov, @sychen52, @zhandaz, @russellb, @SandishKumarHN, @juhi10071998, @itayalroy, @djmmoss, @SumanthRH, @mayuyuace, @zhougit86, @meenchen, @lucifer1004, @popkart-EZ, @jzakrzew, @ffggs, @huanghua1994, @orozery, @danisereb, @rshavitt, @Yihuki, @QingZhou-YangHY, @Jie-Fang, @bbartels
+
+## New Contributors
+
+* @abinggo made their first contribution in https://github.com/vllm-project/vllm/pull/42128
+* @afierka-intel made their first contribution in https://github.com/vllm-project/vllm/pull/40327
+* @alexagriffith made their first contribution in https://github.com/vllm-project/vllm/pull/41987
+* @alexeldeib made their first contribution in https://github.com/vllm-project/vllm/pull/43255
+* @amitport made their first contribution in https://github.com/vllm-project/vllm/pull/41666
+* @anishesg made their first contribution in https://github.com/vllm-project/vllm/pull/43079
+* @bedeks made their first contribution in https://github.com/vllm-project/vllm/pull/40269
+* @blake-snc made their first contribution in https://github.com/vllm-project/vllm/pull/35568
+* @blancsw made their first contribution in https://github.com/vllm-project/vllm/pull/41154
+* @bobofang11235 made their first contribution in https://github.com/vllm-project/vllm/pull/42604
+* @BWAAEEEK made their first contribution in https://github.com/vllm-project/vllm/pull/42233
+* @CynicDora made their first contribution in https://github.com/vllm-project/vllm/pull/39487
+* @daniel-devlab made their first contribution in https://github.com/vllm-project/vllm/pull/42479
+* @DaoyuanLi2816 made their first contribution in https://github.com/vllm-project/vllm/pull/42905
+* @Dogacel made their first contribution in https://github.com/vllm-project/vllm/pull/42764
+* @DomBrown made their first contribution in https://github.com/vllm-project/vllm/pull/42080
+* @dusthunter made their first contribution in https://github.com/vllm-project/vllm/pull/42594
+* @ffggs made their first contribution in https://github.com/vllm-project/vllm/pull/43414
+* @frida-andersson made their first contribution in https://github.com/vllm-project/vllm/pull/41825
+* @fuergaosi233 made their first contribution in https://github.com/vllm-project/vllm/pull/43488
+* @gaozihao-shy made their first contribution in https://github.com/vllm-project/vllm/pull/42869
+* @gracie-guo made their first contribution in https://github.com/vllm-project/vllm/pull/42626
+* @haic0 made their first contribution in https://github.com/vllm-project/vllm/pull/40453
+* @hks-9697-v2 made their first contribution in https://github.com/vllm-project/vllm/pull/42521
+* @hlin99 made their first contribution in https://github.com/vllm-project/vllm/pull/42740
+* @inisis made their first contribution in https://github.com/vllm-project/vllm/pull/41710
+* @izikgo made their first contribution in https://github.com/vllm-project/vllm/pull/42938
+* @j9smith made their first contribution in https://github.com/vllm-project/vllm/pull/41215
+* @junyanxu made their first contribution in https://github.com/vllm-project/vllm/pull/42671
+* @KaivalyaMDabhadkar made their first contribution in https://github.com/vllm-project/vllm/pull/42333
+* @libinta made their first contribution in https://github.com/vllm-project/vllm/pull/41689
+* @lucifer1004 made their first contribution in https://github.com/vllm-project/vllm/pull/43433
+* @meena-at-work made their first contribution in https://github.com/vllm-project/vllm/pull/40082
+* @mrjunwan-lang made their first contribution in https://github.com/vllm-project/vllm/pull/43360
+* @MrZ20 made their first contribution in https://github.com/vllm-project/vllm/pull/42394
+* @mwawrzos made their first contribution in https://github.com/vllm-project/vllm/pull/42498
+* @NoeliaBentancor made their first contribution in https://github.com/vllm-project/vllm/pull/42250
+* @ovidiusm made their first contribution in https://github.com/vllm-project/vllm/pull/42542
+* @paulyu12 made their first contribution in https://github.com/vllm-project/vllm/pull/42306
+* @QingZhou-YangHY made their first contribution in https://github.com/vllm-project/vllm/pull/43579
+* @qizzzh made their first contribution in https://github.com/vllm-project/vllm/pull/41680
+* @qyYue1389 made their first contribution in https://github.com/vllm-project/vllm/pull/42289
+* @rasdani made their first contribution in https://github.com/vllm-project/vllm/pull/42481
+* @rebklee made their first contribution in https://github.com/vllm-project/vllm/pull/42098
+* @revit13 made their first contribution in https://github.com/vllm-project/vllm/pull/42926
+* @ruizhang99 made their first contribution in https://github.com/vllm-project/vllm/pull/43260
+* @Sarah-Salah made their first contribution in https://github.com/vllm-project/vllm/pull/42441
+* @sonusflow made their first contribution in https://github.com/vllm-project/vllm/pull/36329
+* @TheDuyIT made their first contribution in https://github.com/vllm-project/vllm/pull/40131
+* @tuukkjs made their first contribution in https://github.com/vllm-project/vllm/pull/42880
+* @vllm-agent made their first contribution in https://github.com/vllm-project/vllm/pull/42913
+* @wangrui6 made their first contribution in https://github.com/vllm-project/vllm/pull/40326
+* @wasnertobias made their first contribution in https://github.com/vllm-project/vllm/pull/43001
+* @weizhoublue made their first contribution in https://github.com/vllm-project/vllm/pull/42830
+* @woernfl made their first contribution in https://github.com/vllm-project/vllm/pull/42397
+* @xwu-intel made their first contribution in https://github.com/vllm-project/vllm/pull/37888
+* @Yihuki made their first contribution in https://github.com/vllm-project/vllm/pull/42933
+* @yiwen101 made their first contribution in https://github.com/vllm-project/vllm/pull/42654
+* @ylangtsou made their first contribution in https://github.com/vllm-project/vllm/pull/43038
+* @yufufi made their first contribution in https://github.com/vllm-project/vllm/pull/42972
+* @zhengluo-nv made their first contribution in https://github.com/vllm-project/vllm/pull/43105
+* @zhougit86 made their first contribution in https://github.com/vllm-project/vllm/pull/42739
+* @zx3xyy made their first contribution in https://github.com/vllm-project/vllm/pull/42855

--- a/claude-skills/vllm-release-notes/examples/v0.22.1/release-notes.md
+++ b/claude-skills/vllm-release-notes/examples/v0.22.1/release-notes.md
@@ -1,0 +1,29 @@
+## Highlights
+
+This release features 8 commits from 6 contributors (1 new)!
+
+v0.22.1 is a patch release on top of v0.22.0 with targeted bug fixes plus a couple of additions: new model support for JetBrains' Mellum v2, zentorch-accelerated quantized linear inference on AMD Zen CPUs, and fixes for multi-node Ray data-parallel serving, DeepSeek-V4 initialization, and a few model-loading regressions.
+
+### Model Support
+* New model: JetBrains' **Mellum v2**, an open-weights Mixture-of-Experts code-generation model (#43992).
+* **DeepSeek-V4**: resolve a CUTLASS `fmin` compatibility issue that broke initialization (0decac0d).
+* Fix `OlmoHybridForCausalLM` failing to initialise after the checkpoint changed `rope_parameters` from `None` to `{"rope_type": None}` (#43846).
+* Fix **HyperCLOVAX** loading after the upstream HuggingFace repo removed its remote code (now native in `transformers >= 5.9.0`): register the `hyperclovax` model_type so vLLM uses its vendored config instead of the stale `auto_map` (#43860).
+
+### Hardware & Performance
+* **AMD Zen CPUs**: route W8A8 (int8 dynamic-symmetric) and W4A16 (GPTQ) linear inference through zentorch kernels, registered ahead of the generic oneDNN CPU kernels, with transparent fallback on non-Zen CPUs, GPUs, and XPU (#41813).
+
+### Large Scale Serving
+* Fix a deterministic hang in multi-node **Ray data-parallel** serving with `num_api_servers > 1` by excluding the Ray DP backend from the deferred (kernel-assigned) port allocation introduced in #42585 (#43864).
+
+### Build & CI
+* Docker: stop installing `flashinfer-jit-cache` via `--extra-index-url` while it is quarantined on PyPI, fixing image builds (#44366).
+* Normalize **NIXL** KV-connector wheel installs so only the wheel matching the image's CUDA major is kept, fixing `ImportError: libcudart.so.12` when importing `nixl_ep` on CUDA 13 images (#44266).
+
+## Contributors
+
+@khluu, @vadiklyutiy, @aadwived, @shadeMe, @alec-flowers, @hmellor
+
+## New Contributors
+
+* @aadwived made their first contribution in https://github.com/vllm-project/vllm/pull/41813

--- a/claude-skills/vllm-release-notes/examples/v0.23.0/release-notes.md
+++ b/claude-skills/vllm-release-notes/examples/v0.23.0/release-notes.md
@@ -1,0 +1,147 @@
+# vLLM v0.23.0 Release Notes
+
+## Highlights
+
+This release features 426 commits from 203 contributors (63 new)!
+
+* **DeepSeek-V4 matures across backends**: Following its introduction in v0.22.0, DeepSeek-V4 received another large hardening and optimization pass. Its sparse MLA metadata is now decoupled from DeepSeek-V3.2 (#44699), it gained a TRTLLM-gen attention kernel (#43827), EPLB support for the Mega-MoE (#43339), a CuTe DSL sparse-compressor path (#43584) with compressor refactors (#43690, #43710), a fused q-pad kernel (#43162), selective prefix-cache retention for sliding-window KV cache (#43447), and an index-share feature for DSA MTP (#44420). The model was also detached from `torch.compile` (#43746, #43891), its attention and RoPE paths were refactored (#44569, #44262, #43926), an XPU attention decode path was added (#42953), and ROCm gained Tilelang MHC (#43679) while dropping the MegaMoE integration there (#43629).
+* **Model Runner V2 expands to more dense models**: MRv2 is now selected by default for **Llama and Mistral dense models** (#43458) in addition to Qwen3. It gained a FlashInfer sampler (#42472), breakable CUDA graphs (#44050), pipeline-parallel bubble elimination (#42187), kernel block-size support for hybrid models (#38831), and Gemma 4 MTP (#43241).
+* **Rust frontend grows up**: The experimental Rust frontend added a streaming `generate` endpoint (#43779), dynamic LoRA endpoints (#43778), `/version` (#43854) and `/server_info` (#43942) endpoints, a server-router extension hook (#43774), request-ID headers (#43883), and many new tool parsers (InternLM2 #43481, hy_v3 #43872, Phi-4-mini #44213, Gemma4 #43850).
+* **Gemma 4**: Added encoder-free **Gemma 4 Unified** support (#44429) and Gemma 4 MTP (#43241), plus numerous accuracy and startup fixes.
+* **Transformers v5 compatibility**: Continued work toward Transformers v5, with vendored MiniCPM-V/O processors (#44282) and compatibility fixes for Sarvam (#38804) and Voxtral (transformers≥5.10) (#44559).
+* **Multi-tier KV cache offloading**: The offloading framework gained an **object-store secondary tier** (#41968), HMA enabled by default for capable connectors (#41847), tiering support for HMA models (#44287), and a per-request offloading policy via the `on_new_request` lifecycle hook (#43205).
+* **Unified parser**: Reasoning and tool-call parsing are now unified behind a single `Parser.parse()` interface (#44267), with the Responses parser migrated to it (#42977).
+
+### Model Support
+* **New models**: Step-3.7-Flash (#43859), Cosmos3 Reasoner (#43356), Gemma 4 Unified encoder-free (#44429), JetBrains Mellum v2 (#43992), Granite Speech Plus (#43519), Cohere Mini Code (#44707).
+* **Gemma 4**: Encoder-free Unified support (#44429), MTP (#43241), native ViT linear layers (#43798), vision-embedder excluded from quantization (#44571), and fixes for MTP under TP>1 (#43909), block-table mismatch under concurrency (#43982), transformers-processor startup crash (#44232), and CPU init (#44615).
+* **Transformers v5**: Vendor MiniCPM-V/O processors (#44282), Sarvam compat (#38804), Voxtral `fetch_audio` for transformers≥5.10 (#44559).
+* **Model fixes & enhancements**: Qwen3-VL/Qwen3-omni-thinker deepstack accuracy under `torch.compile` (#43617), EVS for Qwen3-VL (#44205), GLM-5.1 PP loading (#42944), GLM-4.1V processor logits (#43575), GLM-4.6V video loader (#44417), OlmoHybrid init (#43846), HyperCLOVAX remote-code removal (#43860), Bailing-MoE rotary factor (#43770), Step3 PP residual KeyError (#37622), MiniCPM-V-4.6 video (#44509), MiniCPM-O audio unpadding (#38053), MiniCPM-V batched preprocessing (#44609), FunASR-Nano init (#44215), Cohere routing method (#44021), Kimi-K2.5 FlashInfer ViT metadata (#44493).
+* **Multimodal**: Auto-select registered video loader for VLMs (#44126), O(log n) multimodal item handling per step (#44212), local image encoding in benchmarks (#43843), interleaved custom image benchmark datasets (#43636).
+* **Pooling/Classification**: Proper exceptions for pooling UX (#44593), `extra_repr()` for pooler classes (#44805), LoRA-adapter-name pooling fix (#44410), resettled generative scoring entrypoint (#44153), expanded pooler unit tests (#43818, #44471).
+* **Refactor**: AutoWeightsLoader for InternLM2 (#38278).
+
+### Engine Core
+* **Model Runner V2**: Default for Llama and Mistral dense models (#43458), FlashInfer sampler (#42472), breakable CUDA graphs (#44050), removed Eagle's dedicated CUDA graph pool (#44078), pipeline-parallel bubble elimination (#42187), kernel block size for hybrid models (#38831), zeroing of freshly allocated KV blocks for hybrid + FP8 KV cache (#43990), actual batch `max_seq_len` for attention metadata (#43991), KVConnector + PP cleanup (#43732), KV-connector handling in the spec-decode case (#43719), speculator-prefill warmup/capture (#44253).
+* **Speculative decoding (DFlash)**: Causal DFlash (#43445), proper lookahead-slot allocation (#43733), prefix-cache corruption fix (#42971); attention-group split by `num_heads_q` for drafts (#43543), EAGLE/MTP lookahead caching in the SWA prefix-cache mask (#44082).
+* **Attention & hybrid/Mamba**: FlexAttention/FlashAttention num-blocks-first layouts (#42095), OOT MLA prefill backend registration (#43325), FlashAttention upstream sync (#44065), Mamba LINEAR attention-module refactor (#43556), corrupted MLA + linear attention fix (#43961), KDA conv-state unification (#44539) and gate/cumsum fusion (#43667), Mamba SSD `do_not_specialize` (#43803), GDN prefill kernel for SM100 (#43273), Qwen3.5 mixed prefill+decode split routing (#44700), MiniMax-M2 gate kernel (#38445).
+* **KV cache & scheduler**: Pluggable `KVCacheSpec` (#37505), `scheduler_block_size` threaded into KVCacheManager/Coordinator (#44165), `max_concurrent_batches` moved to `VllmConfig` (#44274), KV-cache scale boilerplate removed from weight loading (#43167).
+* **Core**: Freeze the garbage collector in workers after model init (#44363), sparse NCCL weight transfer for in-place updates (#40096), RunAI streamer tensor-buffer reuse fix during weight loading (#43464), early CUDA init fix (#43791), graceful spinloop ext-load failure handling (#43659), scheduled-function deprecations (#43358).
+
+### Large Scale Serving & Distributed
+* **KV cache offloading**: Object-store secondary tier (#41968), HMA on by default for capable connectors (#41847) and tiering (#44287), per-request offloading policy (`on_new_request`) (#43205) and `on_schedule_end()` hook (#44206), token-offset selective offload (#39983), skip decode-phase blocks in CPU offload (#43797), page-size block alignment (#43689), Triton fast-path for small CPU→GPU `swap_blocks_batch` (#42212), stale sliding-window block fix (#42959).
+* **KV connectors / disaggregated serving**: PP-aware handshake aggregation and intermediate-PP output plumbing (#43720), multiple-async-KV-load deadlock fix (#44560), Nixl Mamba prefix-caching mode (#42554), NixlConnector `kv_both` role deprecation cycle (#43874), Mooncake fixes (#43742, #44103, #42694), LMCache `LMCacheMPConnector` (#42865), EC connector shutdown API (#42423) and non-blocking lookup (#41627), KV-transfer tokens excluded from `iteration_tokens_total` (#43346).
+* **EPLB**: Async EPLB by default (#43219), EPLB for DeepSeek-V4 Mega-MoE (#43339), Nixl zero-copy EPLB transfers (#41633).
+* **Data parallel**: DP Ray placement groups on specific nodes (#44669) and grouped-node allocation fix (#43998), DP-coordinator startup timeout raised to 120s (#42343), per-GPU-worker RDMA NIC selection (#42083), multi-API-server startup fixes — TOCTOU `EADDRINUSE` race (#42585) and hard-coded-timeout fix (#43768).
+
+### Hardware & Performance
+* **NVIDIA / kernels**: Triton MoE backend on Hopper by default (#44220), CUTLASS FP8 scaled-mm padding bypass (+20%) (#43706), MoE-permute buffer pre-allocation (+9–14%) (#43014), `Fp8BlockScaledMM` `new_empty()` optimization (#43677), tuned `selective_state_update` for H200/RTX PRO (#44251), Inductor fast-path fallback for vLLM/AITER custom ops (#42129), Gemma RMS all-reduce fusion (#42646), NUMA auto-binding on DGX B300 (#43270).
+* **AMD ROCm**: ROCm 7.2.3 (#43136), AITER v0.1.13.post1 (#44265), native W4A16 (#41394) and fused-MoE W4A16 HIP (#44075) kernels for RDNA3 (gfx1100), AITER top-k/top-p sampler by default (#43331), attention-sink support in AITER FA (#43817), AITER hipBLASLt GEMM online tuning (#40426), `permute_cols` for ROCm (#44674), blocks-first KV layout for AMD (#43660), N=5 wvSplitK for spec decode (#40687), MoRI connector improvements (#43303, #41751, #40344).
+* **Intel XPU**: `block_fp8_moe` (#42139), block-scaled W8A8 FP8 path (#39968), WNA16 oracle for GPTQ sym-int4 (#41426), rms_norm/act quant fusions (#43963), GDN-attention MTP (#43565), Triton selective-scan op (#43421), fused-MoE LoRA kernel crash fix (#43646), transparent sleep mode (#37149), CPU/tiering offloading on XPU (#36423), DeepSeek-V4 attention decode path (#42953).
+* **CPU & other architectures**: zentorch-accelerated W8A8/W4A16 on AMD Zen CPUs (#41813), CPU top-k/top-p Triton sampling (#43633), non-divisible GQA decode in mixed batches (#43032), `cpu_awq` folded into `awq_marlin` (#43841), RISC-V RVV WNA16 helpers (#42730), fused GDN gated-delta-rule kernels (#43534), PowerPC SHM communicator (#43754), arm64 CI image (#41303).
+* **TPU**: tpu-inference upgraded to v0.20.0 (#43394) then v0.21.0 (#44621).
+* **torch stable ABI**: Continued migration of kernels to the libtorch stable ABI — merge_attn_states/mamba/sampler [8/n] (#43361), attention/cache kernels [9/n] (#43717), header files (#44013), cuda_view/silu_and_mul [10/n] (#44334), custom all-reduce/DeepSeek-V4 fused MLA/MXFP8 MoE [10b/n] (#44365); ROCm fallback to regular ABI (#44648), `_has_module` trial-import verification (#44035).
+
+### Quantization
+* **ModelOpt**: LM-head quantization (#42124), MXFP8 non-gated MoE (#42958).
+* **compressed-tensors**: WNA8O8Int linears and WNInt embeddings (#44340), asymmetric MoE WNA16 Marlin (#44025), single-class NVFP4 linear refactor (#42443).
+* **Kernels & backends**: Triton W4A16 as CUDA fallback for non-Marlin-aligned shapes (#43731), Marlin MoE on SM 12.x (#40923), fail-fast for unsupported NVFP4 KV-cache-dtype arch (#43669), CuteDSL compressor 128-split kernel optimization (#44230), TRTLLM NVFP4 MoE chunking fix (#43599), `routed_scaling_factor` passed to FlashInfer TRTLLM BF16 MoE (#43769).
+* **MoE refactor (oracle)**: Migrated ModelOpt MXFP8 (#42768), W4A8-int8 (#42789), and WNA16 backend selection (#42553) into the modular-kernel oracle; removed `supports_expert_map` (#43108) and the inplace fused-experts mechanism (#43727).
+
+### API & Frontend
+* **Anthropic Messages API**: Structured output and effort support (#42396), system-role messages inside the messages array (#44283).
+* **OpenAI / Responses API**: `chat_template_kwargs` in Responses (#43761), `reasoning_effort` mapped to `enable_thinking` in chat-template kwargs (#43401), developer-to-system conversion in the HF renderer (#43590), unstreamed tool-call-args streaming fix (#44348).
+* **Parsers**: Unified reasoning + tool-call parsing behind `Parser.parse()` (#44267), Responses parser migrated to the unified interface (#42977), unstreamed tool-arg flush moved into the parser (#44017); new/fixed tool parsers — MiniCPM5 XML (#43175), Qwen3 XML JSON-args-first (#43243), DeepSeek DSML incremental streaming (#42879), first-args-chunk serializer fix (#42683), `tool_choice="none"` honored in streaming (#42752), null-tool-args crash fix (#43862).
+* **Frontend**: GPT-OSS instruction rendering (#44330), Harmony `stop_token_ids` cleanup (#44009), consistent `VLLMValidationError` in chat/completion validators (#36254), consolidation of dev entrypoints (#44170) and online-serving utils (#44479).
+* **Rust frontend**: Streaming `generate` endpoint (#43779), dynamic LoRA endpoints (#43778), `/version` (#43854) and `/server_info` (#43942), server-router extension hook (#43774), `--enable-request-id-headers` (#43883), recursive tool-parameter conversion (#44299), `include_reasoning=false` (#44391), `--language-model-only` skips the multimodal processor (#44500), per-engine batch auto-abort (#44591), HF chat-template fixes (#44311), cross-DP aggregation of `is_sleeping`/`reset_prefix_cache` (#43429); new tool parsers — InternLM2 (#43481), hy_v3 (#43872), Phi-4-mini JSON (#44213), Gemma4 (#43850).
+* **Benchmarks**: Timed trace replay for Moonshot/Alibaba workloads in `vllm bench serve` (#39795), reasoning-model (thinking) benchmarking via `--chat-template-kwargs` (#44244).
+
+This release ships a coordinated security-hardening batch (much of it from security researcher @jperezdealgaba). Note: several of these fixes (#44321, #44680, #44744, #44970, #44971, #44974, #45113, #45116, #45119) merged to `main` as part of the disclosure and are not contained in the `v0.23.0` git tag itself; they are documented here as part of the release's security story.
+
+* **Denial of service**: Fix remote DoS via invalid recovered-token reinjection in speculative decoding (#44744), and DoS via an audio decompression bomb in the speech-to-text endpoint (#44970).
+* **Information disclosure**: Fix int32 truncation in the GGUF dequantize kernels (#44971).
+* **Untrusted input / media handling**: Correct image EXIF orientation and tRNS transparency handling (#44974); reject out-of-vocabulary token IDs before they reach the GPU logprob path (#44042) and in Rust-frontend request params (#44680); reject non-finite `temperature`/`repetition_penalty` (#45116), invalid `thinking_token_budget` (#43402), non-positive `ParallelConfig` knobs (#44057), zero-valued config fields (#43794), and out-of-range `max_num_scheduled_tokens` (#44207).
+* **Error-message hardening**: Apply `sanitize_message` to the Anthropic and STT error paths (#45119), and clarify the audio-duration-limit rejection error (#45113).
+* **Transport & authentication**: SSL/TLS support for the data-parallel supervisor (#43688) and API-key authentication in the Rust frontend (#44321).
+* **Robustness**: Fix a UTF-8 char-boundary panic in the Rust incremental detokenizer on malformed input (#44620).
+
+### Dependencies
+* FlashInfer v0.6.12 (#44036), ROCm 7.2.3 (#43136), AITER v0.1.13.post1 (#44265), tpu-inference v0.21.0 (#44621), CuTe DSL v4.5.2 (#43745), mistral-common bump (#44649), fastsafetensors v0.3.2 (#43625).
+* Removed the stale cuDNN frontend upper bound (#42599); Docker fixes for flashinfer-jit-cache (#44366) and CUTLASS DSL cu13 install order (#45204).
+
+### Deprecations
+* Deprecate `JAISLMHeadModel` (#43784).
+* Begin the deprecation cycle for the NixlConnector `kv_both` role (#43874).
+* Remove functions previously scheduled for deprecation in v0.21.0 (#43358).
+
+## New Contributors
+
+* @aadwived made their first contribution in https://github.com/vllm-project/vllm/pull/41813
+* @adhithyamulticoreware made their first contribution in https://github.com/vllm-project/vllm/pull/44615
+* @adityasingh2400 made their first contribution in https://github.com/vllm-project/vllm/pull/43550
+* @adotdad made their first contribution in https://github.com/vllm-project/vllm/pull/43100
+* @amd-fuweiy made their first contribution in https://github.com/vllm-project/vllm/pull/43684
+* @andakai made their first contribution in https://github.com/vllm-project/vllm/pull/43617
+* @animeshtrivedi made their first contribution in https://github.com/vllm-project/vllm/pull/39795
+* @BramVanroy made their first contribution in https://github.com/vllm-project/vllm/pull/43087
+* @CienetStingLin made their first contribution in https://github.com/vllm-project/vllm/pull/43394
+* @devin-lai made their first contribution in https://github.com/vllm-project/vllm/pull/44213
+* @Dymasik made their first contribution in https://github.com/vllm-project/vllm/pull/43982
+* @ECMGit made their first contribution in https://github.com/vllm-project/vllm/pull/43332
+* @fallintoplace made their first contribution in https://github.com/vllm-project/vllm/pull/43540
+* @gagandhakrey made their first contribution in https://github.com/vllm-project/vllm/pull/43792
+* @galletas1712 made their first contribution in https://github.com/vllm-project/vllm/pull/43926
+* @garrygale made their first contribution in https://github.com/vllm-project/vllm/pull/44205
+* @Gruner-atero made their first contribution in https://github.com/vllm-project/vllm/pull/42967
+* @hanlin12-AMD made their first contribution in https://github.com/vllm-project/vllm/pull/40426
+* @harshaljanjani made their first contribution in https://github.com/vllm-project/vllm/pull/41459
+* @Holworth made their first contribution in https://github.com/vllm-project/vllm/pull/39562
+* @hoobnn made their first contribution in https://github.com/vllm-project/vllm/pull/42752
+* @HueCodes made their first contribution in https://github.com/vllm-project/vllm/pull/44591
+* @IdoAtadTD made their first contribution in https://github.com/vllm-project/vllm/pull/43978
+* @jasonboukheir made their first contribution in https://github.com/vllm-project/vllm/pull/41426
+* @Jie-Fang made their first contribution in https://github.com/vllm-project/vllm/pull/43584
+* @JINO-ROHIT made their first contribution in https://github.com/vllm-project/vllm/pull/43830
+* @JMonde made their first contribution in https://github.com/vllm-project/vllm/pull/37622
+* @JohnQinAMD made their first contribution in https://github.com/vllm-project/vllm/pull/43331
+* @jwzheng96 made their first contribution in https://github.com/vllm-project/vllm/pull/44057
+* @Kartavyasonar made their first contribution in https://github.com/vllm-project/vllm/pull/43669
+* @Krishnachaitanyakc made their first contribution in https://github.com/vllm-project/vllm/pull/38053
+* @linzm1007 made their first contribution in https://github.com/vllm-project/vllm/pull/43402
+* @MaciejBalaNV made their first contribution in https://github.com/vllm-project/vllm/pull/43356
+* @Majid-Taheri made their first contribution in https://github.com/vllm-project/vllm/pull/43803
+* @mfylcek made their first contribution in https://github.com/vllm-project/vllm/pull/43421
+* @MHYangAMD made their first contribution in https://github.com/vllm-project/vllm/pull/42595
+* @mikekg made their first contribution in https://github.com/vllm-project/vllm/pull/43330
+* @nightcityblade made their first contribution in https://github.com/vllm-project/vllm/pull/44118
+* @NolanHo made their first contribution in https://github.com/vllm-project/vllm/pull/43774
+* @oguzhankir made their first contribution in https://github.com/vllm-project/vllm/pull/41759
+* @okorzh-amd made their first contribution in https://github.com/vllm-project/vllm/pull/42129
+* @Oxygen56 made their first contribution in https://github.com/vllm-project/vllm/pull/44236
+* @QiliangCui2023 made their first contribution in https://github.com/vllm-project/vllm/pull/44476
+* @rajkiranjoshi made their first contribution in https://github.com/vllm-project/vllm/pull/42083
+* @Rukhaiya2004 made their first contribution in https://github.com/vllm-project/vllm/pull/43754
+* @ruocco made their first contribution in https://github.com/vllm-project/vllm/pull/39983
+* @sphinx07 made their first contribution in https://github.com/vllm-project/vllm/pull/43817
+* @SunskyXH made their first contribution in https://github.com/vllm-project/vllm/pull/44215
+* @ThibaultCastells made their first contribution in https://github.com/vllm-project/vllm/pull/43636
+* @tianyu-z made their first contribution in https://github.com/vllm-project/vllm/pull/43150
+* @tonyliu312 made their first contribution in https://github.com/vllm-project/vllm/pull/40923
+* @tushar00jain made their first contribution in https://github.com/vllm-project/vllm/pull/41980
+* @viiccwen made their first contribution in https://github.com/vllm-project/vllm/pull/44617
+* @Vikrantpalle made their first contribution in https://github.com/vllm-project/vllm/pull/38804
+* @wanghenshui made their first contribution in https://github.com/vllm-project/vllm/pull/44410
+* @willamhou made their first contribution in https://github.com/vllm-project/vllm/pull/43429
+* @william-rom made their first contribution in https://github.com/vllm-project/vllm/pull/43862
+* @xiaozcy made their first contribution in https://github.com/vllm-project/vllm/pull/43843
+* @XuZhou26 made their first contribution in https://github.com/vllm-project/vllm/pull/44618
+* @Yadan-Wei made their first contribution in https://github.com/vllm-project/vllm/pull/44559
+* @zhangtao2-1 made their first contribution in https://github.com/vllm-project/vllm/pull/43175
+* @zvik made their first contribution in https://github.com/vllm-project/vllm/pull/43519
+* @zzt93 made their first contribution in https://github.com/vllm-project/vllm/pull/43770
+
+## Contributors
+
+Thank you to everyone who made this release possible!
+
+@AndreasKaratzas, @WoosukKwon, @hmellor, @BugenZhao, @yewentao256, @njhill, @khluu, @vadiklyutiy, @sfeng33, @bnellnm, @zyongye, @NickLucche, @JartX, @lucianommartins, @cleonard530, @wzhao18, @yma11, @simondanielsson, @chaojun-zhang, @mmangkad, @jeejeelee, @chaunceyjiang, @bigPYJ1151, @ronensc, @taneem-ibrahim, @gau-nernst, @LucasWilkinson, @MatthewBonanni, @chunyang-wen, @tjtanaa, @yzong-rh, @JaredforReal, @zixi-qi, @Isotr0py, @noooop, @Xunzhuo, @ivanium, @zufangzhu, @DaoyuanLi2816, @CienetStingLin, @Jie-Fang, @aoshen02, @akii96, @benchislett, @MengqingCao, @rshavitt, @kliuae, @omerpaz95, @willamhou, @Majid-Taheri, @micah-wil, @ricky-chaoju, @mikekg, @mgoin, @mayuyuace, @Etelis, @ilmarkov, @tlrmchlsmth, @UranusSeven, @bedeks, @izhuhaoran, @ZJY0516, @fadara01, @pschlan-amd, @dependabot[bot], @wangxiyuan, @Oxygen56, @charlifu, @varun-sundar-rabindranath, @shen-shanshan, @TheEpicDolphin, @adobrzyn, @XuZhou26, @Terrencezzj, @zhejiangxiaomai, @ILikeIneine, @yubofredwang, @chfeng-cs, @ThibaultCastells, @linzm1007, @javierdejesusda, @meenchen, @zhewenl, @xyang16, @angelayi, @nholmber, @zhangtao2-1, @adityasingh2400, @ashwing, @sts07142, @jatseng-ai, @fallintoplace, @andakai, @amitz-nv, @bbartels, @he-yufeng, @ignaciosica, @JINO-ROHIT, @tonyliu312, @QwertyJack, @animeshtrivedi, @jzakrzew, @juliendenize, @zexplorerhj, @ruocco, @mgehre-amd, @jasonboukheir, @MaciejBalaNV, @JohnQinAMD, @huanghua1994, @rajkiranjoshi, @rasmith, @harshaljanjani, @ltd0924, @wdhongtw, @yintong-lu, @tianmu-li, @jikunshang, @JMonde, @MHYangAMD, @frida-andersson, @Wauplin, @czhu-cohere, @gagandhakrey, @nemanjaudovic, @Liangliang-Ma, @liulanze, @sphinx07, @aadwived, @nightcityblade, @umut-polat, @jeffreywang88, @wcynb1023, @zzt93, @shadeMe, @Dao007forever, @alec-flowers, @Krishnachaitanyakc, @orozery, @BWAAEEEK, @cinnamonica02, @albertoperdomo2, @Rukhaiya2004, @mfylcek, @shreyas269, @Gruner-atero, @TomerBN-Nvidia, @wjinxu, @IdoAtadTD, @xiaozcy, @brian-dellabetta, @zhenwei-intel, @adotdad, @Kartavyasonar, @lesj0610, @ECMGit, @cakeng, @william-rom, @qiching, @NolanHo, @andylolu2, @xwu-intel, @linitra24, @hoobnn, @Dymasik, @wanghenshui, @maobaolong, @oguzhankir, @okorzh-amd, @Kevin-XiongC, @jiahanc, @garrygale, @dsikka, @QiliangCui2023, @wjabbour, @zvik, @tc-mb, @jwzheng96, @divakar-amd, @tushar00jain, @galletas1712, @hanlin12-AMD, @tuukkjs, @viiccwen, @Sunt-ing, @HueCodes, @tianyu-z, @adhithyamulticoreware, @rishitdholakia13, @effi-ofer, @Vikrantpalle, @walterbm, @devin-lai, @Yadan-Wei, @amd-fuweiy, @maeehart, @qyYue1389, @BramVanroy, @SunskyXH, @Holworth, @majian4work, @xaguilar-amd, @Rohan138

--- a/claude-skills/vllm-release-notes/examples/v0.24.0/release-notes.md
+++ b/claude-skills/vllm-release-notes/examples/v0.24.0/release-notes.md
@@ -1,0 +1,163 @@
+# vLLM v0.24.0 Release Notes
+
+## Highlights
+
+This release features 571 commits from 256 contributors (77 new)!
+
+* **MiniMax-M3**: Added support for the new **MiniMax-M3** model (#45381), with a fast follow-on of BF16/FP8 indexer via MSA (#45892), MXFP4 support (#45896), FP8 sparse GQA (#45744), and extensive AMD/ROCm tuning — mxfp8 MoE/linear on gfx950 (#45725), fp8_per_channel for bf16 weights on MI300X (#45854), FP8 KV-cache fix (#45720), and packed-modules mapping (#45794). A MiniMax-M2 perf regression was also fixed (#45935).
+* **DeepSeek-V4 keeps maturing**: Following its debut, DeepSeek-V4 received another large optimization pass — a FlashInfer sparse index cache (2–4% TTFT) (#45863), prefill chunk-planning optimization (4% E2E throughput) (#45061), a cluster-cooperative topK kernel for low-latency (#43008), contiguous per-block KV allocations (#44577), TEP=16 for the block-FP8 shared expert (#46001), and native DSA indexer decode for `next_n > 2` on SM100 (#45322). It is now enabled on **SM120** alongside GLM-5.1 (#43477), with XPU (#44144, #44517, #45240) and ROCm (#44899, #45103, #45681) attention/MoE paths added.
+* **Model Runner V2 (MRv2) continues to expand**: MRv2 now **supports quantized models by default** (#44446), enables **GraniteMoE by default** (#45461), and gained migration of Qwen + DeepSeek-V2 MoE models (#42667), DFlash speculative decoding (#44586), and more accurate FP32 Gumbel sampling (#45996).
+* **Streaming Parser Engine**: A new streaming parser engine unifies tool-call/reasoning parsing across models, with parsers for Qwen3 (#45413), MiniMax-M2 (#45701), GLM-4.7/5.1/5.2 (#45915), and Nemotron V3 (#45755).
+* **Diffusion LLMs**: Added **DiffusionGemma** (#45163), including a CPU path (#45690) and structured-output guardrails for diffusion decoders (#45468).
+* **WideEP / DeepEP v2**: Integrated **DeepEP v2** for expert parallelism (#41183), with follow-on robustness fixes (#46404, #46432).
+* **Rust frontend matures further**: Added API-key authentication (#44321), CORS (#45753), `/tokenize` + `/detokenize` (#44222), `/pause` `/resume` `/is_paused` (#44499), `/abort_requests` (#44382), `/get_world_size` (#44801), `thinking_token_budget` (#46137), a Python bridge for Rust tool parsers (#44624), and many new parsers and validation paths.
+* **Device selection change**: vLLM no longer sets `CUDA_VISIBLE_DEVICES` internally; a new `device_ids` argument is provided instead (#45026). On ROCm, a deprecation window for `CUDA_VISIBLE_DEVICES` has begun (#46636).
+
+### Model Support
+* **New models**: MiniMax-M3 (#45381), DiffusionGemma (#45163) + Gemma Diffusion on CPU (#45690), Hierarchical Reasoning Model — Text / HrmTextForCausalLM (#43098), OpenMOSS (#44124).
+* **Gemma 4**: Unified FlashAttention (FA4) across all layers + `mm_prefix` support (#42175); many parser/serving fixes — forced-JSON skip for required/named tool choice (#45795), parsing with thinking disabled (#45832), streaming reasoning-state init (#45852), reasoning rendering on assistant turns (#45867), offline-parser truncation/token-leak fix (#45553); legacy Gemma4 parsers replaced with an engine-based implementation (#45588).
+* **DeepSeek-V4**: OOM fix (#44914), MTP projection prefixing (#44821), supported KV-cache dtypes (#44892).
+* **Qwen / multimodal**: Qwen3-VL video loader (#44412), Qwen2-VL/Qwen2.5-VL processor-mapped video loader (#45555), Qwen3-VL multi-video processing optimization (#46026) and multi-video crash fix (#46305), Qwen3-Omni VIT cu_seqlens device fix (#44264), fused qk-rmsnorm-rope-gate for Qwen3.5 (#44176), Qwen3.5 EP weight-loading fix (#45002).
+* **ViT full CUDA graph**: GLM-4.1V (#40576), DeepSeek-OCR dual-path (#43586), Kimi-VL (#41992), mllama4 (#40660), Lfm2VL encoder (#44930).
+* **Other model fixes**: Llama4 weight loading (#45047) and streamed loading to avoid host-OOM (#44645), MiMo v2.x QKV TP sharding + FP4 (#45200), ColQwen3.5 retrieval correctness (#46108), EXAONE-4.5 vision encoder (#45073), MiDashengLM TP>1 audio-encoder crash (#44408), MiniCPM-o/V device-placement and image-size fixes (#43844, #42332, #44980, #45244), Cohere2 MoE weight loading + parser (#44747, #44907), Nemotron V3 reasoning-as-content (#39091), ColBERT AutoWeightsLoader + query/document embedding io processor (#44999, #45210).
+* **Kernels**: GLM-5 TRT-LLM ragged MLA prefill dimensions (#43525), GLM-5 router GEMM (#46385).
+
+### Engine Core
+* **Model Runner V2**: Quantized models by default (#44446), GraniteMoE default (#45461), Qwen/DSv2 MoE migration (#42667), DFlash (#44586), simplified async output handling (#45442), attention-group split on `num_heads_q` (#45564), LoRA warmup fix (#35536), more accurate FP32 Gumbel sampling (#45996), `min_tokens` off-by-one fix in the V2 GPU sampler (#46243), plus assorted model/config compatibility fixes (#45868).
+* **Speculative decoding**: Dynamic SD (#32374); DFlash with FlashInfer (#43081), mixed KV page sizes (#45181), and Qwen3Next targets (#45319); EAGLE3 support for Qwen3 (#43132); reduced TP communication for large-vocab drafts (#39419); race fix in async accepted counts (#45100); EAGLE multimodal encoder cache fixes (#46315).
+* **KV cache & scheduler**: KV-cache watermark to reduce preemptions (#44594), two-phase allocation for cross-group prefix-cache hits (#44409), Marconi-style admission policy for hybrid cache (#37898), prefix-cache retention for Mamba/linear attention (#45845), DS Mamba tail-copy for MTP align mode (#45473), reduced scheduler copy overhead (#45840).
+* **Attention**: Re-enabled cross-layer KV cache layout for MLA via stride-aware kernels (#45111), MLA prefill FA4 fp8 output (#43050), FlexAttention custom mask mods made fully cudagraphable (#45232), triton diff-kv backend for MiMo (#41797), FlashMLA sparse accuracy fix (#36616).
+* **Weight loading & core**: fastsafetensors `ParallelLoader` for weight loading (#40183), release of cached device memory under pressure on UMA GPUs (#45179), structured outputs for beam search (#35022), `device_ids` arg / no internal `CUDA_VISIBLE_DEVICES` (#45026), graceful fallback when `numactl --membind` is blocked (#45438), config-class registration before tokenizer init (#40299), async scheduling with prompt embeds for multimodal models (#45673).
+
+### Large Scale Serving & Distributed
+* **Expert parallel**: DeepEP v2 integration (#41183) with token-bound and topk-index fixes (#46404, #46432); NIXL EP — DBO with NIXL EP (#45275), top-k index dtype query (#45298), NVFP4 post-receive quantization skip (#45606), elastic-EP communicator (#45013); reject NCCL-based EPLB with async EPLB (#44978).
+* **KV connectors / disaggregated serving**: KV push from prefill to decode via NIXL (#35264); per-region KV transfer classification for mixed full-attn + MLA groups (#44583); Mooncake pipeline-parallel PD support (#44528), async lookup (#45659), compact chunk-hash zero-copy lookup (#45969), SWA-block skipping (#45444); P/D fixes with DP supervisor (#46628) and DSV4 disaggregation (#45831); removed `P2pNcclConnector` (#44854).
+* **KV offloading**: Multi-tier async batched lookup (#44193), packed HMA KV-cache layout (#46205, gated #46252), parallel-agnostic fs-tier cache (#44733), offloading-manager stats (#35669) and labeled/CPU-usage metrics (#45957, #45737), self-describing KV events (#43468), non-blocking idle flush (#45595), and numerous correctness/race fixes (#44784, #45823, #46231, #46278).
+* **Distributed core**: Prefill step cadence for better non-PD DP balancing (#44558), KV-event map encoding (#42892), one-shot fused all-reduce PDL NaN fix (#45448).
+
+### Hardware & Performance
+* **NVIDIA / kernels**: SM90 CUTLASS FP8 mm odd-M support via swap_ab (180–290% kernel speedup) (#44572), tuned `fused_moe` FP8 for Qwen3-Next-80B on H100 (+25%) (#44830), native DSA indexer decode on SM100 (#45322), cluster-cooperative topK for DeepSeek low-latency (#43008), PDL support for DeepGEMM (#46006), FlashInfer cutedsl NVFP4 GEMM (#42235) and cute-dsl MXFP8 linear kernel (#46393), new Helion kernels for FP8/RMSNorm quant (#36902, #33790, #36895, #34432).
+* **torch stable ABI**: Continued (and completed) migration of kernels to the libtorch stable ABI — MoE [10c/n] (#44565), Marlin [11a/n] (#45176), Machete [11b/n] (#45304), final `_C` library migration [12/n] (#45415).
+* **AMD ROCm**: Torch 2.11 (#45362); fused AR + RMSNorm + per-group FP8 quant (#42864), fused softplus-sqrt-topk MoE router under AITER (#44945), DSv4 flash-decode split-K kernel (#44899) and inverse-RoPE fusion (#45103), W4A16 FlyDSL MoE (#44400), A8W4 MoE CDNA4 swizzle gate for gpt-oss (#44804); deprecation window begun for `CUDA_VISIBLE_DEVICES` on ROCm (#46636).
+* **Intel XPU**: Sequence-parallel support (#38608), torch-xpu 2.12 (#42262), vllm-xpu-kernels v0.1.10 (#40367), W4A16 int4 group_size=32 MoE (#45136), DeepSeek-V4 attention/MoE paths (#44144, #44517, #45240), top-p sampling correctness fix (#44470).
+* **CPU & other architectures**: 2.5× faster ASR CPU preprocessing via multi-threading (#44612), CPU W4A16 INT4 MoE (#43409), cgroup memory-limit-aware KV cache sizing (#45086), RISC-V oneDNN W8A8 INT8 (#44478) and RVV micro-GEMM for WNA16 (#44324), pinned memory for WSL2 (#41496), ZenCPU runtime logging (#42726).
+* **TPU**: tpu-inference upgraded to v0.22.1 (#45793).
+* **Misc perf**: `VLLM_TRITON_FORCE_FIRST_CONFIG` to skip Triton autotuning (#42425), Triton recompile detection (#45631), fused multi-group block-table staged writes (#44944).
+
+### Quantization
+* **Online & mixed-precision**: Online FP8 per-token-per-channel (PTPC) quantization (#44132); `modelopt_mixed` support extended to Ampere/SM80-86 (#45306) and Turing/SM75 (#45375).
+* **FP4 / MXFP**: FlashInfer cutedsl NVFP4 GEMM backend (#42235) and cute-dsl MXFP8 linear kernel (#46393), MXFP4 W4A4 MoE CUTLASS E8M0 scale fix (#43557), SwiGLU clamp wired for NVFP4 MoE on non-Blackwell (#45836), `flashinfer_cutlass` allowed as a clamped NVFP4 MoE backend (#46492), NVFP4/OCP MX MoE emulation fix (#46254), FP8 MoE re-enabled on NVIDIA Thor (#46339).
+* **GGUF / compressed-tensors / AWQ**: GGUF quantization migrated to a plugin (#39612), compressed-tensors WNA16 MoE actorder fix (#41161) and KV-cache-scheme rejection (#45312), AWQ format on XPU (#43404) and AWQ dequantize fix on Intel XPU (#42727).
+* **Kernels & correctness**: QuantizedActivation linear-kernel contract (#44260), consolidated Marlin thread-tile padding (#45295), FP8 weight layout canonicalized to (K, N) (#44735), corrupt-output fix for MoE FP8 with LoRAs loaded (#42120), symmetric-quant regression fix in GPTQ/CT MoE (#45656), `fp8_e5m2` KV cache allowed for non-fp8 checkpoints (#45040).
+
+### API & Frontend
+* **Tool calling & parsing**: Strict mode for tool calling in Chat Completions (#45003) and Responses API (#45396); new Streaming Parser Engine (#45413) with Qwen3, MiniMax-M2 (#45701), GLM-4.7/5.1/5.2 (#45915), Nemotron V3 (#45755) parsers; unified Parser consolidation in chat serving (#45548); numerous parser correctness fixes (#46047, #46091, #46159, #45763, #46351, #43984).
+* **OpenAI / Responses**: Real `/v1/embeddings` support for messages + `chat_template_kwargs` (#45173), multimodal token counts in `usage.prompt_tokens_details` (#45458), omit empty `tool_calls` from chat responses (#44105), Responses API streaming `function_call` id fix (#44608), Harmony refactor of streaming/non-streaming paths (#45171, #45104).
+* **Anthropic Messages API**: Cache-usage reporting in `/v1/messages` (#40912), mid-conversation system-message handling (#46025), inline system-message position preserved for prefix caching (#44602), `tool_use` argument-dropping fix (#45287).
+* **Rust frontend**: API-key auth (#44321), CORS (#45753), `/tokenize` + `/detokenize` (#44222), `/pause` `/resume` `/is_paused` (#44499), `/abort_requests` (#44382), `/get_world_size` (#44801), `thinking_token_budget` (#46137), `parallel_tool_calls=false` (#44760), continuous usage stats (#43965), model metadata in `/v1/models` (#45950), Python bridge for Rust tool parsers (#44624), dedicated runtime for HTTP/ZMQ (#46051), and many validation/correctness fixes.
+* **Metrics**: `vllm:tool_call_parser_invocations_total` (#44448), group-aware KV cache capacity in `vllm:cache_config_info` (#42206), MLA attention metrics for DeepSeek MFU estimation (#39457).
+* **Pooling / embeddings**: Validation for Cohere `/v2/embed` input exclusivity (#45640), non-negative rerank `top_n` (#46119), matryoshka embedding dimension bounds (#46313).
+* **Benchmarks**: BFCL tool-calling dataset for `vllm bench serve` (#42457), multi-turn benchmark api_key/custom headers (#44516), tokenizer-mismatch auto-correction (#44708).
+
+### Security
+
+This release ships another coordinated security-hardening batch (much of it from security researcher @jperezdealgaba).
+
+* **Denial of service**: Audio decompression bomb in the speech-to-text endpoint (#44970), remote DoS via invalid recovered-token reinjection in speculative decoding (#44744), DoS via `prompt_embeds` on M-RoPE models (#45252), regex-compilation timeout guard in structured outputs (#45118), audio upload size limit before full materialization (#45510), audio decode duration limit in the chat-completions path (#45908).
+* **Information disclosure**: int32 truncation in the GGUF dequantize kernels (#44971).
+* **Input validation & hardening**: Image EXIF orientation and tRNS transparency handling (#44974), rejection of non-finite `temperature`/`repetition_penalty` (#45116), `sanitize_message` applied to Anthropic and STT error paths (#45119).
+* **Dependencies**: Upgrade Starlette to ≥ 1.0.1 to fix CVE-2026-48710 (#45675).
+
+### Dependencies
+* Torch 2.11 on ROCm (#45362), torch-xpu 2.12 (#42262), tpu-inference v0.22.1 (#45793), NIXL v0.10.1 for XPU (#40287), Starlette ≥ 1.0.1 (#45675).
+* `mistral_common` is now optional via deferred import (#45305); CUDA Dockerfiles upgraded from GCC 10 to GCC 12 for C++20 (#44923); spinloop extension skipped on Python < 3.11 (#44783).
+
+### Deprecations & Removals
+* **Removed models**: ERNIE (obsolete) (#45127), Xverse (#45638), Dots1 (#45637), Bamba (#45990), Mono-InternVL (#45129), InternLM registry alias (#45128).
+* **Deprecated**: First-generation Qwen and QwenVL models (#45131), Transformers v4 support (#45161), `CUDA_VISIBLE_DEVICES` on ROCm (#46636); general deprecations for v0.23/v0.24 (#44992).
+
+## New Contributors
+
+* @abcd1927 made their first contribution in https://github.com/vllm-project/vllm/pull/43098
+* @Achyuthan-S made their first contribution in https://github.com/vllm-project/vllm/pull/44795
+* @Alex-ai-future made their first contribution in https://github.com/vllm-project/vllm/pull/45905
+* @alexbi29 made their first contribution in https://github.com/vllm-project/vllm/pull/45763
+* @amanchugh89 made their first contribution in https://github.com/vllm-project/vllm/pull/45840
+* @ankrovv made their first contribution in https://github.com/vllm-project/vllm/pull/44608
+* @anony-mous-e made their first contribution in https://github.com/vllm-project/vllm/pull/45412
+* @appleparan made their first contribution in https://github.com/vllm-project/vllm/pull/45073
+* @ashishpatel26 made their first contribution in https://github.com/vllm-project/vllm/pull/43984
+* @Bot1822 made their first contribution in https://github.com/vllm-project/vllm/pull/44053
+* @ByteFlowing1337 made their first contribution in https://github.com/vllm-project/vllm/pull/45988
+* @Change72 made their first contribution in https://github.com/vllm-project/vllm/pull/43756
+* @coder3101 made their first contribution in https://github.com/vllm-project/vllm/pull/44801
+* @cquil11 made their first contribution in https://github.com/vllm-project/vllm/pull/45720
+* @dmaniloff made their first contribution in https://github.com/vllm-project/vllm/pull/40470
+* @factnn made their first contribution in https://github.com/vllm-project/vllm/pull/44955
+* @FAUST-BENCHOU made their first contribution in https://github.com/vllm-project/vllm/pull/44760
+* @felix0080 made their first contribution in https://github.com/vllm-project/vllm/pull/44602
+* @gitbisector made their first contribution in https://github.com/vllm-project/vllm/pull/40183
+* @gq112 made their first contribution in https://github.com/vllm-project/vllm/pull/43081
+* @guan404ming made their first contribution in https://github.com/vllm-project/vllm/pull/35022
+* @HanHan009527 made their first contribution in https://github.com/vllm-project/vllm/pull/44528
+* @hello-args made their first contribution in https://github.com/vllm-project/vllm/pull/44109
+* @HumphreySun98 made their first contribution in https://github.com/vllm-project/vllm/pull/45466
+* @j-i-l made their first contribution in https://github.com/vllm-project/vllm/pull/45319
+* @JasonLi314 made their first contribution in https://github.com/vllm-project/vllm/pull/45255
+* @jeffye-dev made their first contribution in https://github.com/vllm-project/vllm/pull/43595
+* @jimmy-evo made their first contribution in https://github.com/vllm-project/vllm/pull/44516
+* @jjppp made their first contribution in https://github.com/vllm-project/vllm/pull/45217
+* @JOSH1024 made their first contribution in https://github.com/vllm-project/vllm/pull/44784
+* @junkang1991 made their first contribution in https://github.com/vllm-project/vllm/pull/46039
+* @KaletoAI made their first contribution in https://github.com/vllm-project/vllm/pull/43495
+* @kliukovkin made their first contribution in https://github.com/vllm-project/vllm/pull/43724
+* @littlecircle0730 made their first contribution in https://github.com/vllm-project/vllm/pull/44750
+* @llx-08 made their first contribution in https://github.com/vllm-project/vllm/pull/45357
+* @m4r1k made their first contribution in https://github.com/vllm-project/vllm/pull/45795
+* @martin-kukla made their first contribution in https://github.com/vllm-project/vllm/pull/45417
+* @MichaelCao0 made their first contribution in https://github.com/vllm-project/vllm/pull/46398
+* @mrn3088 made their first contribution in https://github.com/vllm-project/vllm/pull/45383
+* @nataliepjlin made their first contribution in https://github.com/vllm-project/vllm/pull/45218
+* @nehmathe2 made their first contribution in https://github.com/vllm-project/vllm/pull/44912
+* @nikhilesh-csa made their first contribution in https://github.com/vllm-project/vllm/pull/45852
+* @nv-nedelman-1 made their first contribution in https://github.com/vllm-project/vllm/pull/42120
+* @Oseltamivir made their first contribution in https://github.com/vllm-project/vllm/pull/45879
+* @parthash0804 made their first contribution in https://github.com/vllm-project/vllm/pull/43844
+* @pjdurden made their first contribution in https://github.com/vllm-project/vllm/pull/44942
+* @pst2154 made their first contribution in https://github.com/vllm-project/vllm/pull/45181
+* @Saddss made their first contribution in https://github.com/vllm-project/vllm/pull/44409
+* @sahilsGit made their first contribution in https://github.com/vllm-project/vllm/pull/44499
+* @sasindharan made their first contribution in https://github.com/vllm-project/vllm/pull/44383
+* @shantipriya-amd made their first contribution in https://github.com/vllm-project/vllm/pull/39498
+* @Sirius29 made their first contribution in https://github.com/vllm-project/vllm/pull/46026
+* @srajabos made their first contribution in https://github.com/vllm-project/vllm/pull/44665
+* @sridhar-3009 made their first contribution in https://github.com/vllm-project/vllm/pull/44055
+* @stefankoncarevic made their first contribution in https://github.com/vllm-project/vllm/pull/45706
+* @sunnweiwei made their first contribution in https://github.com/vllm-project/vllm/pull/45100
+* @TanNgocDo made their first contribution in https://github.com/vllm-project/vllm/pull/44222
+* @thisisjimmyfb made their first contribution in https://github.com/vllm-project/vllm/pull/41496
+* @tykow made their first contribution in https://github.com/vllm-project/vllm/pull/44663
+* @V-3604 made their first contribution in https://github.com/vllm-project/vllm/pull/43362
+* @vincentzed made their first contribution in https://github.com/vllm-project/vllm/pull/44930
+* @vraiti made their first contribution in https://github.com/vllm-project/vllm/pull/42331
+* @wangjiaxin99 made their first contribution in https://github.com/vllm-project/vllm/pull/45794
+* @waynehacking8 made their first contribution in https://github.com/vllm-project/vllm/pull/45376
+* @x41lakazam made their first contribution in https://github.com/vllm-project/vllm/pull/43300
+* @xiaguan made their first contribution in https://github.com/vllm-project/vllm/pull/45286
+* @xiaohuguo2023 made their first contribution in https://github.com/vllm-project/vllm/pull/44804
+* @xin3he made their first contribution in https://github.com/vllm-project/vllm/pull/43557
+* @xx-thomas made their first contribution in https://github.com/vllm-project/vllm/pull/45210
+* @yangdian96 made their first contribution in https://github.com/vllm-project/vllm/pull/44173
+* @YellowFoxH4XOR made their first contribution in https://github.com/vllm-project/vllm/pull/45057
+* @yzhan1 made their first contribution in https://github.com/vllm-project/vllm/pull/44552
+* @Zedong-Liu made their first contribution in https://github.com/vllm-project/vllm/pull/45361
+* @ZewenShen-Cohere made their first contribution in https://github.com/vllm-project/vllm/pull/41161
+* @zhangshuoming990105 made their first contribution in https://github.com/vllm-project/vllm/pull/40912
+* @ZiguanWang made their first contribution in https://github.com/vllm-project/vllm/pull/43981
+* @zlxi02 made their first contribution in https://github.com/vllm-project/vllm/pull/44595
+
+## Contributors
+
+Thank you to everyone who made this release possible!
+
+@yewentao256, @Sunt-ing, @jperezdealgaba, @AndreasKaratzas, @BugenZhao, @sfeng33, @njhill, @micah-wil, @bbrowning, @mgoin, @jeejeelee, @hmellor, @tlrmchlsmth, @xianbaoqian, @mmangkad, @jikunshang, @Dao007forever, @zhenwei-intel, @noooop, @Isotr0py, @ivanium, @reidliu41, @varun-sundar-rabindranath, @chaunceyjiang, @WoosukKwon, @mawong-amd, @zxd1997066, @chaojun-zhang, @NickLucche, @bigPYJ1151, @ZJY0516, @charlifu, @yzong-rh, @divakar-amd, @khluu, @cleonard530, @wseaton, @xiaohongchen1991, @ywang96, @taneem-ibrahim, @mikekg, @itayalroy, @Alex-ai-future, @sahilsGit, @bnellnm, @littlecircle0730, @majian4work, @ricky-chaoju, @ronensc, @Fangzhou-Ai, @lucianommartins, @Srinivasoo7, @zyongye, @Rohan138, @Etelis, @wentian-byte, @ekagra-ranjan, @LucasWilkinson, @tahsintunan, @waynehacking8, @gau-nernst, @tuukkjs, @stefankoncarevic, @Palaiologos1453, @lucifer1004, @jmamou, @liulanze, @Terrencezzj, @Change72, @LopezCastroRoberto, @he-yufeng, @benchislett, @juliendenize, @s3woz, @panpan0000, @ilmarkov, @zixi-qi, @wcynb1023, @fynnsu, @ZhanqiuHu, @yuwenzho, @tdoublep, @MatthewBonanni, @hickeyma, @majunze2001, @mrn3088, @Yejing-Lai, @vllmellm, @Saddss, @DarkLight1337, @hongxiayang, @m4r1k, @qli88, @jonathanc-n, @felix0080, @djramic, @aoshen02, @fxmarty-amd, @simon-mo, @llsj14, @akii96, @walterbm, @dmaniloff, @zlxi02, @grYe99, @jeffye-dev, @parthash0804, @qyYue1389, @sagearc, @maeehart, @TanNgocDo, @cinnamonica02, @zucchini-nlp, @tykow, @mganczarenko, @yangdian96, @jimmy-evo, @YellowFoxH4XOR, @yzhan1, @shenoyvvarun, @yufufi, @laviier, @xiaohuguo2023, @EanWang211123, @JartX, @shantipriya-amd, @askliar, @hallerite, @appleparan, @effi-ofer, @angelayi, @TheCodeWrangler, @DanBlanaru, @ankrovv, @velonica0, @pjdurden, @cyyever, @wjinxu, @kliukovkin, @x41lakazam, @Jasen2201, @r-barnes, @tc-mb, @nataliepjlin, @KaletoAI, @WineChord, @fangyuchu, @vraiti, @nascheme, @jjppp, @sasindharan, @xiaguan, @snadampal, @chfeng-cs, @thillai-c, @guan404ming, @sridhar-3009, @vincentzed, @j-i-l, @rjrock, @abinggo, @anony-mous-e, @Achyuthan-S, @Harry-Chen, @mfylcek, @amd-asalykov, @noa-neria, @maobaolong, @TheEpicDolphin, @FAUST-BENCHOU, @martin-kukla, @xin3he, @ZiguanWang, @youkaichao, @factnn, @llx-08, @xx-thomas, @gitbisector, @Bortlesboat, @thisisjimmyfb, @JOSH1024, @wendyliu235, @wangxiyuan, @shen-shanshan, @HanHan009527, @amd-lalithnc, @netanel-haber, @fuscof-ibm, @AjAnubolu, @carlyou, @abcd1927, @CienetStingLin, @kouroshHakha, @alexbi29, @jesse996, @sungsooha, @andakai, @cquil11, @nehmathe2, @liangel-02, @hello-args, @j9smith, @nikhilesh-csa, @ruocco, @oguzhankir, @yiliu30, @xaguilar-amd, @amirkl94, @danisereb, @wangjiaxin99, @shanjiaz, @Oseltamivir, @alexeldeib, @wzhao18, @coder3101, @lyd1992, @markmc, @ashishpatel26, @HumphreySun98, @ByteFlowing1337, @nv-nedelman-1, @JaredforReal, @sammshen, @okorzh-amd, @muhammadfawaz1, @vadiklyutiy, @JasonLi314, @SumanthRH, @Sirius29, @tjtanaa, @zhangshuoming990105, @amanchugh89, @umut-polat, @srajabos, @junkang1991, @pst2154, @WindChimeRan, @Zedong-Liu, @gq112, @sunnweiwei, @athrael-soju, @EazyReal, @Liangliang-Ma, @jinzhen-lin, @V-3604, @aarushjain29, @ZewenShen-Cohere, @Bot1822, @BowenBao, @MichaelCao0, @tanpinsiang, @QwertyJack, @nagisa-kunhah, @Meihan-chen, @robertgshaw2-redhat

--- a/claude-skills/vllm-release-notes/examples/v0.25.0/release-notes.md
+++ b/claude-skills/vllm-release-notes/examples/v0.25.0/release-notes.md
@@ -1,0 +1,152 @@
+# vLLM v0.25.0 Release Notes
+
+## Highlights
+
+This release features 558 commits from 232 contributors (64 new)!
+
+* **Model Runner V2 is now the default for all dense models** (#44443). Building on quantized-model support from the previous release, MRv2 is now the standard execution path, with new support for EVS (#46535), realtime embeddings (#46762), prefix caching for Mamba hybrid models (#42406), multimodal-prefix bidirectional attention (#46942), and dynamic speculative decoding compatible with full CUDA graphs (#45953).
+* **PagedAttention has been removed** (#47361). The legacy attention implementation is deleted now that V1/MRv2 backends are the standard path.
+* **The Transformers modeling backend is now as fast as native vLLM** (#47187), and gained FP8 MoE support (#46820), CUDA graph + embed scaling fixes (#48010), and migration of GPTBigCode/Starcoder2 (#30966) and RoBERTa (#47452).
+* **New models**: LLaVA-OneVision-2 (#44785), Unlimited OCR (#46564, #47102), MOSS-Transcribe-Diarize (#47729), openai/privacy-filter (#41026), and Hy3 (#47192). GLM-5 / DeepSeek-V3.2 landed in the model zoo (#46808) with GLM-5.2 tuning, and MiniMax-M3 gained pipeline parallelism (#45810) and NVFP4 support (#46756).
+* **New Streaming Parser Engine** (#46610) — a unified tool-call/reasoning parsing framework, with a new Kimi k2.5/k2.6/k2.7 parser and ports of seed_oss (#46314) and DeepSeek V4 (#45877). The Rust frontend continues to mature with HTTPS/mTLS (#45890), a DP supervisor (#47076), and profiler control routes (#46306).
+* **Universal speculative decoding for heterogeneous vocabularies (TLI)** (#38174), plus new DSpark (#46995) and DFlash (#46770, #46853) drafters.
+
+### Model Support
+* New models: LLaVA-OneVision-2 (#44785), Unlimited OCR (#46564) with a Triton R-SWA backend (#47102), MOSS-Transcribe-Diarize (#47729), openai/privacy-filter (#41026), Hy3 with token-suffix and JSON Schema array support (#47192).
+* GLM-5 family: GLM-5 / DeepSeek-V3.2 added to the model zoo (#46808), GLM-5.2 FP32 gate (#47410), GLM MTP post-final-norm fix (#47448), GLM4V startup fix (#47155).
+* MiniMax-M3: pipeline parallelism (#45810), streaming reasoning parsing (#45718), and `tok_sparse_select` from MSA replacing Triton kernels (#47502).
+* Transformers backend: now as fast as native vLLM (#47187), FP8 MoE fix (#46820), embed scaling + CUDA graph fix (#48010), GPTBigCode/Starcoder2 (#30966) and RoBERTa (#47452) migration, M-RoPE `mm_token_type_ids` fix (#46552), tied-embedding `lm_head.bias` fix (#46835).
+* Voxtral: migrated to mistral-common 1.11.5 audio API (#46705) and realtime token-feedback hang fix (#44461).
+* Gemma family: Gemma4 sliding-window/FA4 attention fixes (#47217, #47332), Gemma4 MTP quant_config fix (#47091); DiffusionGemma tensor parallelism (#45719) and HF stability-window semantics (#45965).
+* Other fixes: MiniCPM-V 4.6 language-backbone LoRA (#46740) and placeholder grid fix (#45918), pooled Whisper sliding-window sizing (#47071, #47437), Mamba/Mamba2 checkpoint-without-`architectures` crash fix (#46037), DeepSeek-V2 hidden-size and aux-hidden-state fixes (#46986, #46973).
+
+### Engine Core
+* Model Runner V2: default for all dense models (#44443); EVS (#46535), realtime embeddings (#46762), Mamba hybrid prefix caching (#42406), multimodal-prefix bidirectional attention (#46942), cross-attention warmup/block-table fixes (#46753, #47308), Mamba2 crash fix (#47428), scheduling slot accounting (#46974), model-ref cleanup on shutdown (#47483), bounded memory for large-logprobs requests (#46746).
+* Speculative decoding: universal spec decode for heterogeneous vocabularies (TLI) (#38174); DSpark drafter + speculators checkpoint support (#46995, #47093); DFlash backend selection (#46770), per-layer RMSNorm fusion (#46761), CPU support (#44029), SWA+DFlash for MiMo (#46104), Laguna XS.2.1 drafter (#46853); MTP for Bailing hybrid models (#44880); block verification for rejection sampling (#46781); reduced TP communication for draft tokens (#46448).
+* Sleep mode: pluggable sleep-mode backend abstraction (RFC #34303, #44074) with communicator-agnostic capability flags (#47243).
+* Attention: FlashAttention block-size restriction removed for hybrid models (#36701), `FLASH_ATTN_MLA_SPARSE` Hopper sparse-MLA backend (#46189), DCP + FP8 KV cache in MLA decode (#44044), XQA decode kernels (#43232).
+* KV offloading: tiering metric plumbing (#45959), request lifecycle fix (#46284), batched lookup in C (#46713), `LookupResult` enum (#46363).
+* Misc: `VLLM_GPU_SYNC_CHECK` env var (#44800), VRAM semaphore infrastructure (#44465), skip detokenization in online beam search (#46422), several int32-overflow fixes in sampler/attention kernels (#46560, #47383, #47671).
+
+### Hardware & Performance
+* GLM-5.2 / DeepSeek: `fused_indexer_q_rope_quant` Triton kernel (1.9–3.3% E2E throughput) (#46862), reduce-scatter MoE all-reduce (3.1–3.2% E2E) (#46635), op fusion for GLM5/DSV3.2 (#46876), `token_to_req_indices` cache for DSv4 (5–6x kernel speedup) (#47474), better DSv4 MXFP8 kernel (#47229), redundant-op removal (#47198, #46651).
+* NVIDIA/Blackwell: FlashInfer fused all-reduce tuned for world_size=16 on GB300 (#46392), restored NVFP4 swizzled-scale zero-init to recover Blackwell decode throughput (#45739), CuTeDSL/FA4-MLA warmup infrastructure (#46182), skip cooperative top-K on SM120 (#47164), B12x backend for non-gated MoEs (#43328).
+* Kernels: Helion `fused_qk_norm_rope` (#44010) and `silu_and_mul_per_block_quant` (#43994), Triton MLA logits workspace (#46819), swap-AB optimization for fused MoE (#36559), vectorized fp32 `moe_sum` supporting any top-k (#46643), blocking CUDA events to avoid busy-polling the driver lock (#47081).
+* AMD/ROCm: moved to torch 2.11 stable ABI (#47128); AITER FlashAttention MLA prefill backend `ROCM_AITER_FA` (#45033); fused shared-expert for GLM-4.5/6/7 (#44313) and MiniMax-M3 (#46474, #46545); AITER MoE optimization for DeepSeek-V4 (#46122); AITER custom all-reduce in CudaCommunicator (#46065); INT3 quantization for quickreduce (#45666).
+* Intel XPU: W8A8 FP8 linear kernel with multi-granularity quant (#43645), pipeline-parallel accuracy fix (#47253), uniform-batch CUDA graph for FA2 (#46555), route mm_prefix models to Triton attention (#47688), C++ `get_memory_info` (#47134).
+* CPU: accelerated unquantized MoE for AArch64 (#46353), macOS/Apple Silicon hang fix via OpenMP (#46769) and broken-install fix (#47457), compressed-tensor w8a8 int8 MoE (#42920), Mamba ShortConv (#35059), chunked prefill + prefix caching for Qwen3.5 (#46202), faster gelu via tanh AOR (#44639).
+* RISC-V: RVV path for W4A8 INT4 GEMM (#45269), BF16 on VLEN=256 hardware (#45243), reduced LMUL pressure in INT4 LUT dequant (#47538). POWER: fp16 support on PowerPC (#46135).
+* Platform: accelerator-agnostic `get_memory_info` (#44825).
+
+### Large Scale Serving & Distributed
+* Sequence parallelism without requiring DP, 1.9–5.0% E2E throughput improvement (#47070).
+* Distributed: NCCL symmetric memory extended to AllGather and ReduceScatter (#46703), FlashInfer all-reduce defaults to MNNVL on single node (#47219, #47589), fault-tolerance backend to detect all2all peer faults and prevent corrupted output (#43637).
+* Data parallel: throttle prefills based on local prefill work (#46532), rotate load-balancer tie-break to avoid engine bias (#47420), DP supervisor via the Rust frontend (#47076), DP MTP hang fix (#40589).
+* PD disaggregation: secondary-tier implementation (#42285), Mooncake connector GDN (Qwen3.5) + MLA (DeepSeek-V4-Flash) support (#46807), NIXL Mamba1 support (#45019), MultiConnector `kv_transfer_params` merging (#46777), usage field exposed for disaggregated serving (#42748).
+* DCP: FlashInfer MLA support (#43729), FLASHINFER_MLA_SPARSE support (#46076), LSE log-base fixes (#47079); Mooncake parallelized KV load (#45971) and DCP>1 lookup fix (#46855).
+* ROCm: stabilized high-throughput DBO for DP+EP (#46990), EPLB for Quark OCP MXFP4 MoE (#47220).
+
+### Quantization
+* 2/3/5/6/7-bit pack-quantized weight-only inference (Humming) (#46389), Triton INT4 per-token-head KV cache quantization (#40835).
+* NVFP4: fused weight dequantization with compute in the MoE MLP Triton kernel (#44667), NVFP4 KV cache with skip-layers sliding window (#42890), MiniMax-M3 ModelOpt NVFP4 support (#46756).
+* FP8: weights padding for per-block online quantization (#44763); deprecated the old FP8 online MoE quantization class (#44514).
+* Marlin: thread-tile padding extended to MoE (WNA16 + FP8/MXFP8) (#45703), int8 grouped WNA16 MoE (#47154); FlashInfer MXINT4 MoE for gated SiLU (#46518).
+* Fixes: W8A8 int-quant scheme-selection regression (#46860), tied quantized embeddings for ModelOpt Gemma4 (#45544), NVFP4+MTP crash on Qwen3Next (#46316), ModelOpt mixed-precision for sparse configs (#47318), CPU w4a8_int8 MoE path (#46739), actionable error on group-size/TP mismatch (#46230).
+
+### API & Frontend
+* Streaming Parser Engine (#46610): unified tool-call/reasoning parsing with a new Kimi k2.5/k2.6/k2.7 parser; ported seed_oss (#46314) and DeepSeek V4 (#45877).
+* OpenAI compatibility: Responses API namespace tools (#47024), per-request timing `metrics` field on Chat/Completions responses (#46768), token offsets on render endpoints (#44226), `return_loss_mask` for training-data generation (#46846), HTTP 422 for unprocessable image URLs (#47165).
+* gpt-oss / Harmony: dedicated Harmony renderer (#46800), `process_eos()` flush (#46437), raw-output recovery on non-terminal parse (#47062, #47379).
+* Rust frontend: static HTTPS and mTLS for HTTP and gRPC (#45890), DP supervisor (#47076), profiler control routes (#46306), `repetition_detection` sampling param (#46684), unified/combined parser interface (#46583), reduced multimodal tensor copies (#47581), plus many parser and validation fixes.
+* Video: TorchCodec added as a video decoding backend (#46609).
+* CLI/UX: TTFT and TPS printing in `vllm chat` (#46775), `model_class_overrides` for development/debugging (#47148).
+* Tooling/validation: many tool-parser fixes (Kimi K2 IDs #46344, PoolsideV1 #46486/#47311, non-ASCII arguments #46308, `thinking_token_budget` re-entry #43757); rejection of invalid config values (#44070, #44002, #46612) and degenerate `structured_outputs` that crash EngineCore (#45346).
+
+### Security
+* Prevent image decompression-bomb OOM denial of service (#47010).
+* Prevent an infinite loop in `split_audio` with NaN audio samples (#46463).
+* Bound tokenizer work when an explicit `truncation_side` is set (#47007).
+* Block request-level GPU video backend selection (#47259).
+* Document the gRPC interface as insecure, for private use only (#45903).
+
+### Dependencies
+* FlashInfer 0.6.13 (#46683), tpu-inference v0.23.0 (#46568), aiter 0.1.16.post2 (#46692), vllm_xpu_kernels v0.1.10.1 (#46607), huggingface-hub v1.22.0 (#47551).
+* DeepGEMM updated to enable SM120 support (#47304), FlashAttention 3 built against the torch stable API (#46644), Rust frontend TLS switched from rustls to native-tls/OpenSSL (#46696).
+
+### Deprecations & Removals
+* **PagedAttention deleted** (#47361).
+* Models removed: Baichuan (#46362), Aquila (#46605), Grok (#46706), Tarsier / Tarsier2 (#47143), AyaVision / MusicFlamingo (#47263), Mantis (#46806).
+* Deprecated the old FP8 online MoE quantization class (#44514); legacy `api_server.py` moved to the examples directory (#46783); `gptq_marlin` removed from supported ROCm quant schemes (#46655).
+
+## New Contributors
+
+* @aaarkai made their first contribution in https://github.com/vllm-project/vllm/pull/44610
+* @Acaciasama made their first contribution in https://github.com/vllm-project/vllm/pull/45850
+* @ACEEE-1222 made their first contribution in https://github.com/vllm-project/vllm/pull/47716
+* @adamkbaranowski made their first contribution in https://github.com/vllm-project/vllm/pull/46853
+* @AgenticSpark made their first contribution in https://github.com/vllm-project/vllm/pull/46071
+* @AIvashov made their first contribution in https://github.com/vllm-project/vllm/pull/42748
+* @akinsella made their first contribution in https://github.com/vllm-project/vllm/pull/47165
+* @aldenlobo made their first contribution in https://github.com/vllm-project/vllm/pull/45961
+* @alex101-ops made their first contribution in https://github.com/vllm-project/vllm/pull/44880
+* @aman0603 made their first contribution in https://github.com/vllm-project/vllm/pull/46945
+* @Aneureka made their first contribution in https://github.com/vllm-project/vllm/pull/46838
+* @ArsalanShakil made their first contribution in https://github.com/vllm-project/vllm/pull/46236
+* @ayush1399 made their first contribution in https://github.com/vllm-project/vllm/pull/47091
+* @blasrodri made their first contribution in https://github.com/vllm-project/vllm/pull/46827
+* @calvarado2004 made their first contribution in https://github.com/vllm-project/vllm/pull/46177
+* @chengzheng345 made their first contribution in https://github.com/vllm-project/vllm/pull/44785
+* @cpersson-amd made their first contribution in https://github.com/vllm-project/vllm/pull/47519
+* @cyq1017 made their first contribution in https://github.com/vllm-project/vllm/pull/46101
+* @davispuh made their first contribution in https://github.com/vllm-project/vllm/pull/35232
+* @decarpentierg made their first contribution in https://github.com/vllm-project/vllm/pull/46552
+* @eparshut made their first contribution in https://github.com/vllm-project/vllm/pull/47467
+* @fenghourun made their first contribution in https://github.com/vllm-project/vllm/pull/47384
+* @fjosw made their first contribution in https://github.com/vllm-project/vllm/pull/41026
+* @guybd made their first contribution in https://github.com/vllm-project/vllm/pull/44029
+* @harsha20032020 made their first contribution in https://github.com/vllm-project/vllm/pull/44720
+* @hclsys made their first contribution in https://github.com/vllm-project/vllm/pull/44070
+* @hhhhhhhhhhhhhhhhho made their first contribution in https://github.com/vllm-project/vllm/pull/46467
+* @hillelda made their first contribution in https://github.com/vllm-project/vllm/pull/46069
+* @I3eg1nner made their first contribution in https://github.com/vllm-project/vllm/pull/47532
+* @imargulis made their first contribution in https://github.com/vllm-project/vllm/pull/46301
+* @ItsMatti4 made their first contribution in https://github.com/vllm-project/vllm/pull/45263
+* @jesco-absolut made their first contribution in https://github.com/vllm-project/vllm/pull/47589
+* @jessiewei7 made their first contribution in https://github.com/vllm-project/vllm/pull/46560
+* @jialoop-git made their first contribution in https://github.com/vllm-project/vllm/pull/45159
+* @JohnLangford made their first contribution in https://github.com/vllm-project/vllm/pull/46835
+* @Jyothirmaikottu made their first contribution in https://github.com/vllm-project/vllm/pull/47250
+* @kalyanamdewri made their first contribution in https://github.com/vllm-project/vllm/pull/47517
+* @Laurent-Zhang made their first contribution in https://github.com/vllm-project/vllm/pull/47429
+* @lcheng321 made their first contribution in https://github.com/vllm-project/vllm/pull/45715
+* @LiJzd made their first contribution in https://github.com/vllm-project/vllm/pull/45813
+* @lslusarczyk made their first contribution in https://github.com/vllm-project/vllm/pull/43092
+* @Lynn-hh made their first contribution in https://github.com/vllm-project/vllm/pull/46543
+* @Meihan-chen made their first contribution in https://github.com/vllm-project/vllm/pull/44483
+* @nagisa-kunhah made their first contribution in https://github.com/vllm-project/vllm/pull/44124
+* @NathanielMcVicar made their first contribution in https://github.com/vllm-project/vllm/pull/45965
+* @NicolasHug made their first contribution in https://github.com/vllm-project/vllm/pull/46609
+* @omirosh made their first contribution in https://github.com/vllm-project/vllm/pull/44313
+* @orestis-z made their first contribution in https://github.com/vllm-project/vllm/pull/46488
+* @pranavthakur0-0 made their first contribution in https://github.com/vllm-project/vllm/pull/46306
+* @Priyjain-amd made their first contribution in https://github.com/vllm-project/vllm/pull/45818
+* @skajre made their first contribution in https://github.com/vllm-project/vllm/pull/46818
+* @soaringk made their first contribution in https://github.com/vllm-project/vllm/pull/45810
+* @spandantiwari made their first contribution in https://github.com/vllm-project/vllm/pull/46260
+* @sriganesh123 made their first contribution in https://github.com/vllm-project/vllm/pull/35076
+* @tarjan1 made their first contribution in https://github.com/vllm-project/vllm/pull/45657
+* @thisjiang made their first contribution in https://github.com/vllm-project/vllm/pull/45924
+* @umarkovi-amd made their first contribution in https://github.com/vllm-project/vllm/pull/46381
+* @VectorPeak made their first contribution in https://github.com/vllm-project/vllm/pull/47099
+* @wan-danfeng made their first contribution in https://github.com/vllm-project/vllm/pull/38174
+* @yangyang-cs95 made their first contribution in https://github.com/vllm-project/vllm/pull/46684
+* @yuyue0225sc made their first contribution in https://github.com/vllm-project/vllm/pull/44297
+* @zhongjing123 made their first contribution in https://github.com/vllm-project/vllm/pull/47024
+* @zhou9402 made their first contribution in https://github.com/vllm-project/vllm/pull/47448
+* @ZichenYuan made their first contribution in https://github.com/vllm-project/vllm/pull/46452
+
+## Contributors
+
+Thank you to all the contributors who made this release possible!
+
+@AndreasKaratzas, @njhill, @BugenZhao, @hmellor, @yewentao256, @WoosukKwon, @Sunt-ing, @micah-wil, @mgoin, @reidliu41, @peizhang56, @mawong-amd, @TheEpicDolphin, @jeejeelee, @taneem-ibrahim, @chaunceyjiang, @chaojun-zhang, @divakar-amd, @fxmarty-amd, @LopezCastroRoberto, @wzhao18, @mayuyuace, @jperezdealgaba, @noooop, @yzong-rh, @jikunshang, @zxd1997066, @bigPYJ1151, @yma11, @hickeyma, @benchislett, @xianbaoqian, @andakai, @NickLucche, @ivanium, @joerowell, @EazyReal, @mganczarenko, @majunze2001, @hongxiayang, @WindChimeRan, @Rohan138, @tjtanaa, @bbrowning, @thisjiang, @Fangzhou-Ai, @blasrodri, @Isotr0py, @zhenwei-intel, @zyongye, @frida-andersson, @muhammadfawaz1, @lcheng321, @spandantiwari, @Palaiologos1453, @soaringk, @Lynn-hh, @fadara01, @djramic, @Liangliang-Ma, @ronensc, @aarushjain29, @HDCharles, @qianlihuang, @AgenticSpark, @charlifu, @cleonard530, @shen-shanshan, @xaguilar-amd, @xiaohongchen1991, @varun-sundar-rabindranath, @gau-nernst, @tahsintunan, @GirasoleY, @hclsys, @Yejing-Lai, @LucasWilkinson, @matteso1, @akii96, @atalman, @lucianommartins, @I3eg1nner, @rahulssv-ibm, @ZichenYuan, @tanpinsiang, @hillelda, @Srinivasoo7, @Etelis, @Rukhaiya2004, @Oxygen56, @Priyjain-amd, @GuyStone, @nholmber, @CienetStingLin, @xinyu-intel, @JartX, @esmeetu, @hhhhhhhhhhhhhhhhho, @harsha20032020, @walterbm, @Acaciasama, @jessiewei7, @ashwin-phadke, @shivampr, @cyq1017, @kjiang249, @orestis-z, @xyang16, @tianmu-li, @mgehre-amd, @aaarkai, @guybd, @wcynb1023, @Josephasafg, @qyYue1389, @russellb, @haoyangli0109, @sfeng33, @mikekg, @EanWang211123, @ovidiusm, @ItsMatti4, @hyeongyun0916, @qli88, @juliendenize, @calvarado2004, @tdoublep, @brandonpelfrey, @davispuh, @weizhoublue, @jasonozuzu-cohere, @wentian-byte, @skajre, @gty111, @omirosh, @decarpentierg, @fjosw, @ilmarkov, @yuwenzho, @JisoLya, @JohnLangford, @aldenlobo, @bnellnm, @jasonlizhengjian, @zufangzhu, @izhuhaoran, @MatthewBonanni, @deng451e, @ashwing, @sriganesh123, @linitra24, @liranschour, @umarkovi-amd, @aman0603, @adobrzyn, @jwzheng96, @eicherseiji, @ArsalanShakil, @tc-mb, @imargulis, @fangyuchu, @puririshi98, @JeanPaulShapo, @VectorPeak, @tarjan1, @qiching, @Achyuthan-S, @ZJY0516, @lucifer1004, @cinnamonica02, @jmamou, @almayne, @hao-aaron, @Jyothirmaikottu, @andylolu2, @AIvashov, @stevenkuang-tencent, @lcskrishna, @Aneureka, @wan-danfeng, @chengzheng345, @pranavthakur0-0, @zRzRzRzRzRzRzR, @DanBlanaru, @adamkbaranowski, @wendyliu235, @eparshut, @yangyang-cs95, @kalyanamdewri, @maxdebayser, @fenghourun, @tpopp, @okorzh-amd, @labAxiaoming, @sychen52, @ekagra-ranjan, @gausah01, @yuyue0225sc, @cpersson-amd, @lslusarczyk, @alex101-ops, @Zhenzhong1, @velonica0, @zhongjing123, @zhou9402, @llsj14, @majian4work, @akinsella, @BadrBasowid, @afierka-intel, @ayush1399, @LiJzd, @jesco-absolut, @Laurent-Zhang, @Kevin-XiongC, @NathanielMcVicar, @askliar, @ACEEE-1222, @jinzhen-lin, @SherryC41, @simondanielsson, @nv-nedelman-1, @yisustc, @kylesayrs, @jialoop-git, @NicolasHug, @guan404ming, @HumphreySun98, @danielafrimi, @gcanlin, @robertgshaw2-redhat

--- a/claude-skills/vllm-release-notes/examples/v0.25.1/release-notes.md
+++ b/claude-skills/vllm-release-notes/examples/v0.25.1/release-notes.md
@@ -1,0 +1,19 @@
+# vLLM v0.25.1
+
+## Highlights
+
+This release features 2 commits from 2 contributors (1 new)!
+
+v0.25.1 is a patch release containing two targeted bug fixes on top of v0.25.0.
+
+### Bug Fixes
+* **Avoid blocking model launching when no system FFmpeg is available for TorchCodec** (#47888). Previously `import torchcodec` raised a `RuntimeError` at import time when system FFmpeg was missing, which blocked startup (e.g. `vllm serve Qwen/Qwen3-VL-2B-Instruct`) even when TorchCodec was not in use. The error is now deferred to runtime so it only surfaces if TorchCodec is actually needed.
+* **Guard mixed-dtype allreduce RMSNorm quant fusions** (#48330). The fused FlashInfer allreduce + RMSNorm + static-quantization patterns could match graphs where the activation and RMSNorm weight dtypes differ (e.g. a BF16 residual stream with an FP32 Gemma/Qwen-style RMSNorm weight in NVFP4 models), corrupting the hidden state and producing garbage output such as repeated `!!!!!` tokens. A dtype-match guard now routes incompatible mixed-dtype graphs to the safe path, while same-dtype models retain the full allreduce + RMSNorm + quant fusion.
+
+## Contributors
+
+@Isotr0py, @hugo-cen
+
+## New Contributors
+
+* @hugo-cen made their first contribution in https://github.com/vllm-project/vllm/pull/48330

--- a/claude-skills/vllm-release-notes/examples/v0.26.0/release-notes.md
+++ b/claude-skills/vllm-release-notes/examples/v0.26.0/release-notes.md
@@ -1,0 +1,141 @@
+# vLLM v0.26.0 Release Notes
+
+## Highlights
+
+This release features 411 commits from 212 contributors (61 new)!
+
+* **New Inkling model family** with a full support stack: base modeling (#48799), piecewise CUDA graph support (#48822), Hopper FA4 relative attention (#48858), MTP=1 speculative decoding (#48869), LoRA (#48884), and standard ModelOpt NVFP4 quantization (#48990).
+* **DeepSeek-V4 performance push** across vendors: a specialized routing kernel (2.94% E2E TPOT, #48660), `fused_topk_bias` (1.5–2x kernel, #47463), and redundant repeat/copy removal (1.8% E2E TPOT, #48137), plus ROCm two-stage compressor for HCA prefill (#47718), sparse decode/prefill optimizations (#48519, #48788, #46275), and DSpark speculative decoding on AMD (#47419) and XPU (#47677).
+* **fp32 `lm_head` for generation models via `head_dtype`** (#48390), extended to the LoRA path (#48525) and given a ROCm `torch.mm` fast path (#48688), improving accuracy for generation heads.
+* **Flexible attention backends**: the attention backend can now be selected per KV-cache group (#48012), and sliding-window support is now an explicit backend capability (#48011) — improving support for hybrid models.
+* **KV offloading & tiered secondary storage** matured substantially: offloading metrics (#45958, #47666, #47679), tier-owned event handling (#46544, #47923), object-store secondary tier with workload identity (#47063, #47274, #48150), DP-replica-aware tiering (#47987), and encoder-cache (EC) connectors including CPU offloading (#42433, #47423).
+* **Rust frontend** gained multimodal video (#47959) and audio (#48554), a Seed-OSS tool parser (#47741), and a native `vllm-bench` port (#48107).
+* **Transformers 5.13.0** (#47867) with more models migrated to the Transformers modeling backend: Olmo/Olmo2 (#48100), MistralLarge3 (#48153), and HunyuanVL (#47872).
+
+### Model Support
+* New models: Inkling family (#48799, #48822, #48858, #48869, #48884, #48990), BertForMaskedLM (#48463), RobertaForTokenClassification / XLMRobertaForTokenClassification (#47991), LongCat-Flash-Lite n-gram embedding (#47857), Cosmos3 Edge Reasoner (#48291) and Cosmos3-Super registration (#48211), TranslateGemma-12b-it (#41599).
+* Transformers backend migrations: Olmo/Olmo2 (#48100), MistralLarge3 to AutoWeightsLoader (#48153), HunyuanVL native transformers processor for transformers 5.13 (#47872).
+* GLM5.2: migrate MoE sequence-parallel support to the non-torch-compiled path (#47881).
+* LoRA: FlashInfer MoE LoRA for BF16 models (#48632), LoRA for tower/connector in LlavaNextVideo (#48594), fp32 `lm_head` on the LoRA path (#48525), optimized `TrtLlmLoRAExperts` (#48759).
+* Multimodal: automatic fallback to ViT data parallelism when TP is unavailable (#49046).
+* Fixes: correct pooling scores for chunked prefill under `torch.compile` (#48901).
+
+### Engine Core
+* fp32 `lm_head` for generation models via `head_dtype` (#48390); lower memory for capturing large CUDA graph sizes (#48483); opt-in persistence and reuse of the memory-profiling result across boots (#47388); improved InstantTensor loading (#46868).
+* Attention: select a different attention backend per KV-cache group (#48012); sliding-window as an explicit backend capability (#48011); KV-cache layout refactor packing K/V into the content dim across backends (#44455); MRV2 virtual-batch PCP for MLA (#46570).
+* Speculative decoding: runtime draft weight update (#46725), hybrid (SWA + full attention) DFlash drafters (#47914), SWA support for qwen-eagle3 (#47568), Gemma4-12B DSpark draft model (#47216), DSv4 DSpark on AMD (#47419), separate `kv_cache_dtype` for `speculative_config` (#48787).
+* KV offloading: basic offloading metrics (#45958), split CPU cache usage into read/write gauges (#47666) and tiering-lookup-delay into sync/async histograms (#47679), tier-owned event handling and BlockStored events (#46544, #47923), object-store secondary tier with workload identity (#47063, #47274, #48150), DP-replica-aware tiering (#47987), `blocks_per_chunk` config for heterogeneous KV groups (#48878), P2P default host/port env vars (#47636).
+* Caching: partial prefix-cache hit for hybrid models (#46384), selective hybrid cache retention (#47782), report prefix-cache-reused blocks in full report mode (#45261).
+* Reasoning: optimize TPOT for thinking budget when used with speculative decoding (#46662).
+* RLHF: stateful trainer-send abstractions (#48042).
+* Fixes: host memory leak from undrained `new_block_ids` (#44490), DSv3.2 + MTP + sequence-parallel accuracy (#48036).
+
+### Hardware & Performance
+* DeepSeek-V4: specialized routing kernel (2.94% E2E TPOT, #48660), `fused_topk_bias` 1.5–2x (#47463), redundant repeat/copy removal (1.8% TPOT, #48137).
+* MoE router GEMMs: BF16x3 router GEMM (#47973), FP32 router GEMV (#48335), generic CuteDSL LL BF16 router GEMM (#42562); TRTLLM BF16 MoE modular kernel (#45182); write FlashInfer combine into final output (#47156).
+* Qwen: fuse more RMSNorm + all-reduce in Qwen3.5 (#46998), replace MoE all-reduce with reduce-scatter (#47006), Qwen3.5 H20 optimization (#48350), expand Triton warmup coverage (#47546).
+* MLA: dense MHA path for short sparse-MLA sequences (#47327); MiniMax-M3 long-context decode indexer on sm100 (#48582).
+* Kernels: CUDA kernel for ReLUSquaredActivation / relu^2 (#39058), Helion kernel lazy registration (#48264), vectorize `_copy_mamba_state_block` to uint64 (#48110), stop upcasting logits to fp32 in the sampler (#48641).
+* ROCm: fp32 `head_dtype` `torch.mm` fast path (#48688), DSv4 two-stage compressor kernel (#47718), sparse decode/prefill optimizations (#48519, #48788, #46275), DSv3.2 sparse MLA KV-split heuristic (#46832) and MTP CUDA-graph mode (#45149), MXFP8 GEMM for MiniMax-M3 (#46117), AITER sparse paged attention + spec decode for MiniMax-M3 (#47287, #47984), MiniMax-M2 fused QK-norm + all-reduce via AITER (#44849), HybridW4A16 linear kernel (#40977), Qwen3-30B-A3B QK-Norm+RoPE+KV runtime fusion (#42749).
+* XPU: batch-invariant kernels (#41934), HND KV layout support (#47975), DSpark spec decode for DSv4 (#47677), nightly/release image publishing (#47880, #48126).
+* CPU: DFlash speculative decoding for GDN models on CPU (#46090), s390x NUMA topology (#40714), native macOS arm64 CPU wheel builds (#48289); POWER VSX math function optimization (#47321) and IBM Power docker builds using prebuilt wheels (#46017).
+* Distributed fusion: FlashInfer MNNVL all-reduce RMS quant fusion (#48064).
+* Build/autotune: arm64 Blackwell SM10x/SM110 image builds (#48041); skip CuTeDSL fp4_gemm autotuning by default (#48268).
+
+### Large Scale Serving & Distributed
+* Decode Context Parallel (DCP): hybrid attention support (#40996), DCP + Eagle for Tokenspeed MLA backends (#48180).
+* PD disaggregation: NIXL pipeline-parallel prefill in push mode (#45880).
+* Encoder-cache connectors: EC transfer params (#42433) and CPU-offloading EC connector (#47423).
+
+### Quantization
+* Humming w[2-7]a[4,8] weight-only inference with compressed-tensors (#46390); int4 quantization for the emulation MoE backend (#48451); INT2 XPU weight-only quant linear (#47521).
+* NVFP4/MXFP4: `nvfp4_per_token` online MoE quantization (#48538), CuTe-DSL FlashInfer MXFP4 quantization (#48417); bounded peak memory when repacking FP4 MoE weights for Marlin (#47851) and for NVFP4 MoE weight loading (#46276).
+* MLA: `kv_cache_dtype_skip_layers` support (#47309).
+* ROCm: HybridW4A16 linear kernel (#40977).
+
+### API & Frontend
+* Rust frontend: multimodal video (#47959) and audio (#48554), Seed-OSS tool parser (#47741), native `vllm-bench` port (#48107), `continue_final_message` handling with renderer sentinel (#47844).
+* OpenAI compatibility: `bad_words` in `/v1/completions` (#46793), expose `logprob_token_ids` on Python OpenAI endpoints (#43463), `include_reasoning` param for non-Harmony models (#44301), populate `num_cache_creation_tokens` on Messages responses (#48535).
+* Endpoint plugins framework (#47454); `/abort_requests` on the RLHF dev API router (#47173); Deepstream video decoding backend (#42424); overlap preprocessing and computation for pooling models in offline inference (#47699).
+* UX: human-readable integers for more CLI args (#47608), CuTeDSL compilation progress bar (#48881), expanded GPU profiler config scope/annotations (#37524), log worker exit code when a process dies unexpectedly (#38641).
+* Stability/correctness: handle grammar compilation failures without crashing the engine (#47312), fix logprobs token-string collision from SentencePiece spaces (#48674).
+
+### Security
+* Replace diskcache to eliminate pickle deserialization (#44549).
+* Fix a concurrent sparse-invariant race that bypassed CVE remediation (#48583).
+* Add resource-bounds validation to derender endpoints (#47260); sanitize server file paths from validation error responses (#46415); bound the completion prompt list to prevent unbounded engine fan-out (#47845); guard lm-format-enforcer regex compilation with a timeout (#47595).
+
+### Dependencies
+* Transformers 5.13.0 (#47867), FlashInfer 0.6.14 (#47669), NIXL 1.3.1 (#47559), tpu-inference v0.24.0 (#47835), nvidia-cutlass-dsl 4.6.0 (#47442), vllm_xpu_kernels v0.1.11.1 (#48942).
+* FlashAttention 3 pinned to the torch stable-ABI commit (#47995); ABI-stable FlashMLA build (#48174).
+
+### Deprecations & Removals
+* Models removed: TeleChat (#47989), Persimmon and Fuyu (#48096).
+
+## New Contributors
+
+* @adhi29 made their first contribution in https://github.com/vllm-project/vllm/pull/48262
+* @adsridhar made their first contribution in https://github.com/vllm-project/vllm/pull/48291
+* @alexxu-roblox made their first contribution in https://github.com/vllm-project/vllm/pull/48025
+* @amd-ethany made their first contribution in https://github.com/vllm-project/vllm/pull/46117
+* @AndyDai-nv made their first contribution in https://github.com/vllm-project/vllm/pull/48507
+* @aoright made their first contribution in https://github.com/vllm-project/vllm/pull/47797
+* @ap9272 made their first contribution in https://github.com/vllm-project/vllm/pull/43896
+* @avalliappan-nvidia made their first contribution in https://github.com/vllm-project/vllm/pull/47460
+* @brijrajk made their first contribution in https://github.com/vllm-project/vllm/pull/44349
+* @Debasish-87 made their first contribution in https://github.com/vllm-project/vllm/pull/48878
+* @devalshahamd made their first contribution in https://github.com/vllm-project/vllm/pull/37524
+* @DiegoCao made their first contribution in https://github.com/vllm-project/vllm/pull/47216
+* @drakosha made their first contribution in https://github.com/vllm-project/vllm/pull/46972
+* @edwinlim0919 made their first contribution in https://github.com/vllm-project/vllm/pull/47495
+* @ErenAta16 made their first contribution in https://github.com/vllm-project/vllm/pull/48333
+* @Functionhx made their first contribution in https://github.com/vllm-project/vllm/pull/48153
+* @gangula-karthik made their first contribution in https://github.com/vllm-project/vllm/pull/48594
+* @Gavin-Morris-04 made their first contribution in https://github.com/vllm-project/vllm/pull/48293
+* @giuseppegrossi made their first contribution in https://github.com/vllm-project/vllm/pull/48159
+* @GongLei-HW made their first contribution in https://github.com/vllm-project/vllm/pull/45261
+* @guoriyue made their first contribution in https://github.com/vllm-project/vllm/pull/48211
+* @hugo-cen made their first contribution in https://github.com/vllm-project/vllm/pull/48330
+* @ibondarenko1 made their first contribution in https://github.com/vllm-project/vllm/pull/43117
+* @iyastreb made their first contribution in https://github.com/vllm-project/vllm/pull/48209
+* @jacklin78911-collab made their first contribution in https://github.com/vllm-project/vllm/pull/47744
+* @jhu960213 made their first contribution in https://github.com/vllm-project/vllm/pull/42749
+* @joanvelja made their first contribution in https://github.com/vllm-project/vllm/pull/44371
+* @KKothuri made their first contribution in https://github.com/vllm-project/vllm/pull/48390
+* @kl527 made their first contribution in https://github.com/vllm-project/vllm/pull/47464
+* @krishy91 made their first contribution in https://github.com/vllm-project/vllm/pull/47991
+* @langzhao-netizen made their first contribution in https://github.com/vllm-project/vllm/pull/43463
+* @lishunyang12 made their first contribution in https://github.com/vllm-project/vllm/pull/49015
+* @mahadrehmann made their first contribution in https://github.com/vllm-project/vllm/pull/48098
+* @ManaEstras made their first contribution in https://github.com/vllm-project/vllm/pull/47872
+* @mosya415 made their first contribution in https://github.com/vllm-project/vllm/pull/48846
+* @mwoodson made their first contribution in https://github.com/vllm-project/vllm/pull/48523
+* @MynameFelix made their first contribution in https://github.com/vllm-project/vllm/pull/41811
+* @nicklasfrahm made their first contribution in https://github.com/vllm-project/vllm/pull/45313
+* @passtoor-agi made their first contribution in https://github.com/vllm-project/vllm/pull/48849
+* @pierDipi made their first contribution in https://github.com/vllm-project/vllm/pull/47063
+* @ruikangliu made their first contribution in https://github.com/vllm-project/vllm/pull/47309
+* @Sahil170595 made their first contribution in https://github.com/vllm-project/vllm/pull/45207
+* @samnordmann made their first contribution in https://github.com/vllm-project/vllm/pull/47156
+* @shawntsai made their first contribution in https://github.com/vllm-project/vllm/pull/47801
+* @sungbin1015 made their first contribution in https://github.com/vllm-project/vllm/pull/46793
+* @tanish-malekar made their first contribution in https://github.com/vllm-project/vllm/pull/39058
+* @tomerg-nvidia made their first contribution in https://github.com/vllm-project/vllm/pull/47021
+* @tsvikas made their first contribution in https://github.com/vllm-project/vllm/pull/47296
+* @vanshbhatia-amd made their first contribution in https://github.com/vllm-project/vllm/pull/47767
+* @ViranjanPagar made their first contribution in https://github.com/vllm-project/vllm/pull/42424
+* @vivek8123 made their first contribution in https://github.com/vllm-project/vllm/pull/46017
+* @vx120 made their first contribution in https://github.com/vllm-project/vllm/pull/46725
+* @wangxingda made their first contribution in https://github.com/vllm-project/vllm/pull/48829
+* @wendadawen made their first contribution in https://github.com/vllm-project/vllm/pull/46213
+* @wenpengw-nv made their first contribution in https://github.com/vllm-project/vllm/pull/44863
+* @woosebastian made their first contribution in https://github.com/vllm-project/vllm/pull/48901
+* @Yancey0623 made their first contribution in https://github.com/vllm-project/vllm/pull/40996
+* @yushangdi made their first contribution in https://github.com/vllm-project/vllm/pull/48868
+* @yuvalluria made their first contribution in https://github.com/vllm-project/vllm/pull/46396
+* @zihaomu made their first contribution in https://github.com/vllm-project/vllm/pull/47404
+* @zqzten made their first contribution in https://github.com/vllm-project/vllm/pull/44303
+
+## Contributors
+
+@mgoin, @yewentao256, @NickLucche, @njhill, @LucasWilkinson, @micah-wil, @khluu, @AndreasKaratzas, @WoosukKwon, @aoshen02, @BugenZhao, @vanshbhatia-amd, @jperezdealgaba, @jeejeelee, @hmellor, @tlrmchlsmth, @MatthewBonanni, @Change72, @chaojun-zhang, @gau-nernst, @gnovack, @ZJY0516, @reidliu41, @Yejing-Lai, @taneem-ibrahim, @Srinivasoo7, @Sunt-ing, @AmeenP, @zhenwei-intel, @LopezCastroRoberto, @matteso1, @yzong-rh, @stefankoncarevic, @Isotr0py, @djramic, @charlifu, @peizhang56, @giuseppegrossi, @drakosha, @NickCao, @benchislett, @Rohan138, @hickeyma, @muhammadfawaz1, @rasmith, @zixi-qi, @music-dino, @BWAAEEEK, @xianbaoqian, @wendyliu235, @atalman, @joerowell, @ErenAta16, @AlejandroParedesLT, @gcanlin, @liranschour, @omerpaz95, @Alex-ai-future, @tanpinsiang, @Fangzhou-Ai, @KKothuri, @zxd1997066, @akii96, @nemanjaudovic, @Etelis, @afierka-intel, @DaoyuanLi2816, @HDCharles, @tahsintunan, @xiaohongchen1991, @sagearc, @mikekg, @kliuae, @qli88, @arpera, @yushangdi, @edwinlim0919, @tjtanaa, @ariG23498, @lucifer1004, @netanel-haber, @kl527, @Rukhaiya2004, @ronensc, @guan404ming, @shaunkotek, @liulanze, @pierDipi, @eldarkurtic, @simon-mo, @robinguo23, @CienetStingLin, @RishabhSaini, @Sahil170595, @jasonlizhengjian, @jacklin78911-collab, @walterbm, @amd-ethany, @zqzten, @nicklasfrahm, @hongxiayang, @alexeldeib, @ManaEstras, @sungbin1015, @aoright, @Saddss, @vivek8123, @voipmonitor, @shawntsai, @almayne, @ilmarkov, @cleonard530, @kjiang249, @chaunceyjiang, @bigPYJ1151, @tsvikas, @deng451e, @tvirolai-amd, @zhewenl, @zihaomu, @ap9272, @staugust, @Yancey0623, @GongLei-HW, @albertoperdomo2, @guoriyue, @ViranjanPagar, @Functionhx, @XuZhou26, @MynameFelix, @larryli2-amd, @ashwing, @thisisjimmyfb, @robertgshaw2-redhat, @mayuyuace, @ibondarenko1, @zhejiangxiaomai, @vx120, @hugo-cen, @tanish-malekar, @zzt93, @guybd, @R3hankhan123, @mmangkad, @omera-nv, @yma11, @Gavin-Morris-04, @pavanimajety, @shanjiaz, @wenpengw-nv, @atalhens, @langzhao-netizen, @emricksini-h, @Zhenzhong1, @DanBlanaru, @mgehre-amd, @mwoodson, @wangxiyuan, @adsridhar, @hnt2601, @gangula-karthik, @tomerg-nvidia, @adhi29, @rishitdholakia13, @divakar-amd, @chaeminlim-mb, @joanvelja, @russellb, @janeyx99, @aarushjain29, @wjabbour, @mahadrehmann, @krishy91, @tzielinski-habana, @avalliappan-nvidia, @ruikangliu, @majian4work, @maxyanghu, @brijrajk, @lengrongfu, @Josephasafg, @elvircrn, @xiaguan, @ricky-chaoju, @iyastreb, @ovidiusm, @tuukkjs, @noooop, @samnordmann, @AndyDai-nv, @xiao-llm, @DiegoCao, @yuvalluria, @jhu960213, @woosebastian, @Debasish-87, @esmeetu, @hao-aaron, @zhangj1an, @wendadawen, @juliendenize, @passtoor-agi, @mosya415, @labAxiaoming, @devalshahamd, @wangxingda, @xuebwang-amd, @fuscof-ibm, @alexxu-roblox, @frida-andersson, @lishunyang12, @izhuhaoran

--- a/claude-skills/vllm-release-notes/examples/v0.27.0/release-notes.md
+++ b/claude-skills/vllm-release-notes/examples/v0.27.0/release-notes.md
@@ -1,0 +1,145 @@
+# vLLM v0.27.0 Release Notes
+
+## Highlights
+
+This release features 561 commits from 242 contributors (64 new)!
+
+* **Kimi K3 support** with a full stack landing in one release: core model files and kernels (#50089, #50000), Python (#50093) and Rust (#50104) frontends, AttnRes kernels (#50090), DeepGEMM support (#50458), compressed-tensors quantized checkpoints (#50500), DSpark AR fusion (#50242), and an option to shard the shared expert instead of replicating it (#50656).
+* **More new models**: Qwen3.5 text-only dense and MoE models (#50210) with EVS video token pruning (#48912), K-EXAONE-2.0-750B-A37B (#50524), VaultGemma via the Transformers modeling backend (#49803), and jina-embeddings-v5-text-nano (#50688).
+* **PyTorch 2.13.0 upgrade** along with torchvision 0.28.0 and Triton 3.7.1 (#48155) — this is a breaking environment change; XPU (#48677) and CPU (#50412) followed to torch 2.13 as well.
+* **FlashAttention 4 integration deepens on SM100**: FP8 KV cache support (#42569) and headdim-256 support (#42669), backed by a new JIT warmup infrastructure (#47451) and runner-owned Triton kernel warmup (#49903) that remove first-request compilation stalls.
+* **DeepSeek-V4 performance push**: sequence parallelism (#46789), ~2x kernel improvement by skipping empty c128 launches (#48957), 3.4% E2E TTFT from skipping unneeded topk/router (#49486), 3.9% E2E TTFT from workspace reuse (#49236), 1.88x kernel from removing a redundant full kernel (#50298), adaptive topk width (1.0% E2E, #50004), 448 MiB GPU memory saved in the PP buffer (#50312), a compact MXFP4 indexer KV cache (#48993), and removal of sparse-MLA q-head padding on FlashInfer >= 0.6.14 (#48047).
+* **Model Runner V2 expands to non-generative workloads**: encoder-only attention (#49331), sequence pooling for embedding/classification (#48791), encoder token classification (#50293) and token embedding (#50574), BGE-M3 pooling (#50661), multimodal on CPU (#50073), a multi-layer MTP speculator (#48892), and PCP now selects MRV2 (#50034).
+* **Resilient large-scale serving**: a (simplified) fault tolerance framework for DP+EP external load-balancer deployments (#44428) and async preparation for elastic EP scaling (#47288).
+* **Disaggregation for hybrid models**: NIXL P/D for hybrid MLA+SSM models (#49762), heterogeneous P/D block sizes for hybrid models (#49612), and MoRIIO heterogeneous TP<->DP prefill/decode read routing (#46116).
+* **Rust frontend grows a gRPC control plane**: engine-aware health reporting (#48992), abort control (#49255), server and model discovery (#49491), KV event source discovery (#50033), plus `vllm-bench` integrated into the `vllm` CLI (#48930).
+* **Early next-gen hardware enablement**: `sm_107` target for NVIDIA Rubin (#49387) with NVLink all-reduce paths on SM107 (#49647), and ROCm gfx1250 architecture enabled (#46516).
+
+### Model Support
+* Kimi K3: new model (#50000) with model files and kernels (#50089), Python frontend (#50093), Rust frontend (#50104), AttnRes kernels (#50090), DeepGEMM support (#50458), DSpark AR fusion (#50242), and optional shared-expert sharding (#50656).
+* New models: Qwen3.5 text-only dense and MoE (#50210), K-EXAONE-2.0-750B-A37B (#50524), VaultGemma via Transformers backend (#49803), jina-embeddings-v5-text-nano with EuroBERT encoder backbone (#50688).
+* Inkling: llm-compressor NVFP4 weights (#49258) and compressed-tensors dynamic FP8 (#48876).
+* Multimodal: VidCom2 video token pruning (#47750), EVS for Qwen3.5 (#48912), ViT CUDA graph for Gemma-4 (#46837), Cosmos3 FP8 ModelOpt/Diffusers remapping (#48952), MiniMax-M3 MSA speculative decode verification (#50032) and default video processor (#50305), DeepSeek-OCR-2 TTFT optimization (#49531), longer max audio duration for MOSS-TD (#49403).
+* Diffusion models: top_k and top_p sampling for DiffusionGemma (#45429).
+* Transformers modeling backend: audio model support (#39330), improved `fx` tracer (#49957), fused residual-add + RMSNorm compilation pass (#48757), and fixes for MLA padding + grouped topk routing (#49982), MQA with TP (#49987), and Qwen3-VL M-RoPE (#49292).
+
+### Engine Core
+* Warmup: new JIT warmup infrastructure (#47451), runner-owned Triton kernels warmed before the first request (#49903), and proper renderer warmup (#50408).
+* Attention: FlashAttention 4 SM100 FP8 KV cache (#42569) and headdim-256 (#42669); query replication for MLA decode under DCP for DeepSeek-V2/R1 and Kimi-K2.5 (#45964); masked MHA for sparse MLA prefills (#48770); skip sparse indexer scoring for short dense prefills (#48407); FlexAttention epilogue hook (#45841) and encoder block-mask compile explosion avoided (#50339); attention backends stay eligible for text-only serving of prefix-LM models (#48796); merge-attention context count as a runtime argument (#48739); unified multi-path encoder CUDA graph support (#49934); encoder cache extension hooks (#48218).
+* Model Runner V2: encoder-only attention (#49331), sequence pooling for embedding and classification (#48791), encoder token classification (#50293), encoder token embedding (#50574), BGE-M3 pooling (#50661), multimodal on CPU (#50073), multi-layer MTP speculator (#48892), PCP selects MRV2 (#50034), attention metadata always built at capture time (#49364), encoder cache profiling (#47985), skipped no-op FP32 logits materialization (#47711), chunked rejection sampler to avoid OOM (#48630), fewer GPU<->CPU syncs in hybrid Mamba (#49736).
+* KV offloading: generic P2P secondary tier with peer lookup/serving (#48021), per-request tier filtering with TierFilter/TierMatcher (#48123), self-describing KV events with TieringOffloadingSpec (#48679), pluggable eviction policies via CachePolicyFactory (#49114), deduplicated replicated MLA KV in the shared CPU region (#48906), single-copy MLA layout for CPUOffloadingSpec (#50301), CPUOffloadingSpec moved onto SharedOffloadRegion (#50094), TP-independent compact secondary identity (#49858), batched C store/load for filesystem offload (#49152), reliable partial-tail offload for sub-block prompts (#49502), per-layer canonical KV page mappings for parallelism-agnostic offload (#48408).
+* Mamba/hybrid: ReplaySSM caching for faster Mamba2 standard decode (#48018), fused align-mode DS-conv state migration with num_accepted_tokens > 1 (#49291), FlashInfer Mamba SSU algorithm selection (#50157), fixed `/wake_up` crash on hybrid models (#41602).
+* Spec decode: DSpark Markov head replicated across TP ranks (#49731), `sample_from_anchor` loaded from speculators config (#48639), earliest-completing stop string selected (#49391).
+* Structured outputs: grammar advanced across the reasoning boundary with spec decode (#44993).
+* Preprocessing performance: derender CPU work offloaded to the renderer thread pool (#49396), raw-prompt preprocessing off the event loop in AsyncLLM (#49608), multimodal preprocessing isolated on its own executor (#49524), MM embeds loading deferred off the event loop (#49477), parallel preprocessing within a request for online pooling (#49153), videos hashed by source bytes (#49607), original image mode preserved in ImageIO (#49159).
+* RL: weight version tagging for RL rollouts (#49040), stateful trainer-send IPC (#48981), vLLM config set during weight reload (#45989), router replay output from the FlashInfer monolithic MoE kernel (#44214).
+* Memory & robustness: CuMem slept-L1 fragmentation accounting (#49208), cgroup memory limits respected on all platforms (#49966), fail fast when /dev/shm is too small (#48879), zero-copy tensor pickling in shm_broadcast (#48442), LRU hash-split skipped in free_blocks when prefix caching is off (#48017), location-derived path vars excluded from torch.compile cache factors (#47573), `CustomOp.forward_native` compiled for ReLU^2 (#50244), HF config used for HF tokenizers (#49907), batch-invariant RMSNorm via pinned block size (#48391).
+
+### Hardware & Performance
+* DeepSeek-V4: sequence parallelism (#46789), ~2x kernel skipping empty c128 launches (#48957), 3.4% E2E TTFT skipping topk/router in decode (#49486), 3.9% E2E TTFT workspace reuse (#49236), 1.88x kernel removing a redundant full kernel (#50298), adaptive topk width 1.0% E2E (#50004), 448 MiB GPU memory saved (#50312), compact MXFP4 indexer KV cache (#48993), sparse-MLA q-head padding removed for FlashInfer >= 0.6.14 (#48047).
+* Kernels: RMSNorm uncontiguous support with 1.2–3.1x kernel improvement (#49750), MoE `reduce_scatter` regression fix restoring 5% E2E throughput (#48763), non-grouped bias-less topk routing dispatched to the fused path (#49618), tuned LL BF16 router GEMM (#48774) with warmup skipped for non-MoE models (#49659), Triton tensor-descriptor path for fused MoE via `VLLM_TRITON_USE_TD` (#42436), cudagraph/DP padding skipped in topk (#48979), coalesced HBM access in the Marlin INT4-FP8 AWQ preprocess kernel (#47268).
+* NVIDIA next-gen: `sm_107` for Rubin (#49387), NVLink all-reduce paths on SM107 (#49647), fixed CUDA arch detection producing kernel-less builds on SM121 (#49904).
+* ROCm: gfx1250 architecture enabled (#46516), AITER FP8 ViT encoder attention (#49937), fused shared expert for Quark DeepSeek-V4 checkpoints (#48044), Quark GLM-5.2 checkpoint inference fixes (#48886), DSv3.2 per-decode FillFunctor launches eliminated in the sparse-MLA hot loop (#44527), B-preshuffled attention FP8 projections for DSv4 (#46720), TML Inkling enabled (#48841), tuned selective_state_update float16 config for MI325X (#50006), GPT-J-style MRoPE fixed and optimized (#49906), quickreduce accuracy fix in cudagraph mode (#46913), cached fp32 upcast of static e8m0 weight scales (#47773), batch DMA for CPU KV cache loads (#49843), elastic EP scaling accuracy fix (#47206).
+* XPU: QK Norm + RoPE fusion pass (#49394), FP8 o_proj with fp8_bmm and load-time scale transpose (#48334), DeepSeek-V4 fuse_index_q SYCL kernel path (#45991), TD operand loads for batched MoE GEMM (#46340), RMSNorm kernels unified with vllm_c (#46981).
+* CPU: INT8 fused MoE kernel for Arm CPUs (#48637), s390x inference optimization with oneDNN INT8 GEMM (#50219), GDN conv path optimized for speculative decoding (#48577), granite-4 enabled (#47641), FAST_EXP for Power (#49571), CPU kernels bumped to the latest version (#50387), macOS build fixes (#49021, #50915).
+
+### Large Scale Serving & Distributed
+* Fault tolerance framework (simplified) for DP+EP external LB deployments (#44428).
+* Elastic EP: async preparation (#47288) and non-contiguous weight transfer fix (#50641).
+* P/D disaggregation: NIXL P/D for hybrid MLA+SSM models (#49762), NIXL heterogeneous P/D block sizes for hybrid models (#49612), MoRIIO heterogeneous TP<->DP prefill/decode read routing (#46116), optional lookup disable on PD decode (#50498), prefill token ids reused on the decode chat path (#48145), detokenization streaming derender (#47301), NixlPush skips an extra handshake step in D->P (#49345).
+* Fixes: P/D preemption race (#50297), KV lease deadlines rebased onto the worker clock (#50326), NIXL hybrid MLA+mamba heterogeneous TP (#49297), internal LB load-balancing (#49204).
+* Mooncake: vectorized `prepare_value` on the KV load path (#48531), full external hits re-derived on stored boundaries (#49481).
+* Encoder-cache connectors: `has_pending_push_work` (#49582).
+* Communicators: process-checkpoint lifecycle hooks, starting with FlashInfer (#46877).
+
+### Quantization
+* New capabilities: FP4 Qutlass integration for compressed-tensors (#43229), CuTeDSL MoE for ReLU2 NVFP4 (#49580), MXFP8 linear support in INC (#47514), AutoRound W4A16 MoE and MXFP4 linear/MoE on XPU (#47124), KV quant mode for TurboQuant (#50533), ModelOpt FP8 emulation on SM80 (#50019), `--linear-backend` honored for ModelOpt W4A16 (#50273).
+* Checkpoints: compressed-tensors support for DeepSeek-V4 (#41276) and Kimi-K3 (#50500); `find_matched_target` prioritizes fused-name matches (#49483).
+* MoE refactor: FusedMoE renamed to FusedMoEFactory (#44941), MoeWNA16 migrated to the MK oracle scheme (#44120), Quark w8a8-int8 (#46765) and MXFP4 `aiter`/`emulation` backends (#49348, #48949) moved to kernel abstractions, CT WNA16 Marlin/MoE methods merged (#44570), Quark W4A8 (INT4-FP8) MoE CI coverage (#48050).
+
+### API & Frontend
+* Rust frontend: gRPC control plane with engine-aware health reporting (#48992), abort control RPC (#49255), server and model discovery (#49491), and KV event source discovery (#50033); `vllm-bench` integrated into `vllm-rs` and the `vllm` CLI (#48930) with opt-in Rust delegation for `vllm bench serve` (#50081); zero-copy multimodal tensor slicing (#48781), multimodal tensors in auxiliary frames (#49341), `--limit-mm-per-prompt` (#49604), ordinary-text tokenizer encoding (#49992).
+* APIs: Cohere chat v2 API support (#47189), `cache_salt` in the Anthropic Messages API (#49498), strict tool calling and constrained decoding for GPT-OSS Harmony (#45560), unified engine-based Mistral parser for reasoning and tool calls (#48947), `stream_interval` exposed as a per-request sampling param (#49754), additional sampling parameters for the translation API (#45839), `diarized_json` for MOSS-Transcribe-Diarize (#48543), cumulative speech-to-text chunk timestamps (#41131).
+* Multimodal: mm hash algorithm selection via CLI (#49686), configurable PyNvVideoCodec decoder concurrency (#49753), RFC 2397 parameters accepted in base64 data URLs (#48973).
+* UX & validation: standardized request error handling with a VLLMError hierarchy (#49665), reduced startup log noise (#50590), incompatible nested runtime overrides rejected (#49247), improved data-parallel launch validation (#49124), DCP topology validation (#49777), 400 instead of 500 for non-numeric logprobs (#49144), bare Inkling text preserved in Python and Rust parsers (#50403).
+* Benchmarks: probe requests in `vllm bench serve` (#49611).
+
+### Dependencies
+* PyTorch 2.13.0, torchvision 0.28.0, Triton 3.7.1 (#48155); torch 2.13 for XPU (#48677) and CPU (#50412).
+* Transformers 5.14.1 (#49223), FlashInfer 0.6.15 (#48914) then 0.6.16.post3 (#50892), AITER 0.1.16.post5 (#48683) then 0.1.19 (#49361), NCCL 2.30.7 enabling DeepEPv2 in the vllm/vllm-openai image (#45321), tpu-inference v0.25.0 (#49431) then v0.26.0 (#50522), Helion 1.4.0 (#50307), NIXL and UCX upgraded on ROCm (#49251).
+* Build: vllm-flash-attn bumped to a C++20-compatible commit for torch-nightly (#49326), ABI-stable FA2 build pin (#50474).
+
+### Deprecations & Removals
+* Models removed: Plamo2 (#49729), Ouro (#49786).
+* Removed the no-longer-supported `max_num_partial_prefills` and `max_long_partial_prefills` arguments (#49244).
+
+## New Contributors
+
+* @afriedri made their first contribution in https://github.com/vllm-project/vllm/pull/49621
+* @amd-sourjya made their first contribution in https://github.com/vllm-project/vllm/pull/48050
+* @andreatassi made their first contribution in https://github.com/vllm-project/vllm/pull/48879
+* @andrewbcohere made their first contribution in https://github.com/vllm-project/vllm/pull/47189
+* @avininjamay8 made their first contribution in https://github.com/vllm-project/vllm/pull/47764
+* @bastefaniak made their first contribution in https://github.com/vllm-project/vllm/pull/49190
+* @boe20211 made their first contribution in https://github.com/vllm-project/vllm/pull/49431
+* @bugkeep made their first contribution in https://github.com/vllm-project/vllm/pull/41357
+* @cagrikymk made their first contribution in https://github.com/vllm-project/vllm/pull/46720
+* @chun-wan made their first contribution in https://github.com/vllm-project/vllm/pull/44972
+* @ColinZ22 made their first contribution in https://github.com/vllm-project/vllm/pull/48044
+* @dsocek made their first contribution in https://github.com/vllm-project/vllm/pull/47791
+* @euisuh made their first contribution in https://github.com/vllm-project/vllm/pull/49654
+* @evantakahashi made their first contribution in https://github.com/vllm-project/vllm/pull/47953
+* @FeathBow made their first contribution in https://github.com/vllm-project/vllm/pull/49111
+* @fxmarty made their first contribution in https://github.com/vllm-project/vllm/pull/49732
+* @hotTea123 made their first contribution in https://github.com/vllm-project/vllm/pull/48218
+* @Ibrahim2595 made their first contribution in https://github.com/vllm-project/vllm/pull/45432
+* @jcotant-inferact made their first contribution in https://github.com/vllm-project/vllm/pull/49474
+* @jiacao-amd made their first contribution in https://github.com/vllm-project/vllm/pull/47773
+* @Johnny-Liou made their first contribution in https://github.com/vllm-project/vllm/pull/48018
+* @johnnyychiu made their first contribution in https://github.com/vllm-project/vllm/pull/45532
+* @jongukc made their first contribution in https://github.com/vllm-project/vllm/pull/49440
+* @kevglynn made their first contribution in https://github.com/vllm-project/vllm/pull/41602
+* @krishnateja95 made their first contribution in https://github.com/vllm-project/vllm/pull/48876
+* @Lafunamor made their first contribution in https://github.com/vllm-project/vllm/pull/40289
+* @latent-9 made their first contribution in https://github.com/vllm-project/vllm/pull/50491
+* @LG-0927 made their first contribution in https://github.com/vllm-project/vllm/pull/50571
+* @liminfei-amd made their first contribution in https://github.com/vllm-project/vllm/pull/48739
+* @lkk12014402 made their first contribution in https://github.com/vllm-project/vllm/pull/47124
+* @loulanyue made their first contribution in https://github.com/vllm-project/vllm/pull/50704
+* @markyangcc made their first contribution in https://github.com/vllm-project/vllm/pull/49021
+* @meiyeh123 made their first contribution in https://github.com/vllm-project/vllm/pull/50522
+* @Mi-Jiazhi made their first contribution in https://github.com/vllm-project/vllm/pull/49691
+* @microslaw made their first contribution in https://github.com/vllm-project/vllm/pull/47298
+* @molly-ting made their first contribution in https://github.com/vllm-project/vllm/pull/49660
+* @neweyes made their first contribution in https://github.com/vllm-project/vllm/pull/49659
+* @nickus made their first contribution in https://github.com/vllm-project/vllm/pull/48366
+* @nikhilkulkarni1755 made their first contribution in https://github.com/vllm-project/vllm/pull/44239
+* @nvbfalk made their first contribution in https://github.com/vllm-project/vllm/pull/47750
+* @omkar-droid made their first contribution in https://github.com/vllm-project/vllm/pull/50688
+* @oops-oom made their first contribution in https://github.com/vllm-project/vllm/pull/49985
+* @ormandj made their first contribution in https://github.com/vllm-project/vllm/pull/48317
+* @PerkzZheng made their first contribution in https://github.com/vllm-project/vllm/pull/50210
+* @philippesic made their first contribution in https://github.com/vllm-project/vllm/pull/49114
+* @qtris123 made their first contribution in https://github.com/vllm-project/vllm/pull/48796
+* @RyanClark2k made their first contribution in https://github.com/vllm-project/vllm/pull/48438
+* @samlaf made their first contribution in https://github.com/vllm-project/vllm/pull/50200
+* @ShuoleiWang made their first contribution in https://github.com/vllm-project/vllm/pull/49040
+* @siddhant-bharti made their first contribution in https://github.com/vllm-project/vllm/pull/50065
+* @Spycsh made their first contribution in https://github.com/vllm-project/vllm/pull/47871
+* @stacyroberts made their first contribution in https://github.com/vllm-project/vllm/pull/47207
+* @stefan-kaestle made their first contribution in https://github.com/vllm-project/vllm/pull/49177
+* @thomas-fahrner-parasail made their first contribution in https://github.com/vllm-project/vllm/pull/48973
+* @TobyB1702 made their first contribution in https://github.com/vllm-project/vllm/pull/41131
+* @vecheruk-amd made their first contribution in https://github.com/vllm-project/vllm/pull/38293
+* @wangqia0309 made their first contribution in https://github.com/vllm-project/vllm/pull/48563
+* @wkutak made their first contribution in https://github.com/vllm-project/vllm/pull/48952
+* @wskr00 made their first contribution in https://github.com/vllm-project/vllm/pull/49073
+* @xuanyu-mistral made their first contribution in https://github.com/vllm-project/vllm/pull/44214
+* @yamt made their first contribution in https://github.com/vllm-project/vllm/pull/50547
+* @yuan-alex made their first contribution in https://github.com/vllm-project/vllm/pull/48917
+* @yudigege86 made their first contribution in https://github.com/vllm-project/vllm/pull/50476
+* @zaristei made their first contribution in https://github.com/vllm-project/vllm/pull/49647
+
+## Contributors
+
+@AndreasKaratzas, @njhill, @hmellor, @mgoin, @BugenZhao, @yewentao256, @khluu, @taneem-ibrahim, @guan404ming, @NickLucche, @stefankoncarevic, @Change72, @zhenwei-intel, @reidliu41, @oonyshch, @Isotr0py, @MatthewBonanni, @andyxning, @WoosukKwon, @tlrmchlsmth, @ZJY0516, @fxmarty-amd, @ivanium, @aoshen02, @xwu-intel, @connorcarpenter15, @lengrongfu, @bnellnm, @mikekg, @kylesayrs, @aarushjain29, @fadara01, @netanel-haber, @Etelis, @LopezCastroRoberto, @jikunshang, @chaunceyjiang, @umut-polat, @divakar-amd, @gau-nernst, @ColinZ22, @jcotant-inferact, @R3hankhan123, @chaojun-zhang, @jongukc, @zxd1997066, @bigPYJ1151, @yzong-rh, @hickeyma, @yushangdi, @majunze2001, @Akashcodes732, @zufangzhu, @sagearc, @FeathBow, @xiaolong-intel, @coltonottley, @okorzh-amd, @sungsooha, @cleonard530, @microslaw, @vllm-agent, @LucasWilkinson, @eicherseiji, @Fangzhou-Ai, @peizhang56, @ZeldaHuang, @noooop, @atalman, @wzhao18, @matteso1, @GirasoleY, @Dao007forever, @chaeminlim-mb, @music-dino, @amd-sourjya, @BadrBasowid, @Johnny-Liou, @Rohan138, @brandonpelfrey, @harjothkhara, @tianmu-li, @fxmarty, @oops-oom, @TheEpicDolphin, @yma11, @itayalroy, @shen-shanshan, @JaredforReal, @wskr00, @janeyx99, @mayuyuace, @omkar-droid, @mganczarenko, @Spycsh, @hclsys, @EdalatiAli, @wangqia0309, @tc-mb, @wkutak, @charlifu, @fynnsu, @xuanyu-mistral, @ormandj, @flutist, @simon-mo, @yuan-alex, @esmeetu, @stefan-kaestle, @bastefaniak, @markyangcc, @ilmarkov, @jjmiao1, @stecasta, @evantakahashi, @ariG23498, @sfeng33, @rasmith, @gnovack, @boe20211, @bbrowning, @S1ro1, @davidjpyu, @nikhilkulkarni1755, @vllmellm, @yuyue0225sc, @euisuh, @zhou9402, @li-jinpeng, @hotTea123, @mgazz, @thomas-fahrner-parasail, @elvircrn, @djramic, @adobrzyn, @qtris123, @harshaljanjani, @mosya415, @gcanlin, @fangyuchu, @anthonsu, @Palaiologos1453, @Achyuthan-S, @athrael-soju, @LiuLi1998, @liranschour, @Alex-ai-future, @dsocek, @galletas1712, @nickus, @edwinlim0919, @walterbm, @thegoldenflow, @Zhenzhong1, @haoyangli0109, @tjtanaa, @ronensc, @neweyes, @liminfei-amd, @garrygale, @jesse996, @TobyB1702, @puririshi98, @andreatassi, @avininjamay8, @frida-andersson, @nvbfalk, @varun-sundar-rabindranath, @mindungil, @ayush1399, @afriedri, @ShuoleiWang, @Liangliang-Ma, @xin3he, @liangel-02, @Ibrahim2595, @qianlihuang, @jiacao-amd, @brian-dellabetta, @labAxiaoming, @johnnyychiu, @siddhant-bharti, @jdebache, @mrn3088, @kevglynn, @krishnateja95, @danielafrimi, @zqzten, @philippesic, @afierka-intel, @PerkzZheng, @omerpaz95, @cinnamonica02, @fallintoplace, @yintong-lu, @chanh, @roikoren755, @zaristei, @bugkeep, @vecheruk-amd, @molly-ting, @lkk12014402, @LiuYinfeng01, @jperezdealgaba, @stacyroberts, @juliendenize, @hao-aaron, @cagrikymk, @zou3519, @RyanClark2k, @samlaf, @jpvillam-amd, @mawong-amd, @vanshbhatia-amd, @rjrock, @majian4work, @woosebastian, @Mi-Jiazhi, @jeejeelee, @latent-9, @oguzhankir, @LG-0927, @ylangtsou, @meiyeh123, @skavulya, @Lafunamor, @Amir-19, @andrewbcohere, @yudigege86, @aeon-x, @wentian-byte, @almogtavor, @hongxiayang, @loulanyue, @jasonlizhengjian, @chun-wan, @wjabbour, @yamt, @amitz-nv, @JianDan0212, @lkm2835, @lk-chen

--- a/claude-skills/vllm-release-notes/examples/v0.28.0/release-notes.md
+++ b/claude-skills/vllm-release-notes/examples/v0.28.0/release-notes.md
@@ -1,0 +1,161 @@
+# v0.28.0
+
+## Highlights
+
+This release features 584 commits from 270 contributors (76 new)!
+
+* **Kimi-K3 performance push**: a major optimization effort for Kimi-K3 across the stack — Decode Context Parallel (DCP) support (#50484), fused FlashKDA decode and prefill kernels (#50654, #51311, #52458), SiTU activation support for MegaMoE (#50510), GEMM-RS for sequence parallelism (#52079), combined all-gathers with 1.5~3x kernel-level speedup (#51070), an adaptive speculative token budget delivering ~60% better DSpark TTFT (#51725), and optional shared-expert sharding saving ~17 GiB of memory per GPU (#50912). Kimi-K3 also now runs on ROCm with the V2 model runner (#51653).
+* **DeepSeek V4 end-to-end**: sparse MLA now works end-to-end for plain decode, MTP, and DSpark speculative decoding (#51538), joined by AMD Quark NVFP4 support (#47972), reasoning-effort prompts and mappings (#50580), sparse top-k metadata kernel optimizations (#52084, #51967), narrowed eager CUDA graph regions (#51430, #52401), and ROCm enablement on gfx11 and gfx950 (#47017, #52212).
+* **Speculative decoding advances**: DFlash2 with local convolution and a candidate selector (#52816), DSpark confidence-scheduled verification (#47808), and async scheduling auto-enabled for draft models (#48341).
+* **Model Runner V2 maturation**: E/P/D disaggregation (#38390), weight offloading (#51413), multi-layer MTP KV cache support (#50062), encoder CUDA graphs (#49852), decoder token-wise pooling (#50931) plus Transformers pooling models (#52425), attention-free models (#52374), and `thinking_token_budget` support (#46727).
+* **Tiered KV cache offloading**: disk offloading support (#49644), out-of-tree secondary tier managers via `module_path` (#51007), partial secondary-tier load results (#50321), tiering metrics (#48798), and a canonical CPU layout for parallelism-agnostic offload (#48414).
+* **Rust frontend & gRPC**: a standalone renderer (#50289), multimodal image inference over gRPC (#50368), explicit data-parallel rank routing (#51178), and RL lifecycle control (#51316), with protobuf schemas now published to Buf (#51276).
+* **New defaults**: `max_num_batched_tokens` raised from 8192 to 16384 (#51726), prefix caching enabled by default for Mamba models (#50991), and the Blackwell CUDA graph capture default raised to 1024 (#49390).
+* **Breaking changes**: bitsandbytes support migrated to an out-of-tree plugin (#43529); Transformers bumped to 5.15.0 (#51668); the deprecated `calculate_kv_scales` runtime KV scale calculation was removed (#49389); `override_attention_dtype` was removed (#48684).
+
+## Model Support
+* **New models**: Muse Glimmer (#51655), Ling 3.0 Flash with BF16, MTP, and parser support (#51045) plus an FP8 variant (#51265) and hybrid MXFP4 routed experts (#52114), Dots3 NOTE native multimodal support (#51255), and Interns2mobius (#51149).
+* **Qwen**: Qwen3.8 enabled on AMD ROCm (#50068), fused CUDA post-conv MTP decode kernel for Qwen3.5 GDN (#51674), GDN gates aligned with speculative tokens (#51812), and Qwen3.5 fixes for text-only checkpoints (#50734, #50355).
+* **Transformers modeling backend**: MLA support (#48250), hardware-agnostic model definition (#49458), fully generalized input embedding handling (#51247), logit softcapping (#52173), and a hardened multimodal path (#51408, #51657).
+* **LoRA**: vision tower LoRA for Gemma4 (#42662), tower/connector LoRA for Keye (#51780) and Ultravox (#48215).
+* **Vision encoders**: ViT full CUDA graph for Kimi-K2.5 (#50929) and Ernie-4.5-VL (#45254, #51461), torch.compile for the Qwen3-VL encoder (#40116), and long-blocking H2D copies avoided in ViT (#51841).
+* **MoE**: extended EPLB support for Mistral Large 3 and additional MoE backends (#48355), CuTe DSL skinny GEMM extended to GLM-5.2 (#49791).
+* **Speculative decoding coverage**: EAGLE3 support declared on KimiLinear (#52171), Qwen3.6 dSpark acceptance coverage (#51310).
+* **Correctness**: MiniMax-M3 NVFP4 inference (#48929) and compressed-tensors FP8 MoE SwiGLU params (#46845), Gemma3n/Gemma4 variable-length audio batch padding (#50958), Gemma 4 compatibility with the upcoming Transformers version (#49797), and a Qwen3-Omni crash on video without an audio track (#48420).
+* **Multimodal performance**: fused on-device multimodal preprocess normalization (#50411), faster placeholder and token-match scanning (#50716), and repeated prompt-update scans avoided (#51774).
+
+## Engine Core
+* **Speculative decoding**: DSpark confidence-scheduled verification (#47808), top-k DSpark Markov projection (#49969), DFlash2 with local convolution and a candidate selector (#52816), async scheduling auto-enabled for draft models (#48341), fused MTP trailing all-reduce with local-argmax draft tokens (#49793), and an adaptive budget for speculative scheduled input tokens (#51725).
+* **KV cache & scheduling**: per-request scheduling for MLA chunked context (#50613), partial-tail prefix reuse with fine-grained prefix matching (#50507), backend-published KV packing in the KV-cache layout refactor (#51612, #51704), LIFO free-block reuse order restored when prefix caching is off (#51482), and silent request skipping in priority scheduling fixed (#49206).
+* **Performance**: continued elimination of GPU<->CPU syncs on the execution path (#51458, #51738, #52369) now guarded by a CI sync check (#43107), new JIT warmup infrastructure with predicate filtering (#49315), the top-k/top-p Triton sampler launched with 8 warps (#51507), detokenization skipped in offline beam search (#50333), Mask Replay (#49577), optimized long-context MLA cache gathers (#51739), and HF revisions resolved to a commit hash once per model load (#49990).
+* **Hybrid/Mamba**: prefix caching on by default (#50991), the final part of the Mamba attention module refactor (#44857), 3D-grid tiling of the state-copy Triton kernels (#49436), and Mamba alignment applied before encoder caps (#51603).
+* **RL workflows**: stateful trainer send over NCCL and sparse NCCL (#50902), `CuMemAllocator.discard()` for tag-selective GPU memory release (#52514), level-2 sleep/wake/reload fixed with LoRA enabled (#39935), and rewritten weight-transfer docs with standardized examples (#51729).
+* **Startup robustness**: file:// rendezvous for single-node executors eliminates startup port races (#50999, #51652), frontend processes are watched during engine startup (#43417), a `get_open_port()` livelock on DP-reserved ports was fixed (#50965), and NVML is no longer re-initialized on every device-capability check (#50393).
+
+## Hardware & Performance
+* **NVIDIA**: FlashInfer XQA decode support on SM12x (#49718), a CuTeDSL fused query kernel on SM100 (#49792), programmatic dependent launch for the DSA decode kernels (#50230), the native DSA decode path for MTP=3 on SM90 (#52164), GB10 fused-MoE FP8 tuning configs (#52502), and B12X dense linear backends (#52016).
+* **AMD ROCm**: torch 2.12 / triton 3.7 stack bump (#50607), AITER and FP8 inference enabled on GFX120x (#43615), DeepSeek-V4 on gfx11 (#47017), optimized Triton sparse-MLA decode on gfx950 (#52212), FlyDSL decode-attention kernel for 4-bit TurboQuant KV cache (#47896) and an fp8 MQA logits kernel on gfx942 (#49544), a fused Kimi-K3 KDA decode kernel (#50654), fused bf16→fp32 router GEMM (#50268), pinned memory on supported WSL2 kernels (#50126), and preshuffled sparse indexing for 16-token blocks (#51216).
+* **Intel XPU**: a torch linear backend including blockwise GEMM (#49664, #50826), MXFP8 linear weights for the INC DeepSeek V4 model (#48476), async-scheduling PP sampled-token broadcast overlapped with compute (#51650), an XPU wheel added to the release pipeline (#52108), tuned Mamba SSU configs for Arc Pro B70 (#50534), and UVA weight offloading fixes (#51770).
+* **CPU**: an MLA backend so DeepSeek-V2/V3 can run on CPU (#49453), a triton-cpu wheel (#52092), GPTQ and AWQ enabled on s390x (#51148) along with tcmalloc (#50841), BF16 MoE routed through zentorch on AMD (#44201), an unquantized MoE backend for Power (VSX) (#51624), unquantized MoE migrated to the modular-kernel experts structure (#50133), and the MXFP4 block scale folded in 2 instructions instead of 4 (#51583).
+
+## Large Scale Serving
+* **E/P/D disaggregation**: Model Runner V2 E/P/D support (#38390), duplicate image preprocessing removed with GPU-side preprocessing (#50390), KV consumers may omit multimodal embeddings (#52697), encoder-instance requests kept alive until their images are encoded (#50275), and EC connector scheduler/worker metadata plumbing (#49579, #49585).
+* **KV offloading**: disk offloading for SimpleCPUOffloadConnector (#49644), out-of-tree secondary tier managers via `module_path` (#51007), partial secondary-tier load results (#50321), tiering offloading metrics (#48798), data-parallel topology exposed to offloading backends (#51879), a canonical CPU layout for parallelism-agnostic offload (#48414), and quadratic ARC batch eviction avoided (#50992).
+* **Mooncake**: store group semantics (#44956), tenant ID support (#48069), and official wheels in the Docker image (#51067).
+* **Connectors**: transfer mode (push/pull) included in the NIXL compatibility hash (#50620), a MoRIIO per-layer READ-completion barrier (#48534), 2P2D wide-EP with mori-ep/mori-io at dp=ep=16 (#45043), and stale remote cleanup in the push connector (#50234).
+* **Parallelism**: EPLB balancedness calculation fixed and tested (#51813), dense multinode DP rescope (#49212).
+
+## Quantization
+* **Online quantization**: online MXFP4 support (#49347), online weight scales shared across TP (#49764), precision preserved in online NVFP4 expert packing (#50029), and the online NVFP4 MoE kernel reused across reloads (#50074).
+* **NVFP4**: batch-invariant NVFP4 MoE via CUTLASS (#40372), KV 4-over-6 scale search (#45187), CuTeDSL MoE with SwiGLU-OAI and ReLU2 activations (#47106), and out_dtype matched to the model dtype (#48861).
+* **New kernels**: block-wise scaled_mm (#49932), DeepSeek-V4 AMD Quark NVFP4 with an emulation kernel (#47972).
+* **Fixes**: dynamic INT8 W8A8 MoE config no longer built as W8A16 (#50833) and a TritonExperts crash (#51411), MXFP4 conversion for FlashInfer CUTLASS (#51038), fp32 weight scales and per-expert checkpoint mapping for MXFP4 (#51419), and fused block-scale orientation (#50727).
+
+## API & Frontend
+* **New capabilities**: request priority parsed from an HTTP header (#51089), session ID plumbing into requests (#48048), `count_reasoning_tokens` in the streaming parser engine (#45802), `content_parts` on `/inference/v1/generate` (#51478), `model` optional on all `/derender` request classes (#51463), output token IDs logged at DEBUG level (#52098), and vLLM Recipes connected to native config-based deployment and benchmarking (#51308, #51878).
+* **Rust frontend**: a standalone renderer (#50289), gRPC multimodal image inference (#50368), explicit data-parallel rank routing (#51178), RL lifecycle control (#51316), dynamic tools from developer messages (#51144), protobuf schemas published to Buf (#51276), and MiniJinja upgraded to 2.22 (#51235).
+* **Anthropic API**: 4xx returned for client-caused errors on `/v1/messages` (#52246), `disable_parallel_tool_use` preserved (#52021), and stop sequences bounded (#51997).
+* **Cohere**: upstreamed parser fixes (#51998), stop sequences reported correctly (#51556), and vectorized binary embedding bit-packing (#52277).
+* **Structured output**: request stop tokens masked in xgrammar until the grammar terminates (#49227, #50595), NUL bytes rejected in `structured_outputs.regex` (#51796), negative token IDs rejected as out-of-vocabulary (#51795), and `VLLMValidationError` raised from validators (#52394).
+* **Robustness**: uvicorn signal handlers disabled instead of racing them (#50916), a consolidated entrypoint exception handler (#52261), 400 instead of 500 on non-object JSON bodies (#51654, #52528), generation inputs bounded before expensive work (#51447), and `cache_salt` now required to be non-empty (#50816).
+
+## Security
+* Fixed a DoS via sample-rate forgery that bypassed the audio decode duration guard (#49948); the audio decode duration limit is now also enforced in NanoNemotronVL (#50221).
+* DeepStream classified as a GPU backend with pixel limits enforced (#50755).
+* `_load_ov2_processor` guarded with `resolve_trust_remote_code` (#52952).
+* Documentation now warns that `--api-key` does not gate all endpoints (#51999).
+
+## Dependencies
+* Transformers 5.15.0 (#51668), huggingface-hub 1.27.0 (#51422), fastsafetensors upgrade (#50827).
+* ROCm: torch 2.12, triton 3.7, torchaudio, torchvision (#50607).
+* Runtime image upgraded to Ubuntu 24.04, picking up rdma-core > 44 (#51058).
+* DeepGEMM pinned to the deepseek-ai nv_dev tip (#52035), DeepEP pinned by full commit hash (#52028), FlashAttention 3 built with the torch stable API (#49599).
+
+## Breaking Changes & Deprecations
+* bitsandbytes support is now an out-of-tree plugin (#43529).
+* The deprecated `calculate_kv_scales` runtime KV scale calculation was removed (#49389).
+* `override_attention_dtype` was removed (#48684).
+* `reasoning_content` output removal is documented as a breaking client change (#50624).
+* KV offload tiering metrics renamed from `kv_offload_tiering_block_{queries,hits}` to `..._chunk_...` (#52812).
+* MoE legacy code removed (#51078).
+
+## New Contributors
+* @acheamponge made their first contribution in https://github.com/vllm-project/vllm/pull/49353
+* @acmore made their first contribution in https://github.com/vllm-project/vllm/pull/51259
+* @anhtra3889 made their first contribution in https://github.com/vllm-project/vllm/pull/51002
+* @anujbolewar made their first contribution in https://github.com/vllm-project/vllm/pull/50867
+* @arthurgao2003 made their first contribution in https://github.com/vllm-project/vllm/pull/48215
+* @baodii made their first contribution in https://github.com/vllm-project/vllm/pull/51215
+* @bitborne made their first contribution in https://github.com/vllm-project/vllm/pull/44956
+* @bohnstingl made their first contribution in https://github.com/vllm-project/vllm/pull/49458
+* @ccaadaro made their first contribution in https://github.com/vllm-project/vllm/pull/51583
+* @cmiyai made their first contribution in https://github.com/vllm-project/vllm/pull/46870
+* @d4l3k made their first contribution in https://github.com/vllm-project/vllm/pull/51097
+* @dmai-afk made their first contribution in https://github.com/vllm-project/vllm/pull/51120
+* @dmholtz made their first contribution in https://github.com/vllm-project/vllm/pull/50977
+* @efschu made their first contribution in https://github.com/vllm-project/vllm/pull/50734
+* @fangchenli made their first contribution in https://github.com/vllm-project/vllm/pull/52277
+* @fanxingran made their first contribution in https://github.com/vllm-project/vllm/pull/51011
+* @fatday made their first contribution in https://github.com/vllm-project/vllm/pull/48171
+* @fattchris made their first contribution in https://github.com/vllm-project/vllm/pull/48861
+* @fcui-amd made their first contribution in https://github.com/vllm-project/vllm/pull/50126
+* @fede-kamel made their first contribution in https://github.com/vllm-project/vllm/pull/50624
+* @fxfxfxfxfxfxfxfx made their first contribution in https://github.com/vllm-project/vllm/pull/49139
+* @gabriel-peracio made their first contribution in https://github.com/vllm-project/vllm/pull/50183
+* @gchinora made their first contribution in https://github.com/vllm-project/vllm/pull/51427
+* @guanxingithub made their first contribution in https://github.com/vllm-project/vllm/pull/50589
+* @haregali made their first contribution in https://github.com/vllm-project/vllm/pull/50716
+* @hsusul made their first contribution in https://github.com/vllm-project/vllm/pull/49613
+* @iwannagotobed made their first contribution in https://github.com/vllm-project/vllm/pull/51664
+* @jacobzhang22 made their first contribution in https://github.com/vllm-project/vllm/pull/38771
+* @jairitAge made their first contribution in https://github.com/vllm-project/vllm/pull/51100
+* @jamesETsmith made their first contribution in https://github.com/vllm-project/vllm/pull/51216
+* @jimmy-adams made their first contribution in https://github.com/vllm-project/vllm/pull/47972
+* @jyan-R made their first contribution in https://github.com/vllm-project/vllm/pull/52311
+* @Kaif10 made their first contribution in https://github.com/vllm-project/vllm/pull/52528
+* @karen-sy made their first contribution in https://github.com/vllm-project/vllm/pull/48048
+* @Lin-z-w made their first contribution in https://github.com/vllm-project/vllm/pull/48069
+* @liushujia122 made their first contribution in https://github.com/vllm-project/vllm/pull/51780
+* @Luosuu made their first contribution in https://github.com/vllm-project/vllm/pull/48789
+* @mispa-ms made their first contribution in https://github.com/vllm-project/vllm/pull/52419
+* @mkhazraee made their first contribution in https://github.com/vllm-project/vllm/pull/50321
+* @NVShreyas made their first contribution in https://github.com/vllm-project/vllm/pull/50911
+* @pavelzak made their first contribution in https://github.com/vllm-project/vllm/pull/52502
+* @positive666 made their first contribution in https://github.com/vllm-project/vllm/pull/52329
+* @rajfirke made their first contribution in https://github.com/vllm-project/vllm/pull/51573
+* @Rapisurazurite made their first contribution in https://github.com/vllm-project/vllm/pull/50950
+* @rchalamala made their first contribution in https://github.com/vllm-project/vllm/pull/50487
+* @RobbieJ made their first contribution in https://github.com/vllm-project/vllm/pull/49328
+* @ruirui6946 made their first contribution in https://github.com/vllm-project/vllm/pull/52098
+* @RyanJHamby made their first contribution in https://github.com/vllm-project/vllm/pull/48420
+* @samuelkim7 made their first contribution in https://github.com/vllm-project/vllm/pull/50333
+* @shanewidanagama made their first contribution in https://github.com/vllm-project/vllm/pull/51901
+* @shikamd123 made their first contribution in https://github.com/vllm-project/vllm/pull/45043
+* @SilenNaihin made their first contribution in https://github.com/vllm-project/vllm/pull/39935
+* @skysnow2001 made their first contribution in https://github.com/vllm-project/vllm/pull/43615
+* @Sundaresan-G made their first contribution in https://github.com/vllm-project/vllm/pull/50526
+* @syedalijaseem made their first contribution in https://github.com/vllm-project/vllm/pull/47692
+* @taking-lying-flat made their first contribution in https://github.com/vllm-project/vllm/pull/51391
+* @tandixit95 made their first contribution in https://github.com/vllm-project/vllm/pull/50462
+* @Tejas-Raj01 made their first contribution in https://github.com/vllm-project/vllm/pull/49206
+* @theminghuang made their first contribution in https://github.com/vllm-project/vllm/pull/51482
+* @tobymao made their first contribution in https://github.com/vllm-project/vllm/pull/51318
+* @TrainToGPB made their first contribution in https://github.com/vllm-project/vllm/pull/50958
+* @tzulingk made their first contribution in https://github.com/vllm-project/vllm/pull/49230
+* @UgaTheDev made their first contribution in https://github.com/vllm-project/vllm/pull/51627
+* @varoudis made their first contribution in https://github.com/vllm-project/vllm/pull/50404
+* @Vegetog made their first contribution in https://github.com/vllm-project/vllm/pull/49876
+* @vitamin-chaos made their first contribution in https://github.com/vllm-project/vllm/pull/47106
+* @wangxian001 made their first contribution in https://github.com/vllm-project/vllm/pull/50276
+* @WillZZZy made their first contribution in https://github.com/vllm-project/vllm/pull/46747
+* @xiaopusun made their first contribution in https://github.com/vllm-project/vllm/pull/51495
+* @xijiaat made their first contribution in https://github.com/vllm-project/vllm/pull/50693
+* @xudonlyu made their first contribution in https://github.com/vllm-project/vllm/pull/51682
+* @yifjiang made their first contribution in https://github.com/vllm-project/vllm/pull/51218
+* @yu-xin-c made their first contribution in https://github.com/vllm-project/vllm/pull/51652
+* @zcxGGmu made their first contribution in https://github.com/vllm-project/vllm/pull/50746
+* @ziqifan617 made their first contribution in https://github.com/vllm-project/vllm/pull/51879
+* @zobinHuang made their first contribution in https://github.com/vllm-project/vllm/pull/52164
+
+## Contributors
+@yewentao256, @AndreasKaratzas, @njhill, @mgoin, @aoshen02, @khluu, @hmellor, @stefankoncarevic, @taneem-ibrahim, @LucasWilkinson, @chaunceyjiang, @jikunshang, @zufangzhu, @bigPYJ1151, @NickLucche, @askliar, @fxmarty-amd, @Rohan138, @gty111, @zhenwei-intel, @Isotr0py, @jeejeelee, @ZJY0516, @wangxiyuan, @BugenZhao, @yma11, @zyongye, @DarkLight1337, @jperezdealgaba, @zhou9402, @connorcarpenter15, @kliuae, @lucifer1004, @Alex-ai-future, @aarushjain29, @TheEpicDolphin, @chaojun-zhang, @pmanczak, @WoosukKwon, @BabyDrangoner, @noooop, @almogtavor, @hongxiayang, @fuscof-ibm, @gau-nernst, @zxd1997066, @tlrmchlsmth, @music-dino, @zexplorerhj, @S1ro1, @jdebache, @sfeng33, @mayuyuace, @ganeshr10, @benchislett, @tzulingk, @gcanlin, @ivanium, @divakar-amd, @R3hankhan123, @sagearc, @vhagor, @ronensc, @micah-wil, @qyYue1389, @vanshbhatia-amd, @hao-aaron, @chengy-sysu, @elvircrn, @taking-lying-flat, @omerpaz95, @Etelis, @vllmellm, @frank-suwen, @KernelClint, @Fangzhou-Ai, @louie-tsai, @simondanielsson, @maxyanghu, @dmai-afk, @KurodaKanbei, @ziqifan617, @bastefaniak, @ECMGit, @haregali, @cmiyai, @fede-kamel, @drakosha, @vineethsaivs, @zcxGGmu, @TQCB, @skysnow2001, @shenoyvvarun, @karen-sy, @fattchris, @RyanJHamby, @shikamd123, @namgyu-youn, @zzt93, @abmfy, @reidliu41, @Rapisurazurite, @tandixit95, @mganczarenko, @yimdev, @anujbolewar, @LiuYinfeng01, @lk-chen, @NVShreyas, @huangzhilin-hzl, @varoudis, @Yejing-Lai, @mkhazraee, @jzakrzew, @TrainToGPB, @waynehacking8, @zixi-qi, @Sundaresan-G, @mindungil, @bitborne, @Wauplin, @jacobzhang22, @zhewenl, @bnellnm, @pisceskkk, @Lin-z-w, @gabriel-peracio, @SilenNaihin, @baodii, @YunzhuLu, @xwu-intel, @BWAAEEEK, @thisjiang, @maobaolong, @anhtra3889, @JaredforReal, @lvhan028, @xiaolong-intel, @andyxning, @cleonard530, @gnovack, @MatthewBonanni, @wangxian001, @lengrongfu, @Tejas-Raj01, @simon-mo, @vitamin-chaos, @arpera, @jairitAge, @jimmy-adams, @ILikeIneine, @woosebastian, @haic0, @edwinlim0919, @fcui-amd, @jhu960213, @jinzhen-lin, @coltonottley, @walterbm, @meenchen, @matteso1, @djramic, @gchinora, @davidjpyu, @tianmu-li, @xiaopusun, @majunze2001, @Vegetog, @puririshi98, @janeyx99, @RobbieJ, @oonyshch, @thegoldenflow, @Srinivasoo7, @fatday, @acheamponge, @efschu, @rajfirke, @fanxingran, @xudonlyu, @lcskrishna, @xijiaat, @GirasoleY, @d4l3k, @samuelkim7, @tarukumar, @acmore, @theminghuang, @khushali9, @wzhao18, @Priyjain-amd, @yiz-liu, @lkm2835, @dmholtz, @Dao007forever, @liushujia122, @LopezCastroRoberto, @UgaTheDev, @tuukkjs, @aditi-amd, @guan404ming, @yiliu30, @zou3519, @Luosuu, @JoursBleu, @varun-sundar-rabindranath, @mpashkovskii, @yu-xin-c, @WillZZZy, @vrdn-23, @xyang16, @ccrhx4, @tanpinsiang, @russellb, @fxfxfxfxfxfxfxfx, @afriedri, @yifjiang, @Akashcodes732, @HF-001, @ovidiusm, @arthurgao2003, @TomerBN-Nvidia, @hotTea123, @vx120, @bohnstingl, @qwerqwerqwe8688-jpg, @jasonozuzu-cohere, @vineetatiwari27, @ruirui6946, @linitra24, @syedalijaseem, @nickus, @yzong-rh, @s3woz, @jhaotingc, @lukealonso, @Jie-Fang, @kzwrime, @xianbaoqian, @velonica0, @ccaadaro, @yisustc, @fangchenli, @iwannagotobed, @zobinHuang, @rchalamala, @shanjiaz, @jamesETsmith, @stacyroberts, @guanxingithub, @biswapanda, @shanewidanagama, @UranusSeven, @hsusul, @tobymao, @mispa-ms, @jeffreywang88, @SayHelloToWorld, @jyan-R, @oops-oom, @shantipriya-amd, @andakai, @akii96, @shen-shanshan, @Kaif10, @yitingdc, @positive666, @pavelzak, @SubSir, @ywang96

--- a/claude-skills/vllm-release-notes/examples/v0.29.0/release-notes.md
+++ b/claude-skills/vllm-release-notes/examples/v0.29.0/release-notes.md
@@ -1,0 +1,210 @@
+# v0.29.0
+
+## Highlights
+
+This release features 594 commits from 277 contributors (91 new)!
+
+* **Model Runner V2 is now the default for all models** (#53183), completing the rollout that began with pooling models (#48290). MRV2 also gained CUDA graph memory profiling for KV cache auto-sizing (#53306), batch-sharded sampling that cuts per-step logits memory by 1/TP (#50465), prompt embeds (#42963), `extract_hidden_states` speculation (#49811), padded FULL cudagraph dispatch for uniform decode under spec decode (#53407), and DP-sync skipping before EAGLE/MTP draft prefill (#53694). MRV1 remains in use for a few ROCm models and features MRV2 does not yet support.
+* **New models**: Hy4-preview, Tencent's 770B/49B-active MoE with Gated DeepSeek Sparse Attention and native MTP (#54160); Qwen3.8-Flash-Next with BF16/FP8/NVFP4 and MTP (#53896); GraniteSWA and GraniteMoeSWA (#52706); NemotronH_Omni_Reasoning_V3 with MTP (#52929, #53121); Kimi K3 NVFP4 checkpoints (#53132).
+* **Kimi-K3 and DeepSeek V4 performance**: fused MXFP4 top-k finalization in the K3 latent tail (about 5% E2E latency, #53152), K3 Mamba metadata preparation in one Triton launch (6.6-7.6x kernel speedup, #52388), tuned Hopper low-latency GEMM (#54088) now also dispatched on SM100 (#53534) and used for `eh_proj` (12.9-25.2% kernel speedup, #53942), GEMM-RS extended to GEMM-AR (#53053), MLA gate merged into the QKV-A projection (#54015), K3 DCP with DSpark (#52188) and DCP partial prefix cache hits (#50493); DeepSeek V4 shared experts fused into MegaMoE (#53040), adaptive top-k width re-landed (#52823), a native SwiGLU clamp kernel for Humming MoE (#53685), and an opt-in FlashInfer `moe_ep` expert backend (#49636).
+* **Speculative decoding**: per-request acceptance stats in OpenAI API responses via `--per-request-spec-decode-metrics` (#48915), adaptive verification extended to logprobs (#52242), SM100 sparse MLA for GLM-5.2 (#52783) and DeepSeek V4 on SM90 (#52795), Qwen3-Omni DSpark drafts (#52560), PLaMo3 EAGLE-3/DFlash (#54239), and DFlash2 loading from speculators format (#53797).
+* **RL weight sync**: a new `sharded_rdt` P2P backend where each worker pulls only its TP/EP slice over NIXL or Ray Direct Transport (#43375), rank-local IPC weight updates (#52497), sparse checkpoint-coordinate updates through native weight loaders (#50723, #53751), and routed expert loading for gpt-oss (#52209).
+* **Mamba prefix caching**: internal prefill checkpoints deliver a 9%-25% TTFT improvement (#52789); `prefix_cache_retention_interval` is now a CLI argument defaulting to 0 (#52216), with dense retention automatically restored for hybrid models using EAGLE/MTP (#55760, #55861).
+* **New defaults**: FlashInfer all-reduce enabled by default for TP CUDA groups, opt out with `VLLM_ALLREDUCE_USE_FLASHINFER=0` (#52998); prefix-cache `NONE_HASH` is deterministic by default so distributed KV cache users no longer need to pin `PYTHONHASHSEED` (#51875); new `--max-num-queued-reqs` / `--max-num-queued-tokens` admission-control flags (#49445).
+* **Breaking changes**: ten deprecated model architectures removed (#53608); FlexOlmo, Olmo3 and Hunyuan V1/VL migrated to the Transformers modeling backend (#53615); PyAV video decoder backend removed (#54231); `python -m vllm.entrypoints.openai.api_server` deprecated in favor of `vllm serve` (#52131); `VLLM_TEST_FORCE_FP8_MARLIN` (#52182) and `VLLM_ROCM_USE_AITER_FP4_ASM_GEMM` (#53141) removed.
+
+## Release Artifacts
+
+### Python Wheels
+
+| Platform | Install |
+|---|---|
+| PyPI (CUDA 13.0) | `pip install vllm` |
+| PyPI (CUDA 13.0, uv) | `uv pip install vllm --torch-backend=auto` |
+| ROCm | `pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/0.29.0/rocm723` |
+| XPU | `uv pip install vllm --extra-index-url https://wheels.vllm.ai/0.29.0/xpu --extra-index-url https://download.pytorch.org/whl/xpu --index-strategy unsafe-best-match` |
+
+### Docker Images
+
+| Platform | Docker Image |
+|---|---|
+| CUDA 13.0 (Default) | `docker pull vllm/vllm-openai:v0.29.0` (`v0.29.0-cu130` also works) |
+| CUDA 12.9 | `docker pull vllm/vllm-openai:v0.29.0-cu129` |
+| CUDA 13.0 + Ubuntu 24.04 | `docker pull vllm/vllm-openai:v0.29.0-ubuntu2404` |
+| CUDA 12.9 + Ubuntu 24.04 | `docker pull vllm/vllm-openai:v0.29.0-cu129-ubuntu2404` |
+| ROCm | `docker pull vllm/vllm-openai-rocm:v0.29.0` |
+| CPU | `docker pull vllm/vllm-openai-cpu:v0.29.0` |
+| XPU | `docker pull vllm/vllm-openai-xpu:v0.29.0` |
+
+### Other Artifacts
+
+Pre-built release artifacts are available in the **Assets** section at the bottom of this page, including:
+- Source distribution tarball
+- CUDA 12.9 Python wheels for x86_64 and arm64
+- CUDA 13.0 Python wheels for x86_64 and arm64
+- CPU Python wheels for x86_64, arm64, and macOS
+- XPU Python wheel for x86_64
+
+## Model Support
+* **New models**: Hy4-preview (#54160), Qwen3.8-Flash-Next (#53896), GraniteSWA and GraniteMoeSWA via the existing Granite implementation (#52706), NemotronH_Omni_Reasoning_V3 (#52929) with MTP for Nemotron VL models (#53121), bidirectional attention for DeepSeek-backbone embedding models (#52948), FP8 ModernBERT (#53101), and Kimi K3 NVFP4 checkpoints (#53132).
+* **Transformers modeling backend**: FlexOlmo, Olmo3 and Hunyuan V1/VL migrated off native implementations (#53615), multimodal path hardened (#51827), and `RMSNormFuser.fuse` performance fixed (#52766).
+* **Weight loading**: weight tying now inspects the checkpoint so a real `lm_head` is loaded even when the config claims tied embeddings (#51665, #53170).
+* **LoRA**: DeepSeek V4 (#53361), Qwen3-Omni multimodal LoRA (#52786, #53557), tower/connector LoRA for LLaVA-NeXT (#49788) and LFM2-VL (#51498), plus fixes for Muse-Glimmer (#53513), Qwen3.5 embedding modules (#48850), partial LoRA on Qwen3.5/3.6 GatedDeltaNet (#47640), int32 overflow in punica kernels at long context (#53034), false target matches on unsupported module types (#52313), and base-layer/routed-expert prefix ordering (#52552).
+* **Multimodal performance**: ViT full CUDA graph for Idefics3 and SmolVLM (#47625), packed encoder attention for Pixtral (#52185), fused Kimi vision Q/K RoPE kernel (#50400), Dots3 NOTE runtime (#53517) and Omni encoder optimizations (#53460), MM tensors no longer broadcast to workers for prefix-cache-covered items (#52041), redundant placeholder scans skipped (#52925), common token sequences cached (#53560), async media resolved concurrently across modalities (#54537), and H2D copies pinned to avoid stream stalls (#53412, #54292, #54299).
+* **Multimodal inputs**: video embeds accepted by the Python frontend (#54242), modality-scoped `mm_processor_kwargs` honored (#53808), Qwen3-VL profiling honors `cap_pixels_per_frame` (#54380), video frame sampling respects MP4 edit-list trims (#48608), oversized items skip the MM processor cache instead of crashing (#53016), encoder cache entries survive until their last use (#54284), and repeated multimodal requests with the SHM cache no longer terminate the engine (#54994).
+* **Correctness**: PaliGemma stale image scaling removed (#52692), Mistral3 placeholder grid with processor size overrides (#52874), MiniCPM-o on Transformers v5 (#54501), JinaVL cache order (#53553), mixed CLIP/SigLIP pooling batches (#53165), XD-RoPE models on prefix-cache hits (#53456), Qwen3-Omni audio encoder with non-divisible TP (#50858), GLM-5.2 no longer uses dense MHA (#52512), Moondream3 MoE all-reduce (#54152), deepseek-vl2 config defaults (#51302), HY-V3 compressed-tensors ignore matching (#48682), MiniMax-M3 FP8 query allocation under CUDA graph replay (#51203), and GraniteMoeHybrid quantized expert loading (#54052).
+
+## Engine Core
+* **Model Runner V2**: default for all models (#53183) and pooling models (#48290), CUDA graph memory reservation (#53306), batch-sharded sampling (#50465), prompt embeds (#42963), `extract_hidden_states` (#49811), padded FULL cudagraph dispatch (#53407), DP-sync skipping for drafts (#53694), decoupled draft/target gumbel noise streams (#54282), encoder-only path split out (#53176), and memory released correctly on shutdown and sleep (#53508, #54246, #54162, #53955, #53682).
+* **Speculative decoding**: per-request acceptance stats (#48915), adaptive verification with logprobs (#52242), on SM100 sparse MLA (#52783) and DSv4 + SM90 (#52795), varlen trtllm-gen decode (#52157), FlashInfer MLA for DSpark drafting under DCP (#54277), fused GDN MTP for all Qwen head ratios (#52539), widest uniform decode batch captured by default (#50488) with memory-safe graph sizes (#54418), and fixes for short_conv/LFM2 targets (#50272), speculators-format config overrides (#42376), DFlash draft RoPE layout (#54373), draft models with a different GQA ratio (#53002), draft models with a larger hidden size under TP (#52193), DSpark backend inheritance scoped to DeepSeek V4 (#52809), generic `DSparkDraftModel` configs for Qwen3 (#52197), and Gemma4 MTP under CUDA graphs (#53884).
+* **Prefix caching & scheduling**: Mamba internal prefill checkpoints (#52789), `prefix_cache_retention_interval` argument (#52216, #55760, #55861), deterministic `NONE_HASH` (#51875), queue admission control (#49445), KV null block reserved when validating `max_model_len` (#47272), spec decode no longer padded up to `max_model_len` (#53962), and negative external block allocation prevented (#52707).
+* **RL workflows**: `sharded_rdt` P2P weight sync (#43375), rank-local IPC updates (#52497), sparse checkpoint updates (#50723, #53751), gpt-oss routed expert loading (#52209), stable DeepSeek V4 mHC broadcast buffers across weight sync (#52626), and packed weight transfer stream reuse capping reserved-memory waste (#52951).
+* **Determinism**: `trace_decode_token_ids` for deterministic decode replay (#46701), per-arch tuned batch-invariant matmul configs (about 3x decode kernels on RTX 4090D/H20, #53247), Blackwell autotuning with 33.6% E2E latency reduction (#53649), deterministic MoE combine under DP+EP (#45683), and `fuse_allreduce_rms` disabled under batch invariance (#51292).
+* **Kernels**: fused embedding kernel (#53677), FA4 re-enabled for head_size=256 on Blackwell (#52980), vectorized sparse MLA mask loads (#52217), masked MHA prefill for GLM-5 head dimensions (#53785), GLM-5.2 sparse MLA Q concatenation fused with head padding (#53878), fused QK-norm + partial MRoPE + gate for Qwen3.6 (#52676), FlashInfer CuTeDSL BF16 low-latency GEMM as opt-in `--linear-backend flashinfer_cutedsl` (#50572), replicated embedding and norm fusion for DSV3 flat models (#48484), standardized fused shared-expert selection (#51695), GPT-OSS MoE topk metadata reuse (#45457), tuned cooperative topk (#53382), and tuned FP8 fused_moe for Qwen3.5 on L40S (+7%, #53819).
+* **Robustness**: KV cache layout standardized under a `KVCacheLayout` enum (#51718), JIT warmup provider registry (#50174), `--cpu-offload-params` now reaches vision/audio towers (#53120), attention backend probe failures no longer crash init (#51703), FlashInfer XQA falls back on unsupported head_dim (#53111), FlashInfer prefill LSE normalized before merging to fix prefix-cache logits divergence (#52796), seed preserved when a batch mixes seeded and unseeded requests (#51866), startup thread allocation accounts for local DP workers (#52385), int32 overflow fixes in fused SiLU block quant (#53409) and LoRA kernels (#53034), a shared-memory race in fused groupwise RMSNorm quantization (#54111), BLHNC addressing for FlashInfer sparse MLA (#54465), Mamba state copy race (#50729), and a `start_profile` no-op after auto-stop (#51839).
+
+## Hardware & Performance
+* **NVIDIA**: DeepSeek V3.2 / GLM-5.2 DSA routed to the optimized CUDA path on all GPUs (#52861), PCP for DSv3.2 sparse MLA (#52046), cuBLAS out_dtype router GEMM on all archs including GB10 (#54048), FlashInfer all-reduce tuning on SM103 (#53318, #53606), FA4 hdim256 on SM100 (#52980), SM120 sparse MLA fixes (#51395, #53574), DeepSeek V3.2 fused kernel grids hardened for 65k+ token launches (#52381), FlashMLA sparse decode workspace fix (#53755), MNNVL Lamport corruption fix (#53000), and opt-in Rubin Docker builds for CUDA 13.4/13.5 (#53443).
+* **AMD ROCm**: dual-stream decode with hipgraphs (#52033), W4A4 preshuffled asm GEMM by default (+15% throughput on Llama-3.3-70B MXFP4, #53141), ROCr/CLR update fixing graph replay segfaults with up to about 20% TPOT improvement (#53712), fused KDA decode on MI325X (#52293), FULL cudagraphs for AITER MLA spec decode (#51171), FP8 asm MLA prefill for non-divisor head counts (#51040), DCP causal multi-token verification (#51705) and prefix cache hits for Kimi-K3 (#53598), AITER PA gluon decode for MiniMax-M3 (#52849), DeepSeek-V4 fusions for mHC/RMSNorm (#52737), C4A top-k (#52882), C4 compressor GEMMs (#53838) and SWA q/kv norm + FP8 quant (#53540), fused shared experts for block-FP8 (#53097), CPU offload on ROCm 7.13+ (#43018), TheRock 7.14 preview docker (#49925), int4/int8 quantization fixes (#52112, #48998, #51632, #53110), CUDA graphs captured on the current stream (#53818), AITER metadata preserved across graph replay (#53821), and improved ROCm detection under WSL (#38434).
+* **Intel XPU**: INC int4 W4A8 linear backend (#50501), AutoRound MXFP8 MoE (#51248), EC connector KV offloading (#49532), and fixes for HunyuanOCR XD-RoPE (#52174), sparse-MLA metadata sync (#52066), Mamba state pointer overflow (#48109), oneCCL warm-up at world size 1 (#52389), and MRoPE (#53201).
+* **CPU**: AMX high-performance MLA backend for DeepSeek V2/V3/R1 (#52616) with MLA now running end-to-end (#51471), FP16/BF16 persisted GDN state on AMX (#52191), Int8 MoE through zentorch on AMD Zen (#44834), Voxtral support (#53921), C++ causal_conv1d GDN on non-AMX AVX-512BF16 (#49688), and assorted fixes (#54042).
+
+## Large Scale Serving
+* **Context parallelism**: Kimi-K3 DCP with DSpark (#52188) and partial prefix cache hits (#50493), FlashInfer native CP for MLA decode (#54012), FlashMLA sparse DCP on Hopper with MTP (#46514), NIXL P/D DCP for MLA models (#50611), PCP for DSv3.2 (#52046) and NIXL PCP producers (#52779), `--dcp-q-replicate` with query replication default-on for GLM sparse attention (#50382), DCP fused attention fix for DeepSeek-V3.2 / GLM-5.2 (#50005), sparse MLA metadata and kernel block sizes under DCP (#52377, #51031), PCP PIECEWISE cudagraph fixes (#53869, #53515), and PCP compatibility checks delegated to the PCP manager so plugins can enable GQA+PCP (#53853).
+* **Elastic EP**: reduced eager-mode reconfiguration downtime (#51885), AOT cache reuse preserved during scaling (#53378), and scale-below-minimum rejected (#52702).
+* **MoE communication**: DeepEP v2 receiver CPU overhead (#51114) and MXFP8 activation scale dispatch (#51398), FlashInfer one-sided All2All refinements (#51924), DeepEP v2 fixes for `--enforce-eager` startup (#51824) and the decode/cudagraph path (#52632), NCCL>=2.31 heap overflow fix (#53008), cross-node MNNVL all-reduce gated by capability (#53253), and MNNVL all-reduce buffers sized for DSpark (#50932).
+* **KV connectors**: Mooncake Store decode KV saving via `save_decode_cache` (#52466) and hybrid DCP prefix caching (#53324), externally transferable KV cache group identification (#53779), async KV loads deferred past forward launch (#53333), `kv_transfer_params` for `/inference/v1/generate` (#42644), MoRIIO shared KV region registration after the layout refactor (#53698), and Mamba fixes for Mooncake (#51362, #51358, #53663) and NIXL (#53523).
+* **KV offloading**: EC offloading connector driven by CUDA events (#49994), ownership in KV cache events (#52067, #52068), P2P tier request-level offload (#52912) and abort handling (#52571), `/dev/shm` leak on crash fixed (#52596), CPU->GPU loads ordered against compute stream (#50696), `store_threshold` counting fixed (#52227), in-flight primary keys cascaded (#53329), and padded GPU cache storage handled (#54021).
+* **Data/pipeline parallel**: PP silent corruption fix (#54962, #49274), DP coordinator wake handling (#51481), device sync on pause (#52914), TCPStore port fixes for Ray (#53666, #50969), DP supervisor inheriting the uvicorn config (#52473), EPD encoder round-robin fix (#52491), and producer-only EC config normalization (#53656).
+
+## Quantization
+* **New backends**: FlashInfer TRT-LLM MXFP8 linear (#52204), b12x FP4 MoE for SM120/SM121 (#52018), AutoRound block-wise FP8 (#47434), Humming MoE with MXFP4 weights + block-FP8 activations (#51332), and Humming for compressed-tensors WNA16 MoE (#48918).
+* **Fixes**: weight-only NVFP4 checkpoints routed through W4A16 (#54427), compressed-tensors block FP8 with Marlin (#52966) and int8 grouped WNA16 MoE (#52002), OCP MX mxfp6 activation emulation (#52704), MXFP8 FlashInfer path guarded on availability (#52648), and Humming activation aliasing (#54056).
+
+## API & Frontend
+* **New endpoints & options**: `/v1/messages/render` for the Anthropic Messages API (#45803), `/cohere/v2/chat/render` (#53219), SSE keep-alive comments for idle streams (#51034), per-request spec decode metrics (#48915), video embeds input (#54242), `--max-num-queued-reqs` / `--max-num-queued-tokens` (#49445), and pooling requests can set padding (#51157).
+* **Anthropic & Cohere**: `vllm_xargs` forwarded to sampling params (#53308), `stop_sequence` stop reason reported (#45807), Cohere citation/tool 500s fixed (#52175), and stop string limit applied (#53750).
+* **OpenAI compatibility**: `logprobs=-1` in Completions (#46175), streamed logprob offsets with echo (#47815), batched chat echo (#52529), all choices returned from `/inference/v1/generate` with n>1 (#52399), `cache_salt` forwarded for content parts (#54315), `stop_token_ids` validated against vocab (#54196), and 4xx for client errors in `/detokenize` (#52622), malformed namespace tools (#53763), malformed base64 audio (#53744), and unknown chat roles in DeepSeek encoders (#53071); tool-call arguments in replayed history are parsed defensively (#48922), empty `FlatLogprobs` slices are handled (#53704), and empty bad-word tokenizations are rejected (#53433).
+* **Structured output & parsers**: reasoning-end detection scoped to the current turn (#54089), terminal grammars stop under `min_tokens` (#54218), unsupported pattern+length schemas rejected (#49996), MistralCommonBackend tokenizers (#52720), XGrammar termination in batches (#52805), spurious FSM errors after speculative reasoning end (#53046), shared parser engine adapters (#52830), Gemma4 parenthesized tool calls (#53657) and `enable_thinking` default (#52430), HY-V3 parallel calls in one delta (#53965), GPT-OSS Harmony strict grammar (#52222), Kimi K3 reserved markers excluded from response text (#52889), and unused request-local reasoners skipped (#52573).
+* **Rust frontend**: HY3 unified parser with local XGrammar structural tags (#53054), gRPC audio/video inputs (#53760), gRPC LoRA lifecycle control (#52840, #52031, #53756), `--generation-config vllm` (#53044), `truncate_prompt_tokens` (#48584), OpenAI edge-case alignment (#53218), optimized SSE hot path (#51321), pure-Rust `protox` replacing `protoc` (#52892), RL world-size reporting (#53204) and routed expert prompt offsets (#52703), and fixes for GLM-5.2 template parity (#51426), Qwen parser auto-detection (#51169), Kimi K3 `reasoning_effort="none"` (#53043), `n > 1` rejection on `/inference/v1/generate` (#52844), and the `LogprobsTensors` wire schema (#53939).
+* **Pooling**: BGE-M3 throughput (+3.13%, #53464) and task validation (#51823), prompts truncated before padding (#54364), parallel arrays truncated with the prompt (#54407, #54509), and batched input throughput in `vllm bench serve` (#53213).
+* **CLI & tooling**: `vllm launch` runs the serve argument checks (#52825), `run_batch.py` moved out of the openai folder (#53500) with its upload retry fixed (#50588), `vllm bench` warns on a warm prefix cache for random runs (#53920) and restores multimodal datasets on the `vllm` throughput backend (#52168), and the vLLM recipes tool gained sweep recommendations and alias parsing (#53325, #53946).
+
+## Security
+* `cache_salt` length bounded to 1024 to prevent scheduler CPU exhaustion (#54353).
+* Oversized media rejected before full download (#51896); `VLLM_MAX_AUDIO_CLIP_FILESIZE_MB` enforced on all audio paths (#53561).
+* Decoder prompt-length validation enforced for processors that skip the check (#46588); PyNvVideoCodec decoder slot limit bypass fixed (#52126).
+* `api_key` and `hf_token` redacted from startup logs, compile cache factors, and the Rust frontend launch log (#52523, #53625, #53738).
+
+## Dependencies
+* FlashInfer 0.6.18 (#54313), huggingface-hub 1.28.0 (#52797), tpu-inference v0.28.0 (#54020), NIXL 1.3.2 (#51777).
+* InstantTensor added to CUDA dependencies; the loader is not enabled by default (#52801). CuPy constraint relaxed to exclude only 14.1.0 (#44284).
+* ROCm base image: ROCr/CLR update (#53712), rocprofiler-sdk 1.3.2 (#53182), TheRock 7.14 preview (#49925), LMCache connector packages (#51208).
+* XPU: vllm_xpu_kernels 0.1.14.1 (#54203), UCX install updated (#53817).
+* Build fails closed when the selected precompiled CUDA variant is unavailable (#52545).
+
+## Breaking Changes & Deprecations
+* Ten deprecated architectures removed: Arctic, Chameleon, Cheers, Fairseq2Llama, FireRedLID, GritLM, HCXVision, MPT, the `RWForCausalLM` and `StableLMEpochForCausalLM` aliases, and `PrithviGeoSpatialMAE` (superseded by `Terratorch`) (#53608).
+* FlexOlmo, Olmo3, Hunyuan V1 and Hunyuan VL are now served through the Transformers modeling backend (#53615).
+* PyAV video decoder backend removed; use OpenCV or Torchcodec (#54231).
+* `python -m vllm.entrypoints.openai.api_server` is deprecated; use `vllm serve` (#52131).
+* Model Runner V2 is the default runner for all models (#53183).
+* `prefix_cache_retention_interval` default changed from dense to 0 for SWA/SSM models; the env var is deprecated in favor of the argument (#52216).
+* FlashInfer all-reduce enabled by default (#52998).
+* `VLLM_TEST_FORCE_FP8_MARLIN` removed in favor of `--linear-backend` / `--moe-backend` (#52182); `VLLM_ROCM_USE_AITER_FP4_ASM_GEMM` removed (#53141); dead `--attention-config.use_prefill_decode_attention` removed (#52557); other long-deprecated parameters cleaned up (#53559).
+
+## New Contributors
+* @030611 made their first contribution in https://github.com/vllm-project/vllm/pull/51823
+* @92hyungjun made their first contribution in https://github.com/vllm-project/vllm/pull/47272
+* @ActiveSky made their first contribution in https://github.com/vllm-project/vllm/pull/52692
+* @adisivaprasad made their first contribution in https://github.com/vllm-project/vllm/pull/53854
+* @Agoni-02 made their first contribution in https://github.com/vllm-project/vllm/pull/48850
+* @AmitMY made their first contribution in https://github.com/vllm-project/vllm/pull/48608
+* @Andy365-365 made their first contribution in https://github.com/vllm-project/vllm/pull/52523
+* @andyluo7 made their first contribution in https://github.com/vllm-project/vllm/pull/53821
+* @AnkitNakhawa made their first contribution in https://github.com/vllm-project/vllm/pull/52491
+* @anmolgupt made their first contribution in https://github.com/vllm-project/vllm/pull/52874
+* @bobboli made their first contribution in https://github.com/vllm-project/vllm/pull/51924
+* @brianosaurus made their first contribution in https://github.com/vllm-project/vllm/pull/52557
+* @CalvinXKY made their first contribution in https://github.com/vllm-project/vllm/pull/50858
+* @canlahlah made their first contribution in https://github.com/vllm-project/vllm/pull/53409
+* @CherryLemon made their first contribution in https://github.com/vllm-project/vllm/pull/53877
+* @CHIPMUNK-T0T made their first contribution in https://github.com/vllm-project/vllm/pull/47625
+* @cogniera made their first contribution in https://github.com/vllm-project/vllm/pull/53839
+* @cr-zhao made their first contribution in https://github.com/vllm-project/vllm/pull/52385
+* @daviswer made their first contribution in https://github.com/vllm-project/vllm/pull/52706
+* @DCoEngine made their first contribution in https://github.com/vllm-project/vllm/pull/48682
+* @dineshchitlangia made their first contribution in https://github.com/vllm-project/vllm/pull/49688
+* @dkrisman made their first contribution in https://github.com/vllm-project/vllm/pull/54380
+* @dmvevents made their first contribution in https://github.com/vllm-project/vllm/pull/52632
+* @Edge-Explorer made their first contribution in https://github.com/vllm-project/vllm/pull/53435
+* @eilamc14 made their first contribution in https://github.com/vllm-project/vllm/pull/47640
+* @eligotts made their first contribution in https://github.com/vllm-project/vllm/pull/54315
+* @Eoin-Houstoun made their first contribution in https://github.com/vllm-project/vllm/pull/51703
+* @floatlibai made their first contribution in https://github.com/vllm-project/vllm/pull/52144
+* @fuzzifikation made their first contribution in https://github.com/vllm-project/vllm/pull/51034
+* @hagaikwa-redhat made their first contribution in https://github.com/vllm-project/vllm/pull/53230
+* @haoyangqian made their first contribution in https://github.com/vllm-project/vllm/pull/52690
+* @Hert4 made their first contribution in https://github.com/vllm-project/vllm/pull/51157
+* @ima-helikoptaaa made their first contribution in https://github.com/vllm-project/vllm/pull/54427
+* @jbyczkow made their first contribution in https://github.com/vllm-project/vllm/pull/52174
+* @JC-ut0 made their first contribution in https://github.com/vllm-project/vllm/pull/53071
+* @jiahaoliang made their first contribution in https://github.com/vllm-project/vllm/pull/51262
+* @JiataiWang made their first contribution in https://github.com/vllm-project/vllm/pull/53553
+* @jl9876 made their first contribution in https://github.com/vllm-project/vllm/pull/51248
+* @JulianZJN made their first contribution in https://github.com/vllm-project/vllm/pull/53253
+* @jungjiyu made their first contribution in https://github.com/vllm-project/vllm/pull/53939
+* @kyleliang-nv made their first contribution in https://github.com/vllm-project/vllm/pull/51203
+* @LH-and-FPGA made their first contribution in https://github.com/vllm-project/vllm/pull/52648
+* @li-ukumar made their first contribution in https://github.com/vllm-project/vllm/pull/52571
+* @LioEinaudi made their first contribution in https://github.com/vllm-project/vllm/pull/53247
+* @LironKesem made their first contribution in https://github.com/vllm-project/vllm/pull/53921
+* @Lossfull made their first contribution in https://github.com/vllm-project/vllm/pull/52948
+* @lxy-alexander made their first contribution in https://github.com/vllm-project/vllm/pull/52430
+* @lxyxinyi made their first contribution in https://github.com/vllm-project/vllm/pull/50809
+* @machero made their first contribution in https://github.com/vllm-project/vllm/pull/53531
+* @matthewkotila made their first contribution in https://github.com/vllm-project/vllm/pull/48915
+* @mhoqueanik made their first contribution in https://github.com/vllm-project/vllm/pull/49636
+* @mhuzaifa3 made their first contribution in https://github.com/vllm-project/vllm/pull/53625
+* @minjang made their first contribution in https://github.com/vllm-project/vllm/pull/53530
+* @MKQuantum made their first contribution in https://github.com/vllm-project/vllm/pull/51866
+* @new-TonyWang made their first contribution in https://github.com/vllm-project/vllm/pull/53704
+* @nicholaskh-ai made their first contribution in https://github.com/vllm-project/vllm/pull/53819
+* @oliverholworthy made their first contribution in https://github.com/vllm-project/vllm/pull/52185
+* @prakharPant made their first contribution in https://github.com/vllm-project/vllm/pull/52743
+* @Prudhvivuda made their first contribution in https://github.com/vllm-project/vllm/pull/53016
+* @rajathpi made their first contribution in https://github.com/vllm-project/vllm/pull/52622
+* @ray24777 made their first contribution in https://github.com/vllm-project/vllm/pull/53120
+* @roachsinai made their first contribution in https://github.com/vllm-project/vllm/pull/53528
+* @RookieCoder-Camera made their first contribution in https://github.com/vllm-project/vllm/pull/49274
+* @sandeep-maddipatla made their first contribution in https://github.com/vllm-project/vllm/pull/51777
+* @seonjinn made their first contribution in https://github.com/vllm-project/vllm/pull/52204
+* @ShengleiFu made their first contribution in https://github.com/vllm-project/vllm/pull/53650
+* @shepark made their first contribution in https://github.com/vllm-project/vllm/pull/51302
+* @shijuzhao made their first contribution in https://github.com/vllm-project/vllm/pull/45683
+* @shipiyouniao made their first contribution in https://github.com/vllm-project/vllm/pull/51979
+* @ShuaiShao93 made their first contribution in https://github.com/vllm-project/vllm/pull/53034
+* @simon-veitner-redhat made their first contribution in https://github.com/vllm-project/vllm/pull/52980
+* @sseanliu made their first contribution in https://github.com/vllm-project/vllm/pull/52041
+* @studioego made their first contribution in https://github.com/vllm-project/vllm/pull/52389
+* @tanchao made their first contribution in https://github.com/vllm-project/vllm/pull/50191
+* @thanhpt1110 made their first contribution in https://github.com/vllm-project/vllm/pull/52720
+* @theamalsebastian made their first contribution in https://github.com/vllm-project/vllm/pull/52588
+* @thunguo made their first contribution in https://github.com/vllm-project/vllm/pull/53101
+* @tolleybot made their first contribution in https://github.com/vllm-project/vllm/pull/51292
+* @tommy-asai-sonarsource made their first contribution in https://github.com/vllm-project/vllm/pull/51395
+* @tthakkal made their first contribution in https://github.com/vllm-project/vllm/pull/50501
+* @ukannika made their first contribution in https://github.com/vllm-project/vllm/pull/52849
+* @VBS2004 made their first contribution in https://github.com/vllm-project/vllm/pull/48922
+* @wyettzeng made their first contribution in https://github.com/vllm-project/vllm/pull/52209
+* @Xuan-1998 made their first contribution in https://github.com/vllm-project/vllm/pull/53008
+* @y0hnn made their first contribution in https://github.com/vllm-project/vllm/pull/52002
+* @Yiqin-17 made their first contribution in https://github.com/vllm-project/vllm/pull/52925
+* @YukioZzz made their first contribution in https://github.com/vllm-project/vllm/pull/51705
+* @ZHIHANCHEN03 made their first contribution in https://github.com/vllm-project/vllm/pull/53432
+* @Zhou248 made their first contribution in https://github.com/vllm-project/vllm/pull/52560
+* @zllion made their first contribution in https://github.com/vllm-project/vllm/pull/46701
+* @zwischenraum made their first contribution in https://github.com/vllm-project/vllm/pull/50272
+
+## Contributors
+@AndreasKaratzas, @khluu, @mgoin, @taneem-ibrahim, @yewentao256, @njhill, @BugenZhao, @hmellor, @GirasoleY, @DarkLight1337, @mayuyuace, @WoosukKwon, @jeejeelee, @noooop, @jperezdealgaba, @LucasWilkinson, @wzhao18, @stefankoncarevic, @gau-nernst, @okorzh-amd, @ZJY0516, @HollowMan6, @connorcarpenter15, @gcanlin, @aoshen02, @linitra24, @mhuzaifa3, @Isotr0py, @Etelis, @MatthewBonanni, @TheEpicDolphin, @zupengwang, @atalman, @NickLucche, @rasmith, @elvircrn, @JasonKeyiL, @Hotragn, @waizuichougou, @pmanczak, @divakar-amd, @he-yufeng, @xuebwang-amd, @qgallouedec, @esmeetu, @ZeldaHuang, @Prudhvivuda, @chaunceyjiang, @zxd1997066, @louie-tsai, @andyxning, @pisceskkk, @tjtanaa, @qli88, @tlrmchlsmth, @LopezCastroRoberto, @micah-wil, @hongxiayang, @BabyDrangoner, @yimdev, @mganczarenko, @SageMoore, @biswapanda, @sfeng33, @russellb, @itayalroy, @bigPYJ1151, @drakosha, @qwerqwerqwe8688-jpg, @akii96, @shen-shanshan, @meiyeh123, @reidliu41, @yma11, @frgossen, @lukealonso, @tanchao, @Fangzhou-Ai, @vllm-agent, @djramic, @andrewbcohere, @zyongye, @gty111, @ShuoleiWang, @ZHIHANCHEN03, @KurodaKanbei, @alexeldeib, @khushali9, @xiaohuguo2023, @hungnnvidia, @thisjiang, @arpera, @ShengleiFu, @zhenwei-intel, @jungjiyu, @yzong-rh, @charlifu, @hclsys, @Ronald1995, @mkhazraee, @YukioZzz, @theamalsebastian, @030611, @cr-zhao, @jbyczkow, @tommy-asai-sonarsource, @jikunshang, @bobboli, @LH-and-FPGA, @SayHelloToWorld, @kkt-cohere, @floatlibai, @rajathpi, @lxy-alexander, @gangula-karthik, @ActiveSky, @fxmarty-amd, @sstamenk, @mpashkovskii, @LiuYinfeng01, @chaojun-zhang, @Oxygen56, @daviswer, @vineethsaivs, @Agoni-02, @Andy365-365, @wangxiyuan, @haoyangqian, @Naveassaf, @eilamc14, @sseanliu, @y0hnn, @dineshchitlangia, @yiliu30, @Lossfull, @lxyxinyi, @vanshbhatia-amd, @jcotant-inferact, @chengy-sysu, @92hyungjun, @xyang16, @AmitMY, @zllion, @AnkitNakhawa, @dmvevents, @lengrongfu, @JC-ut0, @Eoin-Houstoun, @sagearc, @wjabbour, @sandeep-maddipatla, @seonjinn, @Yiqin-17, @kyleliang-nv, @thanhpt1110, @MKQuantum, @matthewkotila, @vhagor, @tthakkal, @ShuaiShao93, @hagaikwa-redhat, @shijuzhao, @elwhyjay, @Gregory-Pereira, @ErenAta16, @morrison-turnansky, @DCoEngine, @SoluMilken, @xianbaoqian, @kliuae, @nascheme, @waynehacking8, @stecasta, @vMaroon, @zwischenraum, @Rohan138, @Zhou248, @brianosaurus, @anmolgupt, @wyettzeng, @hao-aaron, @frank-suwen, @danisereb, @fuzzifikation, @KernelClint, @thunguo, @studioego, @shipiyouniao, @cjackal, @LioEinaudi, @guan404ming, @libinta, @mhoqueanik, @minjang, @Edge-Explorer, @shepark, @JiataiWang, @jiahaoliang, @therealnaveenkamal, @ColinZ22, @tolleybot, @almogtavor, @simon-veitner-redhat, @hyeongyun0916, @nicholaskh-ai, @mawong-amd, @adisivaprasad, @ray24777, @robertgshaw2-redhat, @new-TonyWang, @oliverholworthy, @fanxingran, @lucianommartins, @hallerite, @avininjamay8, @VBS2004, @omerpaz95, @Sunt-ing, @Hert4, @wangshangsam, @cogniera, @jeffreywang88, @Xarbirus, @fynnsu, @jiahanc, @zixi-qi, @prakharPant, @haic0, @maobaolong, @xinyu-intel, @CHIPMUNK-T0T, @hangy-amd, @afriedri, @canlahlah, @Alnusjaponica, @ukannika, @pranavthakur0-0, @zzaebok, @Xuan-1998, @JulianZJN, @roachsinai, @ivanium, @CalvinXKY, @yu-xin-c, @rchalamala, @QwertyJack, @Kaif10, @yudigege86, @yiz-liu, @dkrisman, @simondanielsson, @machero, @CherryLemon, @ima-helikoptaaa, @RookieCoder-Camera, @LironKesem, @peakcrosser7, @eligotts, @foraxe, @zufangzhu, @tianmu-li, @jl9876, @lucifer1004, @liranschour, @maithilijoshi20, @li-ukumar, @andyluo7, @Zhenzhong1, @faaany, @joerowell, @juhi10071998, @ganeshr10, @Priyjain-amd, @SubSir, @luyixiao95, @djw8605, @codex

--- a/claude-skills/vllm-release-notes/examples/v0.29.0/slack-announcement.md
+++ b/claude-skills/vllm-release-notes/examples/v0.29.0/slack-announcement.md
@@ -1,0 +1,43 @@
+# v0.29.0 Slack announcement
+
+## Main message
+
+Hi all,
+We just finished vLLM v0.29.0 release today. :rocket: This release features 594 commits from 277 contributors. We also welcomed 91 new contributors to vLLM!
+A few highlights of this release: Model Runner V2 is now the default for all models, new models (Hy4-preview, Qwen3.8-Flash-Next), Kimi K3 and DeepSeek V4 performance push, new RL weight sync backends, and more!
+More details and install instructions in :thread:
+
+Thank you everyone for your contributions to the new version of :vllm: :pray:
+
+## Thread reply (install instructions)
+
+• Python wheels:
+    ◦ PyPI (CUDA 13.0):
+        ▪ Install with `pip install vllm`
+        ▪ (Preferred) `uv pip install vllm --torch-backend=auto`
+    ◦ ROCm: `pip install vllm --extra-index-url https://wheels.vllm.ai/rocm/0.29.0/rocm723`
+    ◦ XPU: `uv pip install vllm --extra-index-url https://wheels.vllm.ai/0.29.0/xpu --extra-index-url https://download.pytorch.org/whl/xpu --index-strategy unsafe-best-match`
+• Docker images (`latest` tag also works in place of every `v0.29.0` tag here):
+    ◦ CUDA 13.0 (Default) `docker pull vllm/vllm-openai:v0.29.0` (`v0.29.0-cu130` also works)
+    ◦ CUDA 12.9: `docker pull vllm/vllm-openai:v0.29.0-cu129`
+    ◦ CUDA 13.0 Ubuntu 24.04: `docker pull vllm/vllm-openai:v0.29.0-ubuntu2404`
+    ◦ CUDA 12.9 Ubuntu 24.04: `docker pull vllm/vllm-openai:v0.29.0-cu129-ubuntu2404`
+    ◦ ROCm: `docker pull vllm/vllm-openai-rocm:v0.29.0`
+    ◦ CPU: `docker pull vllm/vllm-openai-cpu:v0.29.0`
+    ◦ XPU: `docker pull vllm/vllm-openai-xpu:v0.29.0`
+• Github Release: https://github.com/vllm-project/vllm/releases/tag/v0.29.0
+    ◦ Source distribution tarball
+    ◦ CUDA 12.9 Python wheels for x86_64 and arm64
+    ◦ CUDA 13.0 Python wheels for x86_64 and arm64
+    ◦ CPU Python wheel for x86_64, arm64, and MacOS
+    ◦ XPU Python wheel for x86_64
+
+## Thread reply (heads-up on breaking changes)
+
+:warning: A few breaking changes to be aware of in v0.29.0:
+• Model Runner V2 is now the default runner for all models (MRV1 still used for a few ROCm models and unsupported features).
+• Ten deprecated model architectures were removed (Arctic, Chameleon, Cheers, Fairseq2Llama, FireRedLID, GritLM, HCXVision, MPT, RW/StableLMEpoch aliases, PrithviGeoSpatialMAE). FlexOlmo, Olmo3 and Hunyuan V1/VL now run via the Transformers modeling backend.
+• PyAV video decoder backend removed; use OpenCV or Torchcodec.
+• `python -m vllm.entrypoints.openai.api_server` is deprecated; use `vllm serve`.
+• `prefix_cache_retention_interval` is now a CLI arg and defaults to 0 for SWA/SSM models (dense retention kept automatically for hybrid models with EAGLE/MTP).
+Full list in the "Breaking Changes & Deprecations" section of the release notes.

--- a/claude-skills/vllm-release-notes/fetch_commits.py
+++ b/claude-skills/vllm-release-notes/fetch_commits.py
@@ -1,0 +1,1592 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["requests", "python-dotenv"]
+# ///
+"""
+Fetch all commits between two tags from a GitHub repository.
+Usage: uv run fetch_commits.py --base-tag vA --head-tag vB --output 0-current-raw-commits.md --stats
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+
+import dotenv
+import requests
+
+# Load .env.local first (higher priority), then .env as fallback
+dotenv.load_dotenv(".env.local")
+dotenv.load_dotenv()  # .env as fallback
+
+
+def get_github_token():
+    """Get GitHub token from environment or argument."""
+    return os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+
+
+def resolve_tag_to_sha(base_url: str, tag: str, headers: dict) -> str:
+    """Resolve a tag name to its commit SHA."""
+    print(f"Resolving tag {tag}...")
+
+    tag_resp = requests.get(f"{base_url}/git/refs/tags/{tag}", headers=headers)
+    if tag_resp.status_code != 200:
+        raise Exception(f"Failed to get tag {tag}: {tag_resp.text}")
+
+    tag_data = tag_resp.json()
+    sha = tag_data["object"]["sha"]
+
+    # If it's an annotated tag, we need to get the commit it points to
+    if tag_data["object"]["type"] == "tag":
+        tag_obj_resp = requests.get(f"{base_url}/git/tags/{sha}", headers=headers)
+        if tag_obj_resp.status_code == 200:
+            sha = tag_obj_resp.json()["object"]["sha"]
+
+    return sha
+
+
+def resolve_commit_sha(base_url: str, commit_ref: str, headers: dict) -> str:
+    """Resolve a commit reference (SHA or short SHA) to full SHA."""
+    print(f"Resolving commit {commit_ref}...")
+
+    commit_resp = requests.get(f"{base_url}/commits/{commit_ref}", headers=headers)
+    if commit_resp.status_code != 200:
+        raise Exception(f"Failed to get commit {commit_ref}: {commit_resp.text}")
+
+    return commit_resp.json()["sha"]
+
+
+def get_default_branch_head(base_url: str, headers: dict) -> tuple[str, str]:
+    """
+    Get the HEAD commit of the default branch.
+
+    Returns:
+        Tuple of (branch_name, head_sha)
+    """
+    print("Getting default branch HEAD...")
+
+    # Get repository info to find default branch
+    repo_resp = requests.get(base_url, headers=headers)
+    if repo_resp.status_code != 200:
+        raise Exception(f"Failed to get repository info: {repo_resp.text}")
+
+    default_branch = repo_resp.json()["default_branch"]
+    print(f"  Default branch: {default_branch}")
+
+    # Get the HEAD commit of the default branch
+    branch_resp = requests.get(f"{base_url}/branches/{default_branch}", headers=headers)
+    if branch_resp.status_code != 200:
+        raise Exception(f"Failed to get branch {default_branch}: {branch_resp.text}")
+
+    head_sha = branch_resp.json()["commit"]["sha"]
+    print(f"  HEAD: {head_sha[:8]}")
+
+    return (default_branch, head_sha)
+
+
+def get_all_tags(base_url: str, headers: dict) -> list[dict]:
+    """Get all tags from the repository with their commit SHAs and dates."""
+    print("Fetching all tags...")
+
+    all_tags = []
+    page = 1
+    per_page = 100
+
+    while True:
+        resp = requests.get(
+            f"{base_url}/tags",
+            headers=headers,
+            params={"per_page": per_page, "page": page},
+        )
+
+        if resp.status_code != 200:
+            raise Exception(f"Failed to get tags: {resp.text}")
+
+        tags = resp.json()
+        if not tags:
+            break
+
+        all_tags.extend(tags)
+        page += 1
+
+        if len(tags) < per_page:
+            break
+
+    print(f"  Found {len(all_tags)} tags")
+    return all_tags
+
+
+def get_commit_date(base_url: str, sha: str, headers: dict) -> str:
+    """Get the commit date for a given SHA."""
+    commit_resp = requests.get(f"{base_url}/commits/{sha}", headers=headers)
+    if commit_resp.status_code != 200:
+        return None
+    return commit_resp.json()["commit"]["committer"]["date"]
+
+
+def find_previous_tag(
+    base_url: str, head_sha: str, headers: dict, tag_pattern: str | None = None
+) -> tuple[str, str] | None:
+    """
+    Find the most recent tag that is an ancestor of the given commit.
+
+    Uses git history to find tags that are reachable from the commit.
+
+    Args:
+        base_url: GitHub API base URL
+        head_sha: The commit SHA to search from
+        headers: Request headers
+        tag_pattern: Optional regex pattern to filter tags (e.g., r'^v\\d+\\.\\d+\\.\\d+$')
+
+    Returns:
+        Tuple of (tag_name, tag_sha) or None if no tag found
+    """
+    print(f"Finding previous tag before commit {head_sha[:8]}...")
+
+    # Get the date of the head commit
+    head_date = get_commit_date(base_url, head_sha, headers)
+    if not head_date:
+        print("  Warning: Could not get head commit date")
+        return None
+
+    print(f"  Head commit date: {head_date}")
+
+    # Get all tags
+    all_tags = get_all_tags(base_url, headers)
+
+    # Filter tags by pattern if provided
+    if tag_pattern:
+        import re
+
+        pattern = re.compile(tag_pattern)
+        all_tags = [t for t in all_tags if pattern.match(t["name"])]
+        print(f"  After pattern filter: {len(all_tags)} tags")
+
+    # For each tag, check if it's an ancestor of head_sha and get its date
+    tag_candidates = []
+
+    for tag in all_tags:
+        tag_name = tag["name"]
+        tag_commit_sha = tag["commit"]["sha"]
+
+        # Skip if this is the same commit as head
+        if tag_commit_sha == head_sha:
+            continue
+
+        # Check if this tag's commit is an ancestor of head
+        compare_resp = requests.get(
+            f"{base_url}/compare/{tag_commit_sha}...{head_sha}", headers=headers
+        )
+
+        if compare_resp.status_code != 200:
+            continue
+
+        compare_data = compare_resp.json()
+
+        # If tag is behind head (status = "behind" or "ahead"), it's an ancestor
+        # We want tags where the comparison shows head is ahead
+        if compare_data.get("status") in ["ahead", "diverged"]:
+            # Get the tag's commit date
+            tag_date = get_commit_date(base_url, tag_commit_sha, headers)
+            if tag_date and tag_date < head_date:
+                tag_candidates.append(
+                    {
+                        "name": tag_name,
+                        "sha": tag_commit_sha,
+                        "date": tag_date,
+                        "ahead_by": compare_data.get("ahead_by", 0),
+                    }
+                )
+                print(
+                    f"  Found candidate: {tag_name} ({compare_data.get('ahead_by', 0)} commits behind)"
+                )
+
+    if not tag_candidates:
+        print("  No previous tag found")
+        return None
+
+    # Sort by date (most recent first) or by ahead_by (smallest first)
+    # Using ahead_by gives us the closest tag
+    tag_candidates.sort(key=lambda x: x["ahead_by"])
+
+    best_tag = tag_candidates[0]
+    print(f"  Selected: {best_tag['name']} ({best_tag['ahead_by']} commits behind)")
+
+    return (best_tag["name"], best_tag["sha"])
+
+
+def fetch_commits_between_tags(
+    owner: str, repo: str, base_tag: str, head_tag: str, token: str | None = None
+) -> list[dict]:
+    """
+    Fetch all commits between two tags by walking the commit graph.
+
+    This method traverses from head_tag back to base_tag, collecting all commits.
+    It properly handles the commit history and doesn't rely on date filtering.
+
+    Args:
+        owner: Repository owner (e.g., 'vllm-project')
+        repo: Repository name (e.g., 'vllm')
+        base_tag: Base tag (older, e.g., 'v0.11.2')
+        head_tag: Head tag (newer, e.g., 'v0.12.0')
+        token: Optional GitHub token for higher rate limits
+
+    Returns:
+        List of commit dictionaries
+    """
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+    }
+    if token:
+        headers["Authorization"] = f"token {token}"
+
+    base_url = f"https://api.github.com/repos/{owner}/{repo}"
+
+    # Resolve tags to commit SHAs
+    base_sha = resolve_tag_to_sha(base_url, base_tag, headers)
+    head_sha = resolve_tag_to_sha(base_url, head_tag, headers)
+
+    print(f"\nBase SHA ({base_tag}): {base_sha}")
+    print(f"Head SHA ({head_tag}): {head_sha}")
+
+    # First, use Compare API to get total commit count (for progress info)
+    print(f"\nComparing {base_tag}...{head_tag}...")
+    compare_resp = requests.get(
+        f"{base_url}/compare/{base_sha}...{head_sha}", headers=headers
+    )
+    if compare_resp.status_code == 200:
+        compare_data = compare_resp.json()
+        total_commits = compare_data.get("total_commits", "unknown")
+        print(f"Total commits to fetch: {total_commits}")
+
+    # Walk the commit history from head to base
+    # We use the commits API starting from head_sha and stop when we reach base_sha
+    all_commits = []
+    seen_shas = set()
+    seen_shas.add(base_sha)  # Don't include the base commit itself
+
+    # BFS traversal of commit graph
+    to_visit = [head_sha]
+    page_count = 0
+
+    print(f"\nFetching commits from {head_tag} back to {base_tag}...")
+
+    while to_visit:
+        current_sha = to_visit.pop(0)
+
+        if current_sha in seen_shas:
+            continue
+
+        seen_shas.add(current_sha)
+
+        # Fetch commit details
+        commit_resp = requests.get(f"{base_url}/commits/{current_sha}", headers=headers)
+
+        if commit_resp.status_code != 200:
+            print(f"  Warning: Failed to fetch commit {current_sha[:8]}")
+            continue
+
+        commit = commit_resp.json()
+        all_commits.append(commit)
+
+        # Add parent commits to visit queue
+        for parent in commit.get("parents", []):
+            parent_sha = parent["sha"]
+            if parent_sha not in seen_shas:
+                to_visit.append(parent_sha)
+
+        # Progress logging
+        if len(all_commits) % 50 == 0:
+            page_count += 1
+            print(f"  Fetched {len(all_commits)} commits...")
+
+    print(f"  Completed: {len(all_commits)} commits fetched")
+
+    return all_commits
+
+
+def fetch_commits_by_date_range(
+    owner: str,
+    repo: str,
+    since: str,
+    until: str,
+    token: str | None = None,
+    branch: str | None = None,
+) -> list[dict]:
+    """
+    Fetch all commits within a date range.
+
+    Args:
+        owner: Repository owner (e.g., 'vllm-project')
+        repo: Repository name (e.g., 'vllm')
+        since: Start date (ISO 8601 format, e.g., '2025-01-01' or '2025-01-01T00:00:00Z')
+        until: End date (ISO 8601 format, e.g., '2025-01-31' or '2025-01-31T23:59:59Z')
+        token: Optional GitHub token for higher rate limits
+        branch: Optional branch name (defaults to repository's default branch)
+
+    Returns:
+        List of commit dictionaries
+    """
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+    }
+    if token:
+        headers["Authorization"] = f"token {token}"
+
+    base_url = f"https://api.github.com/repos/{owner}/{repo}"
+    per_page = 100
+
+    # Normalize date format - add time if not present
+    if len(since) == 10:  # YYYY-MM-DD format
+        since = f"{since}T00:00:00Z"
+    if len(until) == 10:  # YYYY-MM-DD format
+        until = f"{until}T23:59:59Z"
+
+    print(f"\nFetching commits from {since} to {until}...")
+    if branch:
+        print(f"  Branch: {branch}")
+
+    all_commits = []
+    page = 1
+
+    while True:
+        params = {"since": since, "until": until, "per_page": per_page, "page": page}
+        if branch:
+            params["sha"] = branch
+
+        response = requests.get(f"{base_url}/commits", headers=headers, params=params)
+
+        if response.status_code != 200:
+            raise Exception(f"Failed to fetch commits: {response.text}")
+
+        commits = response.json()
+        if not commits:
+            break
+
+        all_commits.extend(commits)
+        print(
+            f"  Page {page}: fetched {len(commits)} commits (total: {len(all_commits)})"
+        )
+
+        if len(commits) < per_page:
+            break
+
+        page += 1
+
+    print(f"  Completed: {len(all_commits)} commits fetched")
+    return all_commits
+
+
+def get_merge_base(
+    base_url: str, base_sha: str, head_sha: str, headers: dict
+) -> str | None:
+    """
+    Get the merge base (common ancestor) of two commits.
+
+    Args:
+        base_url: GitHub API base URL for the repo
+        base_sha: First commit SHA
+        head_sha: Second commit SHA
+        headers: Request headers
+
+    Returns:
+        Merge base commit SHA, or None if not found
+    """
+    # GitHub Compare API returns merge_base_commit
+    compare_resp = requests.get(
+        f"{base_url}/compare/{base_sha}...{head_sha}",
+        headers=headers,
+    )
+
+    if compare_resp.status_code != 200:
+        return None
+
+    compare_data = compare_resp.json()
+    merge_base = compare_data.get("merge_base_commit", {}).get("sha")
+    return merge_base
+
+
+def fetch_commits_by_walking_history(
+    base_url: str,
+    base_sha: str,
+    head_sha: str,
+    base_tag: str,
+    head_tag: str,
+    headers: dict,
+    stop_sha: str | None = None,
+) -> list[dict]:
+    """
+    Fetch commits by walking the commit history from head to a stop point.
+
+    This method correctly handles release branches with cherry-picks.
+    It walks the head's commit history until it reaches the stop commit.
+
+    Args:
+        base_url: GitHub API base URL for the repo
+        base_sha: Base commit SHA (for display purposes)
+        head_sha: Head commit SHA (newer)
+        base_tag: Display name for base reference
+        head_tag: Display name for head reference
+        headers: Request headers
+        stop_sha: SHA to stop at (if None, uses base_sha)
+
+    Returns:
+        List of commit dictionaries (excluding stop commit)
+    """
+    per_page = 100
+    all_commits = []
+    page = 1
+    target_sha = stop_sha or base_sha
+
+    print(f"\nWalking commit history from {head_tag} back to {base_tag}...")
+    print(f"  Stop SHA: {target_sha[:8]}")
+
+    while True:
+        response = requests.get(
+            f"{base_url}/commits",
+            headers=headers,
+            params={"sha": head_sha, "per_page": per_page, "page": page},
+        )
+
+        if response.status_code != 200:
+            print(f"  Warning: API error on page {page}, stopping")
+            break
+
+        commits = response.json()
+        if not commits:
+            print(f"  No more commits found on page {page}")
+            break
+
+        found_stop = False
+        for commit in commits:
+            if commit["sha"] == target_sha:
+                # Reached stop commit, stop (don't include it)
+                found_stop = True
+                break
+            all_commits.append(commit)
+
+        print(
+            f"  Page {page}: fetched {len(commits)} commits (total: {len(all_commits)})"
+        )
+
+        if found_stop:
+            print(f"  Reached stop commit ({target_sha[:8]})")
+            break
+
+        if len(commits) < per_page:
+            print("  Warning: Reached end of history without finding stop commit")
+            break
+
+        page += 1
+
+    return all_commits
+
+
+def fetch_commits_between_tags_fast(
+    owner: str,
+    repo: str,
+    base_tag: str,
+    head_tag: str,
+    token: str | None = None,
+    head_is_commit: bool = False,
+    base_is_commit: bool = False,
+) -> list[dict]:
+    """
+    Fetch all commits between two tags using GitHub Compare API with pagination.
+
+    This properly fetches only the commits between the two tags.
+    Automatically handles diverged branches (e.g., release branches with cherry-picks)
+    by falling back to walking the commit history.
+
+    Args:
+        owner: Repository owner (e.g., 'vllm-project')
+        repo: Repository name (e.g., 'vllm')
+        base_tag: Base tag (older, e.g., 'v0.11.2') or commit SHA if base_is_commit=True
+        head_tag: Head tag (newer, e.g., 'v0.12.0') or commit SHA if head_is_commit=True
+        token: Optional GitHub token for higher rate limits
+        head_is_commit: If True, treat head_tag as a commit SHA instead of a tag
+        base_is_commit: If True, treat base_tag as a commit SHA instead of a tag
+
+    Returns:
+        List of commit dictionaries
+    """
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+    }
+    if token:
+        headers["Authorization"] = f"token {token}"
+
+    base_url = f"https://api.github.com/repos/{owner}/{repo}"
+    per_page = 100
+
+    # Resolve to commit SHAs
+    if base_is_commit:
+        base_sha = resolve_commit_sha(base_url, base_tag, headers)
+    else:
+        base_sha = resolve_tag_to_sha(base_url, base_tag, headers)
+
+    if head_is_commit:
+        head_sha = resolve_commit_sha(base_url, head_tag, headers)
+    else:
+        head_sha = resolve_tag_to_sha(base_url, head_tag, headers)
+
+    print(f"\nBase SHA ({base_tag}): {base_sha}")
+    print(f"Head SHA ({head_tag}): {head_sha}")
+
+    # Use Compare API to check relationship and get commits
+    print(f"\nComparing {base_tag}...{head_tag}...")
+    compare_resp = requests.get(
+        f"{base_url}/compare/{base_sha}...{head_sha}",
+        headers=headers,
+        params={"per_page": per_page},
+    )
+
+    if compare_resp.status_code != 200:
+        raise Exception(f"Failed to compare: {compare_resp.text}")
+
+    compare_data = compare_resp.json()
+    status = compare_data.get("status", "unknown")
+    total_commits = compare_data.get("total_commits", 0)
+
+    print(f"  Comparison status: {status}")
+    print(f"  Total commits: {total_commits}")
+
+    # Get merge_base for potential fallback
+    merge_base = compare_data.get("merge_base_commit", {}).get("sha")
+
+    # If branches have diverged (e.g., release branch with cherry-picks),
+    # we need to filter by PR numbers to avoid duplicates
+    is_diverged = status == "diverged"
+
+    if is_diverged:
+        print("\n  Branches have diverged (likely a release branch scenario)")
+        print("  Will filter by PR numbers to handle cherry-picks...")
+        if merge_base:
+            print(f"  Merge base: {merge_base[:8]}")
+
+    # Use Compare API results
+    all_commits = compare_data.get("commits", [])
+    print(f"  Initial fetch: {len(all_commits)} commits")
+
+    if len(all_commits) >= total_commits:
+        print("  All commits fetched in initial response")
+        return all_commits
+
+    # Need to paginate - try Compare API pagination first
+    page = 1
+    while len(all_commits) < total_commits:
+        page += 1
+        print(f"  Fetching page {page}...")
+
+        compare_resp = requests.get(
+            f"{base_url}/compare/{base_sha}...{head_sha}",
+            headers=headers,
+            params={"per_page": per_page, "page": page},
+        )
+
+        if compare_resp.status_code != 200:
+            # Compare API doesn't support pagination well for large diffs
+            print("  Compare API pagination not supported, using commit walk...")
+            break
+
+        page_data = compare_resp.json()
+        page_commits = page_data.get("commits", [])
+
+        if not page_commits:
+            break
+
+        all_commits.extend(page_commits)
+        print(
+            f"  Page {page}: got {len(page_commits)} commits (total: {len(all_commits)})"
+        )
+
+    # If we still don't have all commits, walk the history
+    if len(all_commits) < total_commits:
+        print(
+            f"\n  Need to fetch remaining {total_commits - len(all_commits)} commits via history walk..."
+        )
+
+        # For diverged branches, use merge_base as stop point
+        # For non-diverged, use base_sha
+        stop_sha = merge_base if (status == "diverged" and merge_base) else base_sha
+
+        # Get commits we already have
+        seen_shas = {c["sha"] for c in all_commits}
+
+        # Walk from head, collecting commits not already seen, until we reach stop point
+        walk_commits = []
+        walk_page = 1
+        found_stop = False
+
+        while len(all_commits) + len(walk_commits) < total_commits and not found_stop:
+            response = requests.get(
+                f"{base_url}/commits",
+                headers=headers,
+                params={"sha": head_sha, "per_page": per_page, "page": walk_page},
+            )
+
+            if response.status_code != 200:
+                print(f"  Warning: API error on page {walk_page}")
+                break
+
+            commits = response.json()
+            if not commits:
+                break
+
+            for commit in commits:
+                sha = commit["sha"]
+                if sha == stop_sha:
+                    found_stop = True
+                    break
+                if sha not in seen_shas:
+                    seen_shas.add(sha)
+                    walk_commits.append(commit)
+
+            print(
+                f"  Walk page {walk_page}: found {len(walk_commits)} additional commits"
+            )
+            walk_page += 1
+
+        # Combine: Compare API commits first (they're in order), then walk commits
+        # Actually, we should return all unique commits
+        all_commits.extend(walk_commits)
+        print(f"  Total after walk: {len(all_commits)} commits")
+
+    # For diverged branches, filter out commits whose PRs are already in base release
+    # This handles cherry-picks that exist in both releases
+    if is_diverged:
+        print(f"\n  Filtering out PRs already in {base_tag}...")
+
+        # Get base release commits to extract PR numbers
+        print(f"  Fetching {base_tag} commits...")
+        base_commits = []
+        base_page = 1
+        while True:
+            response = requests.get(
+                f"{base_url}/commits",
+                headers=headers,
+                params={"sha": base_sha, "per_page": per_page, "page": base_page},
+            )
+            if response.status_code != 200:
+                break
+            commits = response.json()
+            if not commits:
+                break
+
+            for commit in commits:
+                if merge_base and commit["sha"] == merge_base:
+                    break
+                base_commits.append(commit)
+            else:
+                base_page += 1
+                continue
+            break
+
+        print(f"  Found {len(base_commits)} commits in {base_tag}")
+
+        # Extract PR numbers from base commits
+        base_pr_numbers = set()
+        for commit in base_commits:
+            message = commit.get("commit", {}).get("message", "")
+            pr_num = extract_pr_number(message)
+            if pr_num:
+                base_pr_numbers.add(pr_num)
+        print(f"  Found {len(base_pr_numbers)} unique PRs in {base_tag}")
+
+        # Filter out commits whose PR is already in base
+        filtered_commits = []
+        skipped_count = 0
+        for commit in all_commits:
+            message = commit.get("commit", {}).get("message", "")
+            pr_num = extract_pr_number(message)
+            if pr_num and pr_num in base_pr_numbers:
+                skipped_count += 1
+                continue
+            filtered_commits.append(commit)
+
+        print(f"  Skipped {skipped_count} commits (PRs already in {base_tag})")
+        print(f"  Final count: {len(filtered_commits)} new commits in {head_tag}")
+        return filtered_commits
+
+    return all_commits
+
+
+def extract_contributors(commits: list[dict]) -> dict:
+    """
+    Extract unique contributors from commits.
+
+    Returns a dict with:
+        - contributors: set of (login, name) tuples
+        - by_login: dict mapping login -> contributor info
+        - by_email: dict mapping email -> contributor info (for commits without GitHub user)
+    """
+    contributors_by_login = {}
+    contributors_by_email = {}
+
+    for commit in commits:
+        # Try to get GitHub user info first (author field)
+        author = commit.get("author")
+        if author and author.get("login"):
+            login = author["login"]
+            if login not in contributors_by_login:
+                contributors_by_login[login] = {
+                    "login": login,
+                    "name": commit.get("commit", {}).get("author", {}).get("name", ""),
+                    "email": commit.get("commit", {})
+                    .get("author", {})
+                    .get("email", ""),
+                    "avatar_url": author.get("avatar_url", ""),
+                    "html_url": author.get("html_url", ""),
+                    "commits": 0,
+                }
+            contributors_by_login[login]["commits"] += 1
+        else:
+            # Fallback to git author info
+            git_author = commit.get("commit", {}).get("author", {})
+            email = git_author.get("email", "")
+            name = git_author.get("name", "")
+
+            if email and email not in contributors_by_email:
+                contributors_by_email[email] = {
+                    "login": None,
+                    "name": name,
+                    "email": email,
+                    "avatar_url": "",
+                    "html_url": "",
+                    "commits": 0,
+                }
+            if email:
+                contributors_by_email[email]["commits"] += 1
+
+    return {
+        "by_login": contributors_by_login,
+        "by_email": contributors_by_email,
+        "total": len(contributors_by_login) + len(contributors_by_email),
+    }
+
+
+def get_tag_date(base_url: str, tag: str, headers: dict) -> str:
+    """Get the date of a tag's commit."""
+    # First resolve the tag to a commit SHA
+    tag_resp = requests.get(f"{base_url}/git/refs/tags/{tag}", headers=headers)
+    if tag_resp.status_code != 200:
+        return None
+
+    tag_data = tag_resp.json()
+    sha = tag_data["object"]["sha"]
+
+    # If it's an annotated tag, get the underlying commit
+    if tag_data["object"]["type"] == "tag":
+        tag_obj_resp = requests.get(f"{base_url}/git/tags/{sha}", headers=headers)
+        if tag_obj_resp.status_code == 200:
+            sha = tag_obj_resp.json()["object"]["sha"]
+
+    # Get the commit date
+    commit_resp = requests.get(f"{base_url}/commits/{sha}", headers=headers)
+    if commit_resp.status_code == 200:
+        return commit_resp.json()["commit"]["committer"]["date"]
+
+    return None
+
+
+def check_contributor_is_new(
+    owner: str, repo: str, login: str, before_date: str, headers: dict
+) -> bool:
+    """
+    Check if a contributor has any commits before a given date.
+
+    Returns True if this is their first contribution (no commits before the date).
+    """
+    base_url = f"https://api.github.com/repos/{owner}/{repo}"
+
+    # Search for commits by this author before the base tag date
+    response = requests.get(
+        f"{base_url}/commits",
+        headers=headers,
+        params={"author": login, "until": before_date, "per_page": 1},
+    )
+
+    if response.status_code == 200:
+        commits = response.json()
+        # If no commits found before the date, they're a new contributor
+        return len(commits) == 0
+
+    return False
+
+
+def find_first_contribution(commits: list[dict], login: str) -> dict | None:
+    """
+    Find the first (earliest) contribution by a user in the commit list.
+
+    Returns the commit dict or None.
+    """
+    user_commits = []
+    for commit in commits:
+        author = commit.get("author")
+        if author and author.get("login") == login:
+            user_commits.append(commit)
+
+    # Commits are usually newest first, so reverse to get oldest first
+    if user_commits:
+        return user_commits[-1]  # Last one is the oldest/first contribution
+    return None
+
+
+def calculate_new_contributors_via_generate_notes(
+    owner: str,
+    repo: str,
+    base_tag: str,
+    head_tag: str,
+    token: str | None = None,
+) -> list[dict]:
+    """
+    Calculate new contributors using GitHub's generate-notes API.
+
+    This is more accurate than checking commit history because GitHub
+    tracks contributor status internally.
+
+    Args:
+        owner: Repository owner
+        repo: Repository name
+        base_tag: The base tag (older version)
+        head_tag: The head tag (newer version)
+        token: GitHub token
+
+    Returns:
+        List of new contributor info dicts with login and first_pr fields
+    """
+    import re
+    import subprocess
+
+    print("\nGetting new contributors via GitHub generate-notes API...")
+
+    # Use gh CLI to call the generate-notes API
+    cmd = [
+        "gh", "api", f"repos/{owner}/{repo}/releases/generate-notes",
+        "-f", f"tag_name={head_tag}",
+        "-f", f"target_commitish={head_tag}",
+        "-f", f"previous_tag_name={base_tag}",
+        "--jq", ".body"
+    ]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        if result.returncode != 0:
+            print(f"  Warning: gh CLI failed: {result.stderr}")
+            return []
+
+        body = result.stdout
+
+        # Parse new contributors from the generated notes
+        # Format: "* @username made their first contribution in https://github.com/owner/repo/pull/12345"
+        pattern = r'\* @(\S+) made their first contribution in https://github\.com/[^/]+/[^/]+/pull/(\d+)'
+        matches = re.findall(pattern, body)
+
+        new_contributors = []
+        for login, pr_number in matches:
+            new_contributors.append({
+                "login": login,
+                "first_pr": pr_number,
+            })
+
+        print(f"  Found {len(new_contributors)} new contributors")
+        return new_contributors
+
+    except subprocess.TimeoutExpired:
+        print("  Warning: gh CLI timed out")
+        return []
+    except FileNotFoundError:
+        print("  Warning: gh CLI not found, falling back to legacy method")
+        return []
+
+
+def calculate_new_contributors(
+    commits: list[dict],
+    current_contributors: dict,
+    owner: str,
+    repo: str,
+    base_tag: str,
+    head_tag: str = "",
+    token: str | None = None,
+) -> list[dict]:
+    """
+    Calculate which contributors are new (first-time) in this release.
+
+    First tries GitHub's generate-notes API (more accurate), then falls back
+    to checking commit history if that fails.
+
+    Args:
+        commits: List of commits in the current release
+        current_contributors: Output from extract_contributors()
+        owner: Repository owner
+        repo: Repository name
+        base_tag: The base tag (older version)
+        head_tag: The head tag (newer version)
+        token: GitHub token
+
+    Returns:
+        List of new contributor info dicts with first_pr field
+    """
+    # Try the accurate method first (via generate-notes API)
+    if head_tag:
+        new_contributors = calculate_new_contributors_via_generate_notes(
+            owner=owner,
+            repo=repo,
+            base_tag=base_tag,
+            head_tag=head_tag,
+            token=token,
+        )
+        if new_contributors:
+            return new_contributors
+
+    # Fall back to legacy method (checking commit history)
+    print("\nFalling back to legacy new contributor detection...")
+
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+    }
+    if token:
+        headers["Authorization"] = f"token {token}"
+
+    base_url = f"https://api.github.com/repos/{owner}/{repo}"
+
+    # Get the date of the base tag
+    print("Getting base tag date...")
+    base_date = get_tag_date(base_url, base_tag, headers)
+    if not base_date:
+        print(f"  Warning: Could not get date for tag {base_tag}")
+        return []
+
+    print(f"  Base tag date: {base_date}")
+
+    new_contributors = []
+    logins = list(current_contributors["by_login"].keys())
+    total = len(logins)
+
+    print(f"\nChecking {total} contributors for first-time status...")
+
+    for i, login in enumerate(logins):
+        if (i + 1) % 20 == 0:
+            print(f"  Checked {i + 1}/{total} contributors...")
+
+        is_new = check_contributor_is_new(owner, repo, login, base_date, headers)
+
+        if is_new:
+            info = current_contributors["by_login"][login].copy()
+
+            # Find their first PR in this release
+            first_commit = find_first_contribution(commits, login)
+            if first_commit:
+                message = first_commit.get("commit", {}).get("message", "")
+                pr_number = extract_pr_number(message)
+                info["first_pr"] = pr_number
+                info["first_commit_sha"] = first_commit.get("sha", "")[:8]
+
+            new_contributors.append(info)
+
+    print(f"  Found {len(new_contributors)} new contributors (legacy method)")
+
+    return new_contributors
+
+
+def generate_contributor_stats(
+    commits: list[dict],
+    owner: str,
+    repo: str,
+    base_tag: str,
+    head_tag: str,
+    token: str | None = None,
+    check_new: bool = True,
+) -> dict:
+    """
+    Generate contributor statistics for the release.
+
+    Returns a dict with all statistics data.
+    """
+    print("\n" + "=" * 60)
+    print("CONTRIBUTOR STATISTICS")
+    print("=" * 60)
+
+    # Extract contributors from current commits
+    contributors = extract_contributors(commits)
+
+    print(f"\nTotal commits: {len(commits)}")
+    print(f"Total contributors: {contributors['total']}")
+    print(f"  - With GitHub account: {len(contributors['by_login'])}")
+    print(f"  - Without GitHub account (by email): {len(contributors['by_email'])}")
+
+    new_count = 0
+    new_contributors_list = []
+
+    if check_new:
+        # Calculate new contributors (tries GitHub generate-notes API first, then falls back to commit history)
+        new_contributors_list = calculate_new_contributors(
+            commits=commits,
+            current_contributors=contributors,
+            owner=owner,
+            repo=repo,
+            base_tag=base_tag,
+            head_tag=head_tag,
+            token=token,
+        )
+        new_count = len(new_contributors_list)
+
+        print(f"\nNew contributors (first-time): {new_count}")
+
+        if new_contributors_list:
+            print("\nNew contributors list:")
+            for c in sorted(new_contributors_list, key=lambda x: x["login"].lower()):
+                pr_info = f" in #{c['first_pr']}" if c.get("first_pr") else ""
+                print(f"  - @{c['login']} made their first contribution{pr_info}")
+
+    # Print summary line for release notes
+    print("\n" + "-" * 60)
+    print("RELEASE NOTES SUMMARY LINE:")
+    print("-" * 60)
+    if check_new:
+        summary_line = f"This release features {len(commits)} commits from {contributors['total']} contributors ({new_count} new)!"
+    else:
+        summary_line = f"This release features {len(commits)} commits from {contributors['total']} contributors!"
+    print(summary_line)
+    print("-" * 60)
+
+    # Get all contributors sorted by commit count
+    all_contributors_list = list(contributors["by_login"].values()) + list(
+        contributors["by_email"].values()
+    )
+    sorted_contributors = sorted(
+        all_contributors_list, key=lambda x: x["commits"], reverse=True
+    )
+
+    # Print top contributors
+    print("\nTop contributors by commit count:")
+    for i, c in enumerate(sorted_contributors[:20], 1):
+        if c.get("login"):
+            print(f"  {i:2}. @{c['login']:20} - {c['commits']:3} commits")
+        else:
+            print(
+                f"  {i:2}. {c['name']:20} - {c['commits']:3} commits (no GitHub account)"
+            )
+
+    return {
+        "total_commits": len(commits),
+        "total_contributors": contributors["total"],
+        "new_contributors": new_count if check_new else None,
+        "new_contributors_list": new_contributors_list,
+        "contributors": contributors,
+        "sorted_contributors": sorted_contributors,
+        "summary_line": summary_line,
+        "base_tag": base_tag,
+        "head_tag": head_tag,
+        "owner": owner,
+        "repo": repo,
+    }
+
+
+def save_contributor_stats(stats: dict, output_file: str, owner: str, repo: str):
+    """
+    Save contributor statistics to a markdown file.
+
+    Args:
+        stats: Statistics dict from generate_contributor_stats()
+        output_file: Output file path
+        owner: Repository owner
+        repo: Repository name
+    """
+    lines = []
+
+    # Header
+    lines.append(f"# Contributor Statistics: {stats['base_tag']} → {stats['head_tag']}")
+    lines.append("")
+
+    # Summary for release notes
+    lines.append("## Release Notes Summary")
+    lines.append("")
+    lines.append(f"> {stats['summary_line']}")
+    lines.append("")
+
+    # Overview stats
+    lines.append("## Overview")
+    lines.append("")
+    lines.append(f"- **Total Commits**: {stats['total_commits']}")
+    lines.append(f"- **Total Contributors**: {stats['total_contributors']}")
+    if stats["new_contributors"] is not None:
+        lines.append(f"- **New Contributors**: {stats['new_contributors']}")
+    lines.append("")
+
+    # Top contributors table
+    lines.append("## Top Contributors")
+    lines.append("")
+    lines.append("| Rank | Contributor | Commits |")
+    lines.append("|------|-------------|---------|")
+
+    for i, c in enumerate(stats["sorted_contributors"][:30], 1):
+        if c.get("login"):
+            contributor_link = f"[@{c['login']}](https://github.com/{c['login']})"
+        else:
+            contributor_link = c["name"]
+        lines.append(f"| {i} | {contributor_link} | {c['commits']} |")
+
+    lines.append("")
+
+    # New contributors section
+    if stats["new_contributors_list"]:
+        lines.append("## New Contributors 🎉")
+        lines.append("")
+
+        sorted_new = sorted(
+            stats["new_contributors_list"], key=lambda x: x["login"].lower()
+        )
+        for c in sorted_new:
+            pr_num = c.get("first_pr")
+            if pr_num:
+                pr_link = f"https://github.com/{owner}/{repo}/pull/{pr_num}"
+                lines.append(
+                    f"* @{c['login']} made their first contribution in {pr_link}"
+                )
+            else:
+                lines.append(f"* @{c['login']} made their first contribution")
+        lines.append("")
+
+    # All contributors section (collapsed)
+    lines.append("## All Contributors")
+    lines.append("")
+    lines.append("<details>")
+    lines.append("<summary>Click to expand full list</summary>")
+    lines.append("")
+    lines.append("| Contributor | Commits |")
+    lines.append("|-------------|---------|")
+
+    for c in stats["sorted_contributors"]:
+        if c.get("login"):
+            contributor_link = f"[@{c['login']}](https://github.com/{c['login']})"
+        else:
+            contributor_link = c["name"]
+        lines.append(f"| {contributor_link} | {c['commits']} |")
+
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+
+    # Write to file
+    with open(output_file, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+    print(f"\nSaved contributor statistics to {output_file}")
+
+
+def extract_pr_number(message: str) -> str | None:
+    """Extract PR number from commit message."""
+    # Common patterns: (#12345), (https://github.com/.../pull/12345)
+    patterns = [
+        r"\(#(\d+)\)",  # (#12345)
+        r"pull/(\d+)",  # https://github.com/.../pull/12345
+        r"#(\d+)$",  # #12345 at end
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, message)
+        if match:
+            return match.group(1)
+    return None
+
+
+def format_commit_message(
+    commit: dict,
+    owner: str,
+    repo: str,
+    include_sha: bool = False,
+    include_date: bool = False,
+) -> str:
+    """
+    Format a commit message for the output file.
+
+    Format: [Category] Description in https://github.com/owner/repo/pull/XXXX
+    or: [Category] Description (#XXXX)
+
+    If include_sha is True, prepends the full SHA: `sha` Message (#XXXX)
+    If include_date is True, prepends the date: [YYYY-MM-DD] Message (#XXXX)
+    """
+    message = commit["commit"]["message"]
+    sha = commit.get("sha", "")
+
+    # Get commit date (use committer date for when it was merged)
+    commit_date = ""
+    if include_date:
+        date_str = commit.get("commit", {}).get("committer", {}).get("date", "")
+        if date_str:
+            # Parse ISO format and extract date part (YYYY-MM-DD)
+            commit_date = date_str[:10]
+
+    # Get the first line of the commit message
+    first_line = message.split("\n")[0].strip()
+
+    # Extract PR number if present
+    pr_number = extract_pr_number(first_line)
+
+    # Clean up the message - remove existing PR references for reformatting
+    clean_message = first_line
+    clean_message = re.sub(r"\s*\(#\d+\)\s*$", "", clean_message)
+    clean_message = re.sub(
+        r"\s*https://github\.com/[^/]+/[^/]+/pull/\d+\s*", "", clean_message
+    )
+    clean_message = re.sub(r"\s+in\s*$", "", clean_message)
+    clean_message = clean_message.strip()
+
+    # Format output
+    if pr_number:
+        # Check if message already contains the full URL pattern
+        if f"https://github.com/{owner}/{repo}/pull/" in first_line:
+            formatted = first_line
+        else:
+            formatted = f"{clean_message} (#{pr_number})"
+    else:
+        formatted = clean_message
+
+    # Prepend metadata if requested
+    prefix_parts = []
+    if include_date and commit_date:
+        prefix_parts.append(f"[{commit_date}]")
+    if include_sha and sha:
+        prefix_parts.append(f"`{sha}`")
+
+    if prefix_parts:
+        formatted = f"{' '.join(prefix_parts)} {formatted}"
+
+    return formatted
+
+
+def save_commits_to_file(
+    commits: list[dict],
+    output_file: str,
+    owner: str,
+    repo: str,
+    sort_mode: str = "chronological",
+    include_sha: bool = False,
+    include_date: bool = False,
+):
+    """
+    Save formatted commits to a markdown file.
+
+    Args:
+        commits: List of commit dictionaries
+        output_file: Output file path
+        owner: Repository owner
+        repo: Repository name
+        sort_mode: "chronological" (newest first, like GitHub),
+                   "alphabetical" (by commit message),
+                   "reverse" (oldest first)
+        include_sha: If True, include full commit SHA in output
+        include_date: If True, include commit date in output
+    """
+    print(f"\nFormatting and saving {len(commits)} commits to {output_file}...")
+
+    formatted_lines = []
+    for commit in commits:
+        formatted = format_commit_message(
+            commit, owner, repo, include_sha=include_sha, include_date=include_date
+        )
+        formatted_lines.append(formatted)
+
+    # Sort based on mode
+    if sort_mode == "alphabetical":
+        formatted_lines.sort(key=lambda x: x.lower())
+        print("  Sorted alphabetically by commit message")
+    elif sort_mode == "reverse":
+        formatted_lines.reverse()
+        print("  Sorted chronologically (oldest first)")
+    else:
+        # chronological - keep original order (newest first, as returned by API)
+        print("  Keeping chronological order (newest first)")
+
+    with open(output_file, "w", encoding="utf-8") as f:
+        for line in formatted_lines:
+            f.write(line + "\n")
+
+    print(f"Saved {len(formatted_lines)} commits to {output_file}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fetch commits between two GitHub tags or between a tag and a commit"
+    )
+    parser.add_argument(
+        "--owner",
+        default="vllm-project",
+        help="Repository owner (default: vllm-project)",
+    )
+    parser.add_argument(
+        "--repo", default="vllm", help="Repository name (default: vllm)"
+    )
+    parser.add_argument(
+        "--base-tag",
+        help="Base tag (older, e.g., v0.11.2). If not provided with --head-commit, will auto-detect previous tag.",
+    )
+    parser.add_argument(
+        "--head-tag",
+        help="Head tag (newer, e.g., v0.12.0). Use this OR --head-commit. If neither specified, uses HEAD of default branch.",
+    )
+    parser.add_argument(
+        "--head-commit",
+        help="Head commit SHA (can be short or full). If not specified and no --head-tag, uses HEAD of default branch.",
+    )
+    parser.add_argument(
+        "--tag-pattern",
+        default=r"^v\d+\.\d+\.\d+$",
+        help="Regex pattern to filter tags when auto-detecting previous tag (default: ^v\\d+\\.\\d+\\.\\d+$)",
+    )
+    parser.add_argument(
+        "--output",
+        default="0-current-raw-commits.md",
+        help="Output file (default: 0-current-raw-commits.md)",
+    )
+    parser.add_argument("--token", help="GitHub token (or set GITHUB_TOKEN env var)")
+    parser.add_argument(
+        "--slow",
+        action="store_true",
+        help="Use slower but more thorough commit-by-commit fetching",
+    )
+    parser.add_argument(
+        "--sort",
+        choices=["chronological", "alphabetical", "reverse"],
+        default="chronological",
+        help="Sort mode: chronological (newest first, like GitHub), alphabetical (by message), reverse (oldest first)",
+    )
+    parser.add_argument(
+        "--stats", action="store_true", help="Generate and save contributor statistics"
+    )
+    parser.add_argument(
+        "--stats-output",
+        default="0-contributor-stats.md",
+        help="Output file for contributor statistics (default: 0-contributor-stats.md)",
+    )
+    parser.add_argument(
+        "--no-new-check",
+        action="store_true",
+        help="Skip checking for new contributors (faster, avoids extra API calls)",
+    )
+    parser.add_argument(
+        "--include-sha",
+        action="store_true",
+        help="Include full commit SHA in output (format: `sha` message)",
+    )
+    parser.add_argument(
+        "--include-date",
+        action="store_true",
+        help="Include commit date in output (format: [YYYY-MM-DD] message)",
+    )
+    parser.add_argument(
+        "--since",
+        help="Fetch commits since this date (ISO 8601: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ). Use with --until for date range mode.",
+    )
+    parser.add_argument(
+        "--until",
+        help="Fetch commits until this date (ISO 8601: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ). Use with --since for date range mode.",
+    )
+    parser.add_argument(
+        "--branch",
+        help="Branch to fetch commits from (only used with --since/--until date range mode)",
+    )
+
+    args = parser.parse_args()
+
+    # Validate arguments
+    if args.head_tag and args.head_commit:
+        parser.error("Cannot specify both --head-tag and --head-commit")
+
+    # Check for date range mode
+    date_range_mode = args.since is not None or args.until is not None
+    if date_range_mode:
+        if not args.since or not args.until:
+            parser.error(
+                "Both --since and --until must be specified for date range mode"
+            )
+        if args.head_tag or args.head_commit or args.base_tag:
+            parser.error(
+                "Cannot use --since/--until with --head-tag, --head-commit, or --base-tag"
+            )
+
+    token = args.token or get_github_token()
+
+    if not token:
+        print("Warning: No GitHub token provided. Rate limits will be stricter.")
+        print("Set GITHUB_TOKEN environment variable or use --token argument.")
+        print()
+
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+    }
+    if token:
+        headers["Authorization"] = f"token {token}"
+
+    base_url = f"https://api.github.com/repos/{args.owner}/{args.repo}"
+
+    try:
+        # Date range mode
+        if date_range_mode:
+            print(f"\n{'=' * 60}")
+            print(f"Fetching commits by date range: {args.since} → {args.until}")
+            if args.branch:
+                print(f"Branch: {args.branch}")
+            print(f"{'=' * 60}")
+
+            commits = fetch_commits_by_date_range(
+                owner=args.owner,
+                repo=args.repo,
+                since=args.since,
+                until=args.until,
+                token=token,
+                branch=args.branch,
+            )
+
+            print(f"\nTotal commits found: {len(commits)}")
+
+            save_commits_to_file(
+                commits=commits,
+                output_file=args.output,
+                owner=args.owner,
+                repo=args.repo,
+                sort_mode=args.sort,
+                include_sha=args.include_sha,
+                include_date=args.include_date,
+            )
+
+            # Stats not fully supported in date range mode (no base_tag for new contributor check)
+            if args.stats:
+                print(
+                    "\nNote: Contributor statistics in date range mode won't check for new contributors."
+                )
+                stats = generate_contributor_stats(
+                    commits=commits,
+                    owner=args.owner,
+                    repo=args.repo,
+                    base_tag=args.since,
+                    head_tag=args.until,
+                    token=token,
+                    check_new=False,  # Can't check new contributors without a base tag
+                )
+                save_contributor_stats(
+                    stats=stats,
+                    output_file=args.stats_output,
+                    owner=args.owner,
+                    repo=args.repo,
+                )
+
+            return
+
+        # Tag/commit mode (existing logic)
+        # Determine head reference
+        head_is_commit = False
+        head_ref = None
+        head_display_name = None
+
+        if args.head_tag:
+            head_ref = args.head_tag
+            head_is_commit = False
+            head_display_name = args.head_tag
+        elif args.head_commit:
+            head_ref = args.head_commit
+            head_is_commit = True
+            head_display_name = (
+                args.head_commit[:8] if len(args.head_commit) > 8 else args.head_commit
+            )
+        else:
+            # Auto-detect HEAD of default branch
+            branch_name, head_sha = get_default_branch_head(base_url, headers)
+            head_ref = head_sha
+            head_is_commit = True
+            head_display_name = f"{branch_name} ({head_sha[:8]})"
+
+        base_tag = args.base_tag
+        base_is_commit = False
+
+        # Auto-detect previous tag if needed
+        if not base_tag and head_is_commit:
+            print("Auto-detecting previous tag...")
+            head_sha = resolve_commit_sha(base_url, head_ref, headers)
+
+            result = find_previous_tag(
+                base_url=base_url,
+                head_sha=head_sha,
+                headers=headers,
+                tag_pattern=args.tag_pattern,
+            )
+
+            if result is None:
+                raise Exception(
+                    "Could not find a previous tag. Please specify --base-tag manually."
+                )
+
+            base_tag, _ = result
+            print(f"\nUsing auto-detected base tag: {base_tag}")
+        elif not base_tag:
+            parser.error("Must specify --base-tag when using --head-tag")
+
+        print(f"\n{'=' * 60}")
+        print(f"Fetching commits: {base_tag} → {head_display_name}")
+        print(f"{'=' * 60}")
+
+        if args.slow:
+            # Note: slow mode doesn't support commit SHA yet, only tags
+            if head_is_commit:
+                print(
+                    "Warning: --slow mode with --head-commit not fully supported, using fast mode"
+                )
+            commits = fetch_commits_between_tags_fast(
+                owner=args.owner,
+                repo=args.repo,
+                base_tag=base_tag,
+                head_tag=head_ref,
+                token=token,
+                head_is_commit=head_is_commit,
+                base_is_commit=base_is_commit,
+            )
+        else:
+            commits = fetch_commits_between_tags_fast(
+                owner=args.owner,
+                repo=args.repo,
+                base_tag=base_tag,
+                head_tag=head_ref,
+                token=token,
+                head_is_commit=head_is_commit,
+                base_is_commit=base_is_commit,
+            )
+
+        print(f"\nTotal commits found: {len(commits)}")
+
+        save_commits_to_file(
+            commits=commits,
+            output_file=args.output,
+            owner=args.owner,
+            repo=args.repo,
+            sort_mode=args.sort,
+            include_sha=args.include_sha,
+            include_date=args.include_date,
+        )
+
+        # Generate and save contributor statistics if requested
+        if args.stats:
+            stats = generate_contributor_stats(
+                commits=commits,
+                owner=args.owner,
+                repo=args.repo,
+                base_tag=base_tag,
+                head_tag=head_display_name,
+                token=token,
+                check_new=not args.no_new_check,
+            )
+            save_contributor_stats(
+                stats=stats,
+                output_file=args.stats_output,
+                owner=args.owner,
+                repo=args.repo,
+            )
+
+    except Exception as e:
+        print(f"Error: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/claude-skills/vllm-release-notes/ref-past-release-notes-highlight.md
+++ b/claude-skills/vllm-release-notes/ref-past-release-notes-highlight.md
@@ -1,0 +1,376 @@
+# vLLM Past Release Notes Highlights
+
+## v0.11.0 (2025-10-02)
+## Highlights
+This release features 538 commits, 207 contributors (65 new contributors)!
+
+* This release completes the removal of V0 engine. V0 engine code including AsyncLLMEngine, LLMEngine, MQLLMEngine, all attention backends, and related components have been removed. **V1 is the only engine in the codebase now.**
+* This releases turns on **FULL_AND_PIECEWISE as the CUDA graph mode default**. This should provide better out of the box performance for most models, particularly fine-grained MoEs, while preserving compatibility with existing models supporting only PIECEWISE mode.
+
+Note: In v0.11.0 (and v0.10.2), `--async-scheduling` will produce gibberish output in some cases such as preemption and others. This functionality is correct in v0.10.1. We are actively fixing it for the next version. 
+
+### Model Support
+* New architectures: DeepSeek-V3.2-Exp (#25896), Qwen3-VL series (#24727), Qwen3-Next (#24526), OLMo3 (#24534), LongCat-Flash (#23991), Dots OCR (#24645), Ling2.0 (#24627), CWM (#25611).
+* Encoders: RADIO encoder support (#24595), Transformers backend support for encoder-only models (#25174).
+* Task expansion: BERT token classification/NER (#24872), multimodal models for pooling tasks (#24451).
+* Data parallel for vision encoders: InternVL (#23909), Qwen2-VL (#25445), Qwen3-VL (#24955).
+* Speculative decoding: EAGLE3 for MiniCPM3 (#24243) and GPT-OSS (#25246).
+* Features: Qwen3-VL text-only mode (#26000), EVS video token pruning (#22980), Mamba2 TP+quantization (#24593), MRoPE + YaRN (#25384), Whisper on XPU (#25123), LongCat-Flash-Chat tool calling (#24083).
+* Performance: GLM-4.1V 916ms TTFT reduction via fused RMSNorm (#24733), GLM-4 MoE SharedFusedMoE optimization (#24849), Qwen2.5-VL CUDA sync removal (#24741), Qwen3-VL Triton MRoPE kernel (#25055), FP8 checkpoints for Qwen3-Next (#25079).
+* Reasoning: SeedOSS reason parser (#24263).
+
+### Engine Core
+* KV cache offloading: CPU offloading with LRU management (#19848, #20075, #21448, #22595, #24251).
+* V1 features: Prompt embeddings (#24278), sharded state loading (#25308), FlexAttention sliding window (#24089), LLM.apply_model (#18465).
+* Hybrid allocator: Pipeline parallel (#23974), varying hidden sizes (#25101).
+* Async scheduling: Uniprocessor executor support (#24219).
+* Architecture: Tokenizer group removal (#24078), shared memory multimodal caching (#20452).
+* Attention: Hybrid SSM/Attention in Triton (#21197), FlashAttention 3 for ViT (#24347).
+* Performance: FlashInfer RoPE 2x speedup (#21126), fused Q/K RoPE 11% improvement (#24511, #25005), 8x spec decode overhead reduction (#24986), FlashInfer spec decode with 1.14x speedup (#25196), model info caching (#23558), inputs_embeds copy avoidance (#25739).
+* LoRA: Optimized weight loading (#25403).
+* Defaults: CUDA graph mode FULL_AND_PIECEWISE (#25444), Inductor standalone compile disabled (#25391).
+* torch.compile: CUDA graph Inductor partition integration (#24281).
+
+### Hardware & Performance
+* NVIDIA: FP8 FlashInfer MLA decode (#24705), BF16 fused MoE for Hopper/Blackwell expert parallel (#25503).
+* DeepGEMM: Enabled by default (#24462), 5.5% throughput improvement (#24783).
+* New architectures: RISC-V 64-bit (#22112), ARM non-x86 CPU (#25166), ARM 4-bit fused MoE (#23809).
+* AMD: ROCm 7.0 (#25178), GLM-4.5 MI300X tuning (#25703).
+* Intel XPU: MoE DP accuracy fix (#25465).
+
+### Large Scale Serving & Performance
+* Dual-Batch Overlap (DBO): Overlapping computation mechanism (#23693), DeepEP high throughput + prefill (#24845).
+* Data Parallelism: torchrun launcher (#24899), Ray placement groups (#25026), Triton DP/EP kernels (#24588).
+* EPLB: Hunyuan V1 (#23078), Mixtral (#22842), static placement (#23745), reduced overhead (#24573).
+* Disaggregated serving: KV transfer metrics (#22188), NIXL MLA latent dimension (#25902).
+* MoE: Shared expert overlap optimization (#24254), SiLU kernel for DeepSeek-R1 (#24054), Enable Allgather/ReduceScatter backend for NaiveAllToAll (#23964).
+* Distributed: NCCL symmetric memory with 3-4% throughput improvement (#24532), enabled by default for TP (#25070).
+
+### Quantization
+* FP8: Per-token-group quantization (#24342), hardware-accelerated instructions (#24757), torch.compile KV cache (#22758), paged attention update (#22222).
+* FP4: NVFP4 for dense models (#25609), Gemma3 (#22771), Llama 3.1 405B (#25135).
+* W4A8: Faster preprocessing (#23972).
+* Compressed tensors: Blocked FP8 for MoE (#25219).
+
+### API & Frontend
+* OpenAI: Prompt logprobs for all tokens (#24956), logprobs=-1 for full vocab (#25031), reasoning streaming events (#24938), Responses API MCP tools (#24628, #24985), health 503 on dead engine (#24897).
+* Multimodal: Media UUID caching (#23950), image path format (#25081).
+* Tool calling: XML parser for Qwen3-Coder (#25028), Hermes-style tokens (#25281).
+* CLI: --enable-logging (#25610), improved --help (#24903).
+* Config: Speculative model engine args (#25250), env validation (#24761), NVTX profiling (#25501), guided decoding backward compatibility (#25615, #25422).
+* Metrics: V1 TPOT histogram (#24015), hidden deprecated gpu_ metrics (#24245), KV cache GiB units (#25204, #25479).
+* UX: Removed misleading quantization warning (#25012).
+
+### Security
+* https://github.com/vllm-project/vllm/security/advisories/GHSA-wr9h-g72x-mwhm
+
+### Dependencies
+* PyTorch 2.8 for CPU (#25652), FlashInfer 0.3.1 (#24470), CUDA 13 (#24599), ROCm 7.0 (#25178).
+* **Build requirements**: C++17 now enforced globally (#24823).
+* **TPU**: Deprecated `xm.mark_step` in favor of `torch_xla.sync` (#25254).
+
+### V0 Deprecation
+* Engines: AsyncLLMEngine (#25025), LLMEngine (#25033), MQLLMEngine (#25019), core (#25321), model runner (#25328), MP executor (#25329).
+* Components: Attention backends (#25351), encoder-decoder (#24907), output processor (#25320), sampling metadata (#25345), Sequence/Sampler (#25332).
+* Interfaces: LoRA (#25686), async output processor (#25334), MultiModalPlaceholderMap (#25366), seq group methods (#25330), placeholder attention (#25510), input embeddings (#25242), multimodal registry (#25362), max_seq_len_to_capture (#25543), attention classes (#25541), hybrid models (#25400), backend suffixes (#25489), compilation fallbacks (#25675), default args (#25409).
+
+
+## v0.10.2 
+## Highlights
+This release contains 740 commits from 266 contributors (97 new)!
+
+**Breaking Changes**: This release includes PyTorch 2.8.0 upgrade, V0 deprecations, and API changes - please review the changelog carefully.
+
+**aarch64 support**: This release features native support for aarch64 allowing usage of vLLM on GB200 platform. The docker image `vllm/vllm-openai` should already be multiplatform. To install the wheels, you can download the wheels from this release artifact or install via 
+```
+uv pip install vllm==0.10.2 --extra-index-url https://wheels.vllm.ai/0.10.2/ --torch-backend=auto
+```
+
+### Model Support
+* **New model families and enhancements**: Apertus (#23068), LFM2 (#22845), MiDashengLM (#23652), Motif-1-Tiny (#23414), Seed-Oss (#23241), Google EmbeddingGemma-300m (#24318), GTE sequence classification (#23524), Donut OCR model (#23229), KeyeVL-1.5-8B (#23838), R-4B vision model (#23246), Ernie4.5 VL (#22514), MiniCPM-V 4.5 (#23586), Ovis2.5 (#23084), Qwen3-Next with hybrid attention (#24526), InternVL3.5 with video support (#23658), Qwen2Audio embeddings (#23625), NemotronH Nano VLM (#23644), BLOOM V1 engine support (#23488), and Whisper encoder-decoder for V1 (#21088).
+* **Pipeline parallelism expansion**: Added PP support for Hunyuan (#24212), Ovis2.5 (#23405), GPT-OSS (#23680), and Kimi-VL-A3B-Thinking-2506 (#23114).
+* **Data parallelism for vision models**: Enabled DP for ViT across Qwen2.5VL (#22742), MiniCPM-V (#23948, #23327), Kimi-VL (#23817), and GLM-4.5V (#23168).
+* **LoRA ecosystem expansion**: Added LoRA support to Voxtral (#24517), Qwen-2.5-Omni (#24231), and DeepSeek models V2/V3/R1-0528 (#23971), with significantly faster LoRA startup performance (#23777).
+* **Classification and pooling enhancements**: Multi-label classification support (#23173), logit bias and sigmoid normalization (#24031), and FP32 precision heads for pooling models (#23810).
+* **Performance optimizations**: Removed unnecessary CUDA sync from GLM-4.1V (#24332) and Qwen2VL (#24334) preprocessing, eliminated redundant all-reduce in Qwen3 MoE (#23169), optimized InternVL CPU threading (#24519), and GLM4.5-V video frame decoding (#24161).
+
+### Engine Core
+* **V1 engine maturation**: Extended V1 support to compute capability < 8.0 (#23614, #24022), added cross-attention KV cache for encoder-decoder models (#23664), request-level logits processor integration (#23656), and KV events from connectors (#19737).
+* **Backend expansion**: Terratorch backend integration (#23513) enabling non-language model tasks like semantic segmentation and geospatial applications with `--model-impl terratorch` support.
+* **Hybrid and Mamba model improvements**: Enabled full CUDA graphs by default for hybrid models (#22594), disabled prefix caching for hybrid/Mamba models (#23716), added FP32 SSM kernel support (#23506), full CUDA graph support for Mamba1 (#23035), and V1 as default for Mamba models (#23650).
+* **Performance core improvements**: `--safetensors-load-strategy` for NFS based file loading acceleration (#24469), critical CUDA graph capture throughput fix (#24128), scheduler optimization for single completions (#21917), multi-threaded model weight loading (#23928), and tensor core usage enforcement for FlashInfer decode (#23214).
+* **Multimodal enhancements**: Multimodal cache tracking with mm_hash (#22711), UUID-based multimodal identifiers (#23394), improved V1 video embedding estimation (#24312), and simplified multimodal UUID handling (#24271).
+* **Sampling and structured outputs**: Support for all prompt logprobs (#23868), final logprobs (#22387), grammar bitmask optimization (#23361), and user-configurable KV cache memory size (#21489).
+* **Distributed**: Support Decode Context Parallel (DCP) for MLA (#23734)
+
+### Hardware & Performance
+* **NVIDIA Blackwell/SM100 generation**: FP8 MLA support with CUTLASS backend (#23289), DeepGEMM Linear with 1.5% E2E throughput improvement (#23351), Hopper DeepGEMM E8M0 for DeepSeekV3.1 (#23666), SM100 FlashInfer CUTLASS MoE FP8 backend (#22357), MXFP4 fused CUTLASS MoE (#23696), default MXFP4 MoE on Blackwell (#23008), and GPT-OSS DP/EP support with 52,003 tokens/s throughput (#23608).
+* **Breaking change**: FlashMLA disabled on Blackwell GPUs due to compatibility issues (#24521).
+* **Kernel and attention optimizations**: FlashAttention MLA with CUDA graph support (#14258, #23958), V1 cross-attention support (#23297), FP8 support for FlashMLA (#22668), fused grouped TopK for MoE (#23274), Flash Linear Attention kernels (#24518), and W4A8 support on Hopper (#23198).
+* **Performance improvements**: 13.7x speedup for token conversion (#20413), TTIT/TTFT improvements for disaggregated serving (#22760), symmetric memory all-reduce by default (#24111), FlashInfer warmup during startup (#23439), V1 model execution overlap (#23569), and various Triton configuration tuning (#23748, #23939).
+* **Platform expansion**: Apple Silicon bfloat16 support for M2+ (#24129), IBM Z V1 engine support (#22725), Intel XPU torch.compile (#22609), XPU MoE data parallelism (#22887), XPU Triton attention (#24149), XPU FP8 quantization (#23148), and ROCm pipeline parallelism with Ray (#24275).
+* **Model-specific optimizations**: Hardware-tuned MoE configurations for Qwen3-Next on B200/H200/H100 (#24698, #24688, #24699, #24695), GLM-4.5-Air-FP8 B200 configs (#23695), Kimi K2 optimization (#24597), and QWEN3 Coder/Thinking configs (#24266, #24330).
+
+### Quantization
+* **New quantization capabilities**: Per-layer quantization routing (#23556), GGUF quantization with layer skipping (#23188), NFP4+FP8 MoE support (#22674), W4A8 channel scales (#23570), and AMD CDNA2/CDNA3 FP4 support (#22527).
+* **Advanced quantization infrastructure**: Compressed tensors transforms for linear operations (#22486) enabling techniques like SpinQuantR1R2R4 and QuIP quantization methods.
+* **FlashInfer quantization integration**: FP8 KV cache for TRTLLM prefill attention (#24197), FP8-qkv attention kernels (#23647), and FP8 per-tensor GEMMs (#22895).
+* **Platform-specific quantization**: ROCm TorchAO quantization enablement (#24400) and TorchAO module swap configuration (#21982).
+* **Performance optimizations**: MXFP4 MoE loading cache optimization (#24154) and compressed tensors version updates (#23202).
+* **Breaking change**: Removed original Marlin quantization format (#23204).
+
+### API & Frontend
+* **OpenAI API enhancements**: Gemma3n audio transcription/translation endpoints (#23735), transcription response usage statistics (#23576), and return_token_ids parameter (#22587).
+* **Response API improvements**: Streaming support for non-harmony responses (#23741), non-streaming logprobs (#23319), MCP tool background mode (#23494), MCP streaming+background support (#23927), and tool output token reporting (#24285).
+* **Frontend optimizations**: Error stack traces with --log-error-stack (#22960), collective RPC endpoint (#23075), beam search concurrency optimization (#23599), unnecessary detokenization skipping (#24236), and custom media UUIDs (#23449).
+* **Configuration enhancements**: Formalized --mm-encoder-tp-mode flag (#23190), VLLM_DISABLE_PAD_FOR_CUDAGRAPH environment variable (#23595), EPLB configuration parameter (#20562), embedding endpoint chat request support (#23931), and LM Format Enforcer V1 integration (#22564).
+
+### Dependencies
+* **Major updates**: PyTorch 2.8.0 upgrade (#20358) - breaking change requiring environment updates, FlashInfer v0.3.0 upgrade (#24086), and FlashInfer 0.2.14.post1 maintenance update (#23537).
+* **Supporting updates**: XGrammar 0.1.23 (#22988), TPU core dump fix with tpu_info 0.4.0 (#23135), and compressed tensors version bump (#23202).
+* **Deployment improvements**: FlashInfer cubin directory environment variable (#22675) for offline environments and pre-cached CUDA binaries.
+
+### V0 Deprecation
+* **Backend removals**: V0 Neuron backend deprecation (#21159), V0 pooling model support removal (#23434), V0 FlashInfer attention backend removal (#22776), and V0 test cleanup (#23418, #23862).
+* **API breaking changes**: prompt_token_ids fallback removal from LLM.generate and LLM.embed (#18800), LoRA extra vocab size deprecation warning (#23635), LoRA bias parameter deprecation (#24339), and metrics naming change from TPOT to ITL (#24110).
+
+### Breaking Changes
+1. **PyTorch 2.8.0 upgrade** - Environment dependency change requiring updated CUDA versions
+2. **FlashMLA Blackwell restriction** - FlashMLA disabled on Blackwell GPUs due to compatibility issues
+3. **V0 feature removals** - Neuron backend, pooling models, FlashInfer attention backend
+5. **Quantizations** - Removed quantized Mixtral hack implementation, and original Marlin format. 
+6. **Metrics renaming** - TPOT deprecated in favor of ITL
+
+
+
+
+## v0.10.0 (2025-07-23)
+## Highlights
+v0.10.0 release includes 308 commits, 168 contributors (62 new!).
+
+**NOTE: This release begins the cleanup of V0 engine codebase.** We have removed V0 CPU/XPU/TPU/HPU backends (#20412), long context LoRA (#21169), Prompt Adapters (#20588), Phi3-Small & BlockSparse Attention (#21217), and Spec Decode workers (#21152) so far and plan to continued to delete code that is no longer used. 
+
+### Model Support
+* New families: Llama 4 with EAGLE support (#20591), EXAONE 4.0 (#21060), Microsoft Phi-4-mini-flash-reasoning (#20702), Hunyuan V1 Dense + A13B with reasoning/tool parsing (#21368, #20625, #20820), Ling MoE models (#20680), JinaVL Reranker (#20260), Nemotron-Nano-VL-8B-V1 (#20349), Arcee (#21296), Voxtral (#20970).
+* Enhanced compatibility: BERT/RoBERTa with AutoWeightsLoader (#20534), HF format support for MiniMax (#20211), Gemini configuration (#20971), GLM-4 updates (#20736).
+* Architecture expansions: Attention-free model support (#20811), Hybrid SSM/Attention models on V1 (#20016), LlamaForSequenceClassification (#20807), expanded Mamba2 layer support (#20660).
+* VLM improvements: VLM support with transformers backend (#20543), PrithviMAE on V1 engine (#20577).
+
+### Engine Core
+* Experimental async scheduling `--async-scheduling` flag to overlap engine core scheduling with GPU runner (#19970).
+* V1 engine improvements: backend-agnostic local attention (#21093), MLA FlashInfer ragged prefill (#20034), hybrid KV cache with local chunked attention (#19351).
+* Multi-task support: models can now support multiple tasks (#20771), multiple poolers (#21227), and dynamic pooling parameter configuration (#21128).
+* RLHF Support: new RPC methods for runtime weight reloading (#20096) and config updates (#20095), logprobs mode for selecting which stage of logprobs to return (#21398).
+* Enhanced caching: multi-modal caching for transformers backend (#21358), reproducible prefix cache hashing using SHA-256 + CBOR (#20511).
+* Startup time reduction via CUDA graph capture speedup via frozen GC (#21146).
+* Elastic expert parallel for dynamic GPU scaling while preserving state (#20775).
+
+### Hardwares & Performance
+* NVIDIA Blackwell/SM100 optimizations: CUTLASS block scaled group GEMM for smaller batches (#20640), FP8 groupGEMM support (#20447), DeepGEMM integration (#20087), FlashInfer MoE blockscale FP8 backend (#20645), CUDNN prefill API for MLA (#20411), Triton Fused MoE kernel config for FP8 E=16 on B200 (#20516).
+* Performance improvements: 48% request duration reduction via microbatch tokenization for concurrent requests (#19334), fused MLA QKV + strided layernorm (#21116), Triton causal-conv1d for Mamba models (#18218).
+* Hardware expansion: ARM CPU int8 quantization (#14129), PPC64LE/ARM V1 support (#20554), Intel XPU ray distributed execution (#20659), shared-memory pipeline parallel for CPU (#21289), FlashInfer ARM CUDA support (#21013).
+
+### Quantization
+* New quantization support: MXFP4 for MoE models (#17888), BNB support for Mixtral and additional MoE models (#20893, #21100), in-flight quantization for MoE (#20061).
+* Hardware-specific: FP8 KV cache quantization on TPU (#19292), FP8 support for BatchedTritonExperts (#18864), optimized INT8 vectorization kernels (#20331).
+* Performance optimizations: Triton backend for DeepGEMM per-token group quantization (#20841), CUDA kernel for per-token group quantization (#21083), CustomOp abstraction for FP8 (#19830).
+
+### API & Frontend
+* OpenAI compatibility: Responses API implementation (#20504, #20975), image object support in llm.chat (#19635), tool calling with required choice and $defs (#20629).
+* New endpoints: `get_tokenizer_info` for tokenizer/chat-template information (#20575), cache_salt support for completions/responses (#20981).
+* Model loading: Tensorizer S3 integration with arbitrary arguments (#19619), HF repo paths & URLs for GGUF models (#20793), tokenization_kwargs for embedding truncation (#21033).
+* CLI improvements: `--help=page` option for enhanced help documentation (#20961), default model changed to Qwen3-0.6B (#20335).
+
+### Dependencies
+* Updated PyTorch to 2.7.1 for CUDA (#21011)
+* FlashInfer updated to v0.2.8rc1 (#20718)
+
+
+
+## v0.9.2 (2025-07-07)
+
+**NOTE: This is the last version where V0 engine code and features stay intact. We highly recommend migrating to V1 engine.**
+
+### Engine Core
+* Priority Scheduling is now implemented in V1 engine (#19057), embedding models in V1 (#16188),  Mamba2 in V1 (#19327). 
+* Full CUDA Graph execution is now available for all FlashAttention v3 (FA3) and FlashMLA paths, including prefix caching. CUDA graph now has a live capture progress bar makes debugging easier (#20301, #18581, #19617, #19501).  
+* FlexAttention update  any head size, FP32 fallback (#20467, #19754).  
+* Shared `CachedRequestData` objects and cached sampler ID stores deliver perf enhancements (#20232, #20291).  
+
+### Model Support
+* New families: Ernie 4.5 (+MoE) (#20220), MiniMax M1 (#19677, #20297), Slim MoE "Phi tiny MoE instruct" (#20286), Tencent HunYuan MoE V1 (#20114), Keye VL 8B Preview (#20126), GLM 4.1 V (#19331), Gemma 3 (text only, #20134), Tarsier 2 (#19887), Qwen 3 Embedding & Reranker (#19260), dots1 (#18254), GPT 2 for Sequence Classification (#19663).  
+* Granite hybrid MoE configurations with shared experts are fully supported (#19652).  
+
+### Large Scale Serving & Engine Improvements
+* Expert Parallel Load Balancer (EPLB) has been added! (#18343, #19790, #19885).  
+* Disaggregated serving enhancements: Avoid stranding blocks in P when aborted in D's waiting queue (#19223), let toy proxy handle /chat/completions (#19730) 
+* Native xPyD P2P NCCL transport as a base case for native PD without external dependency (#18242, #20246).  
+
+### Hardware & Performance
+* NVIDIA Blackwell 
+	* SM120: CUTLASS W8A8/FP8 kernels and related tuning, added to Dockerfile (#17280, #19566, #20071, #19794) 
+	* SM100: block scaled group GEMM, INT8/FP8 vectorization, deep GEMM kernels, activation chunking for MoE, and group size 64 for Machete (#19757, #19572, #19168, #19085, #20290, #20331).  
+* Intel GPU (V1) backend with Flash Attention support (#19560).  
+* AMD ROCm: full graph capture for TritonAttention, quick All Reduce, and chunked pre fill (#19158, #19744, #18596).  
+	* Split KV support landed in the unified Triton Attention kernel, boosting long context throughput (#19152).  
+	* Full graph mode enabled in ROCm AITER MLA V1 decode path (#20254).  
+* TPU: dynamic grid KV cache updates, head dim less than 128, tuned paged attention kernels, and KV padding fixes (#19928, #20235, #19620, #19813, #20048, #20339).  
+	* Add models and features supporting matrix. (#20230) 
+
+### Quantization
+* Calibration free RTN INT4/INT8 pipeline for effortless, accurate compression (#18768).  
+* Compressed Tensor NVFP4 (including MoE) + emulation; FP4 emulation removed on < SM100 devices (#19879, #19990, #19563).  
+* Dynamic MoE layer quant (Marlin/GPTQ) and INT8 vectorization primitives (#19395, #20331, #19233).  
+* Bits and Bytes 0.45 + with improved double quant logic and AWQ quality (#20424, #20033, #19431, #20076).
+
+### API � CLI � Frontend
+* API Server: Eliminate api_key and x_request_id headers middleware overhead (#19946) 
+* New OpenAI compatible endpoints: `/v1/audio/translations` & revamped `/v1/audio/transcriptions` (#19615, #20179, #19597).  
+* Token level progress bar for `LLM.beam_search` and cached template resolution speed ups (#19301, #20065).  
+* Image object support in `llm.chat`, tool choice expansion, and custom arg passthroughs enrich multi modal agents (#19635, #17177, #16862).  
+* CLI QoL: better parsing for `-O/--compilation-config`, batch size sweep benchmarking, richer `--help`, faster startup (#20156, #20516, #20430, #19941).
+* Metrics: Deprecate metrics with gpu_ prefix for non GPU specific metrics (#18354), Export NaNs in logits to scheduler_stats if output is corrupted (#18777) 
+
+### Platform & Deployment
+* No privileged CPU / Docker / K8s mode (#19241) and custom default max tokens for hosted platforms (#18557).  
+* Security hardening  runtime (cloud)pickle imports forbidden (#18018).  
+* Hermetic builds and wheel slimming (FA2 8.0 + PTX only) shrink supply chain surface (#18064, #19336).  
+
+## v0.9.1 (2025-06-10)
+
+This release features **274 commits, from 123 contributors (27 new contributors!)**
+
+* Progress in large scale serving
+	* DP Attention + Expert Parallelism: CUDA graph support (#18724), DeepEP dispatch-combine kernel (#18434), batched/masked DeepGEMM kernel (#19111), CUTLASS MoE kernel with PPLX (#18762)
+	* Heterogeneous TP (#18833), NixlConnector Enable FlashInfer backend (#19090)
+	* DP: API-server scaleout with many-to-many server-engine comms (#17546), Support DP with Ray (#18779), allow AsyncLLMEngine.generate to target a specific DP rank (#19102), data parallel rank to KVEventBatch (#18925)
+	* Tooling: Simplify EP kernels installation (#19412)
+* RLHF workflow: Support inplace model weights loading (#18745)
+* Initial full support for Hybrid Memory Allocator (#17996), support cross-layer KV sharing (#18212)
+* Add FlexAttention to vLLM V1 (#16078)
+* Various production hardening related to full cuda graph mode (#19171, #19106, #19321)
+
+### Model Support
+* Support Magistral (#19193), LoRA support for InternVL (#18842), minicpm eagle support (#18943), NemotronH support (#18863, #19249)
+* Enable data parallel for Llama4 vision encoder (#18368)
+* Add DeepSeek-R1-0528 function call chat template (#18874)
+
+### Hardware Support & Performance Optimizations
+* Add H20-3e fused MoE kernel tuning configs for DeepSeek-R1/V3 (#19205), Qwen3-235B-A22B (#19315)
+* Blackwell: Add Cutlass MLA backend (#17625), Tunings for SM100 FP8 CUTLASS kernel (#18778), Use FlashInfer by default on Blackwell GPUs (#19118), Tune `scaled_fp8_quant` by increasing vectorization (#18844)
+* FP4: Add compressed-tensors NVFP4 support (#18312), FP4 MoE kernel optimization (#19110)
+* CPU: V1 support for the CPU backend (#16441)
+* ROCm: Add AITER grouped topk for DeepSeekV2 (#18825)
+* POWER: Add IBM POWER11 Support to CPU Extension Detection (#19082)
+* TPU: Initial support of model parallelism with single worker using SPMD (#18011), Multi-LoRA Optimizations for the V1 TPU backend (#15655)
+* Neuron: Add multi-LoRA support for Neuron. (#18284), Add Multi-Modal model support for Neuron (#18921), Support quantization on neuron (#18283)
+* Platform: Make torch distributed process group extendable (#18763)
+
+### Engine features
+* Add Lora Support to Beam Search (#18346)
+* Add rerank support to run_batch endpoint (#16278)
+* CLI: add run batch (#18804)
+* Server: custom logging (#18403), allowed_token_ids in ChatCompletionRequest (#19143)
+* `LLM` API: make use_tqdm accept a callable for custom progress bars (#19357)
+* perf: [KERNEL] Sampler. CUDA kernel for applying repetition penalty (#18437)
+
+### API Deprecations
+* Disallow pos-args other than `model` when initializing `LLM` (#18802)
+* Remove `inputs` arg fallback in Engine classes (#18799)
+* Remove fallbacks for Embeddings API (#18795)
+* Remove mean pooling default for `Qwen2EmbeddingModel` (#18913)
+* Require overriding `get_dummy_text` and `get_dummy_mm_data` (#18796)
+* Remove metrics that were deprecated in 0.8 (#18837)
+
+### Documentation
+* Add CLI doc (#18871)
+* Update SECURITY.md with link to our security guide (#18961), Add security warning to bug report template (#19365)
+
+## v0.9.0 (2025-05-15)
+
+This release features 649 commits, from 215 contributors (82 new contributors!)
+
+* vLLM has upgraded to PyTorch 2.7!  (#16859) This is a breaking change for environment dependency.
+	* The default wheel has been upgraded from CUDA 12.4 to CUDA 12.8. We will distribute CUDA 12.6 wheel on GitHub artifact. 
+	* As a general rule of thumb, our CUDA version policy follow PyTorch's CUDA version policy. 
+* Enhanced NVIDIA Blackwell support. vLLM now ships with initial set of optimized kernels on NVIDIA Blackwell with both attention and mlp. 
+	* You can use our docker image or install FlashInfer nightly wheel `pip install https://download.pytorch.org/whl/cu128/flashinfer/flashinfer_python-0.2.5%2Bcu128torch2.7-cp38-abi3-linux_x86_64.whl` then set `VLLM_ATTENTION_BACKEND=FLASHINFER` for better performance.
+	* Upgraded support for the new FlashInfer main branch. (#15777)
+	* Please checkout https://github.com/vllm-project/vllm/issues/18153 for the full roadmap 
+* Initial DP, EP, PD support for large scale inference
+	* EP:
+		* Permute and unpermute kernel for moe optimization (#14568)
+		* Modularize fused experts and integrate PPLX kernels (#15956)
+		* Refactor pplx init logic to make it modular (prepare for deepep) (#18200)
+		* Add ep group and all2all interface (#18077)
+	* DP:
+		* Decouple engine process management and comms (#15977)
+	* PD:
+		* NIXL Integration (#17751)
+		* Local attention optimization for NIXL (#18170)
+		* Support multiple kv connectors (#17564)
+* Migrate docs from Sphinx to MkDocs (#18145, #18610, #18614, #18616. #18622, #18626, #18627, #18635, #18637, #18657, #18663, #18666, #18713)
+
+### Notable Changes
+* Removal of CUDA 12.4 support due to PyTorch upgrade to 2.7. 
+* Change `top_k` to be disabled with `0` (still accept `-1` for now) (#17773)
+* The seed is now set to `0` by default for V1 Engine, meaning that different vLLM runs now yield the same outputs even if `temperature > 0`. This does not modify the random state in user code since workers are run in separate processes unless `VLLM_USE_V1_MULTIPROCESSING=0`. (#17929, #18741)
+
+### Model Enhancements
+* Support MiMo-7B (#17433), MiniMax-VL-01 (#16328), Ovis 1.6 (#17861), Ovis 2 (#15826), GraniteMoeHybrid 4.0 (#17497), FalconH1\* (#18406), LlamaGuard4 (#17315)
+  * Please install the development version of `transformers` (from source) to use Falcon-H1.
+* Embedding models: nomic-embed-text-v2-moe (#17785), new class of gte models (#17986)
+* Progress in Hybrid Memory Allocator (#17394, #17479, #17474, #17483, #17193, #17946, #17945, #17999, #18001, #18593)
+* DeepSeek: perf enhancement by moving more calls into cuda-graph region(#17484, #17668), Function Call (#17784), MTP in V1 (#18435)
+* Qwen2.5-1M: Implements dual-chunk-flash-attn backend for dual chunk attention with sparse attention support (#11844)
+* Qwen2.5-VL speed enhancement via rotary_emb optimization (#17973)
+* InternVL models with Qwen2.5 backbone now support video inputs (#18499)
+
+### Performance, Production and Scaling
+* Support full cuda graph in v1 (#16072)
+* Pipeline Parallelism: MultiprocExecutor support (#14219), `torchrun` (#17827)
+* Support sequence parallelism combined with pipeline parallelism (#18243)
+* Async tensor parallelism using compilation pass (#17882)
+* Perf: Use small max_num_batched_tokens for A100 (#17885)
+* Fast Model Loading: Tensorizer support for V1 and LoRA (#17926)
+* Multi-modality: Automatically cast multi-modal input dtype before transferring device (#18756)
+
+### Security
+* Prevent side-channel attacks via cache salting (#17045)
+* Fix image hash collision in certain edge cases (#17378)
+* Add `VLLM_ALLOW_INSECURE_SERIALIZATION` env var (#17490)
+* Migrate to REGEX Library to prevent catastrophic backtracking (#18454, #18750)
+
+### Features
+* CLI: `deprecated=True` (#17426)
+* Frontend: progress bar for adding requests (#17525), `chat_template_kwargs` in `LLM.chat` (#17356), `/classify` endpoint (#17032), truncation control for embedding models (#14776), `cached_tokens` in response usage (#18149)
+* LoRA: default local directory LoRA resolver plugin. (#16855)
+* Metrics: kv event publishing (#16750), API for accessing in-memory Prometheus metrics (#17010)
+* Quantization: `nvidia/DeepSeek-R1-FP4` (#16362), Quark MXFP4 format (#16943), AutoRound (#17850), torchao models with `AOPerModuleConfig` (#17826), CUDA Graph support for V1 GGUF support (#18646)
+* Reasoning: deprecate `--enable-reasoning` (#17452)
+* Spec Decode: EAGLE share input embedding (#17326), torch.compile & cudagraph to EAGLE (#17211), EAGLE3 (#17504), log accumulated metrics(#17913), Medusa (#17956)
+* Structured Outputs: Thinking compatibility (#16577), Spec Decoding (#14702), Qwen3 reasoning parser (#17466), `tool_choice: required` for Xgrammar (#17845), Structural Tag with Guidance backend (#17333)
+* Transformers backend: named parameters (#16868), interleaved sliding window attention (#18494)
+
+### Hardwares
+* NVIDIA: cutlass support for blackwell fp8 blockwise gemm (#14383)
+* TPU: Multi-LoRA implementation(#14238), default max-num-batched-tokens (#17508), V1 backend by default (#17673), top-logprobs (#17072)
+* Neuron: NeuronxDistributedInference support (#15970), Speculative Decoding, Dynamic on-device sampling (#16357), Mistral Model (#18222), Multi-LoRA (#18284)
+* AMD: Enable FP8 KV cache on V1 (#17870), Tuned fused moe config for Qwen3 MoE on MI300X (#17535, #17530), AITER biased group topk (#17955), Block-Scaled GEMM (#14968), MLA (#17523), Radeon GPU use Custom Paged Attention (#17004), reduce the number of environment variables in command line (#17229)
+* Extensibility: Make PiecewiseBackend pluggable and extendable (#18076)
+
+### Documentation
+* Update quickstart and install for cu128 using `--torch-backend=auto` (#18505)
+* NVIDIA TensorRT Model Optimizer (#17561)
+* Usage of Qwen3 thinking (#18291)
+
+### Developer Facing 
+* Benchmark: Add single turn MTBench to Serving Bench (#17202)
+* Usability: Decrease import time of `vllm.multimodal` (#18031)
+* Code Format: Code formatting using `ruff format` (#17656, #18068, #18400)
+* Readability: 
+	* Configuration and arguments unification is now complete! (#17130, #17453, #17562)
+	* Update deprecated type hinting from Python 3.7 (#18056, #18130, #18132, #18129, #18073, #18072, #18126, #18128, #18057, #18058)
+* Process:
+	* Propose a deprecation policy for the project (#17063)
+* Testing: expanding torch nightly tests (#18004)


### PR DESCRIPTION
## Summary

Adds `claude-skills/vllm-release-notes/`, the workflow used to write the GitHub release body and Slack announcement for each vLLM release:

- `SKILL.md`: step-by-step process (fetch commits, classify, draft, edit, contributors, Release Artifacts section with per-release verification, no-tilde rule, Slack main message and install thread).
- `fetch_commits.py`: fetches the commit range between two tags and produces contributor stats. Now carries inline `uv` script metadata so `uv run fetch_commits.py ...` works without a venv.
- `ref-past-release-notes-highlight.md`: style and category reference from older releases.
- `examples/v0.22.0` through `examples/v0.29.0`: the final release notes for each release, plus the v0.29.0 Slack announcement.

Also lists the skill under "Interactive investigation skills" in `AUTOMATIONS.md`.

Only the finished outputs are included as examples; the per-release raw commit dumps, classification CSVs, and fetched PR bodies stay in the maintainer's scratch folder.

Co-authored with @esmeetu and @simon-mo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)